### PR TITLE
refactor: rename IndividualBasedStrategy.rsm to evaluation_ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,8 @@ algorithm = GA(
 surrogate = RBFsurrogate(gaussian_kernel, dim)
 
 # Strategy: Individual-Based Management
-# knn=50: K-Nearest Neighbors for local modeling
-# rsm=0.1: Ratio of surrogate model usage
-strategy = IndividualBasedStrategy(knn=50, rsm=0.1)
+# evaluation_ratio=0.1: Ratio of offspring selected for true objective evaluation
+strategy = IndividualBasedStrategy(evaluation_ratio=0.1)
 
 # Termination Criterion
 termination = Termination(max_fe(100))  # Stop after 100 function evaluations

--- a/examples/sample_saga_rbf.py
+++ b/examples/sample_saga_rbf.py
@@ -57,7 +57,7 @@ def main():
     )
     termination = Termination(max_fe(200 * dim))
     surrogate = RBFsurrogate(gaussian_kernel, dim)
-    strategy = IndividualBasedStrategy(rsm=rsm)
+    strategy = IndividualBasedStrategy(evaluation_ratio=rsm)
 
     opt = (
         Optimizer(problem)

--- a/examples/sample_saga_rbf_moo.py
+++ b/examples/sample_saga_rbf_moo.py
@@ -80,7 +80,7 @@ def main():
     )
     termination = Termination(max_fe(200 * dim))
     surrogate = RBFsurrogate(gaussian_kernel, dim)
-    strategy = IndividualBasedStrategy(rsm=rsm)
+    strategy = IndividualBasedStrategy(evaluation_ratio=rsm)
 
     opt = (
         Optimizer(problem)

--- a/src/saealib/strategies/ib.py
+++ b/src/saealib/strategies/ib.py
@@ -2,7 +2,7 @@
 Individual-based / Pre-selection / Local-modeling.
 
 For each offspring, the surrogate manager scores candidates using a local
-surrogate model. The top-rsm fraction are selected for true evaluation.
+surrogate model. The top-evaluation_ratio fraction are selected for true evaluation.
 """
 
 import numpy as np
@@ -16,19 +16,21 @@ from saealib.strategies.base import OptimizationStrategy
 class IndividualBasedStrategy(OptimizationStrategy):
     """Individual-based strategy."""
 
-    def __init__(self, rsm: float = 0.1):
+    def __init__(self, evaluation_ratio: float = 0.1):
         """
         Initialize IndividualBasedStrategy.
 
         Parameters
         ----------
-        rsm : float
-            Ratio of surrogate model usage. The top ``rsm`` fraction of
-            offspring are selected for true objective evaluation.
+        evaluation_ratio : float
+            Ratio of offspring selected for true objective evaluation.
+            The top ``evaluation_ratio`` fraction of offspring are evaluated
+            with the real objective function; the rest are discarded after
+            surrogate scoring.
             The number of neighbors for local surrogate fitting is now
             configured on the SurrogateManager (e.g. LocalSurrogateManager).
         """
-        self.rsm = rsm
+        self.evaluation_ratio = evaluation_ratio
 
     def step(self, ctx: OptimizationContext, provider: ComponentProvider) -> None:
         """
@@ -46,7 +48,7 @@ class IndividualBasedStrategy(OptimizationStrategy):
         # 1. get candidate solutions as "offspring" (algorithm.ask)
         offspring = provider.algorithm.ask(ctx, provider)
         n_offspring = len(offspring)
-        n_eval = max(1, int(self.rsm * n_offspring))
+        n_eval = max(1, int(self.evaluation_ratio * n_offspring))
 
         provider.dispatch(
             SurrogateStartEvent(ctx=ctx, provider=provider, offspring=offspring)

--- a/tests/scripts/generate_test_integration.py
+++ b/tests/scripts/generate_test_integration.py
@@ -51,7 +51,7 @@ def run_benchmark(seed: int):
     # parameters
     dim = 10
     knn = 50
-    rsm = 0.1
+    evaluation_ratio = 0.1
     ub = [5] * dim
     lb = [-5] * dim
 
@@ -80,7 +80,7 @@ def run_benchmark(seed: int):
     )
     termination = Termination(max_fe(200 * dim))
     surrogate = RBFsurrogate(gaussian_kernel, dim)
-    strategy = IndividualBasedStrategy(knn, rsm)
+    strategy = IndividualBasedStrategy(evaluation_ratio=evaluation_ratio)
 
     opt = (
         Optimizer(problem)

--- a/tests/scripts/generate_test_integration.py
+++ b/tests/scripts/generate_test_integration.py
@@ -50,7 +50,6 @@ def run_benchmark(seed: int):
     """
     # parameters
     dim = 10
-    knn = 50
     evaluation_ratio = 0.1
     ub = [5] * dim
     lb = [-5] * dim

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -661,7 +661,7 @@ class TestPostEvaluationDispatch:
     evaluated offspring after true objective evaluations.
     """
 
-    def _make_strategy_provider(self, rsm: float = 0.5):
+    def _make_strategy_provider(self, evaluation_ratio: float = 0.5):
         """Build a minimal but real optimizer setup for IndividualBasedStrategy."""
         from saealib import (
             GA,
@@ -692,7 +692,7 @@ class TestPostEvaluationDispatch:
                 )
             )
             .set_surrogate(RBFsurrogate(gaussian_kernel, dim), n_neighbors=10)
-            .set_strategy(IndividualBasedStrategy(rsm=rsm))
+            .set_strategy(IndividualBasedStrategy(evaluation_ratio=evaluation_ratio))
             .set_termination(Termination(max_fe(100)))
         )
         # Initialize the context
