### PR TITLE
Dev fix mutation

### DIFF
--- a/src/saealib/core.py
+++ b/src/saealib/core.py
@@ -228,6 +228,8 @@ class GA(Algorithm):
         candidate = np.empty((0, optimizer.problem.dim))
         popsize = len(optimizer.population)
         pop = optimizer.population.get("x")
+        lb = optimizer.problem.lb
+        ub = optimizer.problem.ub
         n_pair = math.ceil(popsize / 2)
         parent_idx_m = self.parent_selection.select(
             optimizer,
@@ -247,7 +249,7 @@ class GA(Algorithm):
         optimizer.dispatch(CallbackEvent.POST_CROSSOVER, data=candidate)
         candidate_len = len(candidate)
         for i in range(candidate_len):
-            candidate[i] = self.mutation.mutate(candidate[i], rng=optimizer.rng)
+            candidate[i] = self.mutation.mutate(candidate[i], (lb, ub), rng=optimizer.rng)
         optimizer.dispatch(CallbackEvent.POST_MUTATION, data=candidate)
         return candidate[:optimizer.popsize]
     

--- a/src/sample_saga_rbf.py
+++ b/src/sample_saga_rbf.py
@@ -29,8 +29,8 @@ def main():
         ub=ub
     )
     algorithm = GA(
-        crossover=CrossoverBLXAlpha(crossover_rate=0.7, gamma=0.4, lb=lb, ub=ub),
-        mutation=MutationUniform(mutation_rate=0.3, lb=lb, ub=ub),
+        crossover=CrossoverBLXAlpha(crossover_rate=0.7, gamma=0.4),
+        mutation=MutationUniform(mutation_rate=0.3),
         parent_selection=SequentialSelection(),
         survivor_selection=TruncationSelection()
     )


### PR DESCRIPTION
# Overview
The range constraint had to be passed separately to the constructors of the MutationUniform and CrossoverBLXAlpha classes, even though it was already given to the constructor of the Problem class.
This has been corrected, and the dependency injection of range constraints has been removed from the constructors of the MutationUniform and CrossoverBLXAlpha classes.

# Changes
- Removed range constraint dependency injection from constructors of MutationUniform and CrossoverBLXAlpha classes.
- Changed the mutate method of the MutationUniform class to accept a tuple to specify the mutation range.