### PR TITLE
fix: when the karnel matrix is singular, the value of weights should be a nan vector instead of a zero vector

### DIFF
--- a/src/saealib/surrogate/rbf.py
+++ b/src/saealib/surrogate/rbf.py
@@ -90,7 +90,7 @@ class RBFsurrogate(Surrogate):
             self.weights = np.linalg.solve(self.kernel_matrix, (train_y - np.mean(train_y)))
         except np.linalg.LinAlgError:
             logger.error("Failed to solve linear system (Kernel matrix might be singular).")
-            self.weights = np.zeros(n_samples)
+            self.weights = np.nan * np.ones(n_samples)
 
     def predict(self, test_x: np.ndarray) -> np.ndarray:
         test = np.asarray(test_x)


### PR DESCRIPTION
# Overview
When the kernel matrix of RBFsurrogate is Singular, the weights are assigned to a vector of 0's. To prevent these individuals from being carried over to the next generation, the weights are assigned to a vector of nan's.

# Changes
- change RBFsurrogate class to assign weights as nan when kernel matrix is singular