@@ -702,12 +702,12 @@ class TestPostEvaluationDispatch:
     def test_post_evaluation_event_is_dispatched(self) -> None:
         from saealib.strategies.ib import IndividualBasedStrategy
 
-        ctx, opt = self._make_strategy_provider(rsm=0.5)
+        ctx, opt = self._make_strategy_provider(evaluation_ratio=0.5)
 
         received: list[PostEvaluationEvent] = []
         opt.cbmanager.register(PostEvaluationEvent, received.append)
 
-        strategy = IndividualBasedStrategy(rsm=0.5)
+        strategy = IndividualBasedStrategy(evaluation_ratio=0.5)
         strategy.step(ctx, opt)
 
         assert len(received) == 1
@@ -715,12 +715,12 @@ class TestPostEvaluationDispatch:
     def test_post_evaluation_event_offspring_is_population(self) -> None:
         from saealib.strategies.ib import IndividualBasedStrategy
 
-        ctx, opt = self._make_strategy_provider(rsm=0.5)
+        ctx, opt = self._make_strategy_provider(evaluation_ratio=0.5)
 
         received: list[PostEvaluationEvent] = []
         opt.cbmanager.register(PostEvaluationEvent, received.append)
 
-        strategy = IndividualBasedStrategy(rsm=0.5)
+        strategy = IndividualBasedStrategy(evaluation_ratio=0.5)
         strategy.step(ctx, opt)
 
         event = received[0]
@@ -730,12 +730,12 @@ class TestPostEvaluationDispatch:
         from saealib.strategies.ib import IndividualBasedStrategy
 
         rsm = 0.3
-        ctx, opt = self._make_strategy_provider(rsm=rsm)
+        ctx, opt = self._make_strategy_provider(evaluation_ratio=rsm)
 
         received: list[PostEvaluationEvent] = []
         opt.cbmanager.register(PostEvaluationEvent, received.append)
 
-        strategy = IndividualBasedStrategy(rsm=rsm)
+        strategy = IndividualBasedStrategy(evaluation_ratio=rsm)
         strategy.step(ctx, opt)
 
         event = received[0]
@@ -751,12 +751,12 @@ class TestPostEvaluationDispatch:
         from saealib.strategies.ib import IndividualBasedStrategy
 
         rsm = 0.2
