### PR TITLE
Dev restore duplication

### DIFF
--- a/src/saealib/population.py
+++ b/src/saealib/population.py
@@ -112,6 +112,8 @@ class Archive(Population):
     ----------
     data : dict[str, np.ndarray]
         Dictionary to store archive data. keys are "x" and "y".
+    duplicate_log : list[dict]
+        List to store duplicate solutions information.
     atol : float
         Absolute tolerance for duplicate check.
     rtol : float


### PR DESCRIPTION
# Overview
When de-duplicating, keep the removed points so they can be restored later.

# Changes
- Archive.add method: when de-duplicating, keep the index and the removed data in Archive.duplicate_log.
- Add method Archive.restore_duplicates: create and return an Archive object before de-duplication.