-        ctx, opt = self._make_strategy_provider(rsm=rsm)
+        ctx, opt = self._make_strategy_provider(evaluation_ratio=rsm)
 
         received: list[PostEvaluationEvent] = []
         opt.cbmanager.register(PostEvaluationEvent, received.append)
 
-        strategy = IndividualBasedStrategy(rsm=rsm)
+        strategy = IndividualBasedStrategy(evaluation_ratio=rsm)
         strategy.step(ctx, opt)
 
         popsize = len(ctx.population)
@@ -768,7 +768,7 @@ class TestPostEvaluationDispatch:
         """PostEvaluationEvent must be dispatched after SurrogateEndEvent."""
         from saealib.strategies.ib import IndividualBasedStrategy
 
-        ctx, opt = self._make_strategy_provider(rsm=0.5)
+        ctx, opt = self._make_strategy_provider(evaluation_ratio=0.5)
 
         order: list[type] = []
         opt.cbmanager.register(
@@ -778,7 +778,7 @@ class TestPostEvaluationDispatch:
             PostEvaluationEvent, lambda _: order.append(PostEvaluationEvent)
         )
 
-        strategy = IndividualBasedStrategy(rsm=0.5)
+        strategy = IndividualBasedStrategy(evaluation_ratio=0.5)
         strategy.step(ctx, opt)
 
         assert order.index(SurrogateEndEvent) < order.index(PostEvaluationEvent)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -90,7 +90,7 @@ def test_integration(seed_str: str, expected_f: float):
     )
     termination = Termination(max_fe(200 * dim))
     surrogate = RBFsurrogate(gaussian_kernel, dim)
-    strategy = IndividualBasedStrategy(rsm=rsm)
+    strategy = IndividualBasedStrategy(evaluation_ratio=rsm)
 
     opt = (
         Optimizer(problem)

--- a/tests/test_moo.py
+++ b/tests/test_moo.py
@@ -466,7 +466,7 @@ class TestMOOIntegration:
         )
         termination = Termination(max_fe(80 * dim))
         surrogate = RBFsurrogate(gaussian_kernel, dim)
-        strategy = IndividualBasedStrategy(rsm=0.1)
+        strategy = IndividualBasedStrategy(evaluation_ratio=0.1)
 
         opt = (
             Optimizer(problem)


### PR DESCRIPTION
## Related Issue        
  Closes #50
                                                                                                                
  ## Overview
  `IndividualBasedStrategy` had a parameter named `rsm` (Ratio of Surrogate Model usage), which was not         
  intuitive. This PR renames it to `evaluation_ratio` to clearly express its meaning: the fraction of offspring 
  selected for true objective evaluation. The underlying logic is unchanged.
                                                                                                                
  ## Changes                                                
  - Rename `IndividualBasedStrategy.__init__` parameter `rsm` → `evaluation_ratio` and update `self.rsm`
  accordingly (`src/saealib/strategies/ib.py`)                                                                  
  - Update all call sites to use the new parameter name (`tests/`, `examples/`, `tests/scripts/`, `README.md`)
  - Fix stale positional call `IndividualBasedStrategy(knn, rsm)` in `generate_test_integration.py` to          
  `IndividualBasedStrategy(evaluation_ratio=evaluation_ratio)`                                                  
                                                                                                                
  ## Verification Steps                                                                                         
  1. Run the test suite: `uv run pytest tests/ --ignore=tests/test_integration.py -q`
     - All 291 tests pass                                                                                       
  2. Confirm no remaining `rsm` references in source/tests/examples:                                            
     - `grep -r "rsm" src/ tests/ examples/` — only local variable names remain, no constructor keyword         
  arguments                                                                                                     
                                                                                                                
  ## Concerns                                                                                                   
  - **Breaking change**: Any user code passing `rsm=` as a keyword argument will need to be updated to
  `evaluation_ratio=`. Acceptable at Alpha stage per the issue.                                                 
  - `tests/test_integration.py` snapshot assertions are environment-dependent (Python 3.10 only) and may differ
  across environments; excluded from CI verification scope. 