### PR TITLE
Dev issue#51

### DIFF
--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -51,6 +51,7 @@ from saealib.population import (
 from saealib.problem import (
     Comparator,
     NSGA2Comparator,
+    ParetoComparator,
     Problem,
     SingleObjectiveComparator,
     WeightedSumComparator,
@@ -104,6 +105,7 @@ __all__ = [
     "OptimizationStrategy",
     "Optimizer",
     "ParentSelection",
+    "ParetoComparator",
     "Population",
     "PopulationAttribute",
     "PostAskEvent",

--- a/src/saealib/problem.py
+++ b/src/saealib/problem.py
@@ -558,7 +558,7 @@ class ParetoComparator(Comparator):
         return np.concatenate([sorted_feasible, sorted_infeasible]).astype(int)
 
     def compare_population(self, population: Population, idx_a: int, idx_b: int) -> int:
-        """Compare via Pareto dominance; -1=a dominates, 1=b dominates, 0=non-dominated."""
+        """Compare via Pareto dominance; -1=a dominates, 1=b dominates, 0=equal."""
         f = population.get("f")
         cv = population.get("cv")
         cv_a, cv_b = float(cv[idx_a]), float(cv[idx_b])

--- a/src/saealib/problem.py
+++ b/src/saealib/problem.py
@@ -507,14 +507,87 @@ def crowding_distance_all_fronts(
     return cd
 
 
-class NSGA2Comparator(Comparator):
+class ParetoComparator(Comparator):
+    """
+    Comparator for multi-objective optimization via non-dominated sorting only.
+
+    Implements rank-only Pareto ordering:
+    - sort_population: Pareto front rank order (no crowding distance tiebreaking).
+      Infeasible individuals (cv > eps) are always ranked after feasible ones,
+      ordered by ascending constraint violation.
+    - compare_population: Pareto dominance (-1 = a dominates b, 1 = b
+      dominates a, 0 = non-dominated). Infeasibility is handled with the
+      standard constraint-domination rule.
+
+    NaN objective values are treated as non-dominating and placed last within
+    the feasible block (consistent with non_dominated_sort).
+
+    This class is a concrete base for Pareto-based comparators. NSGA2Comparator
+    inherits from it and overrides sort_population to add crowding-distance-based
+    secondary ordering within each front.
+
+    Parameters
+    ----------
+    weights : np.ndarray or None
+        Stored for interface compatibility but not used in Pareto ranking.
+    eps : float
+        Epsilon tolerance for constraint violation.
+    """
+
+    def __init__(self, weights: np.ndarray | None = None, eps: float = 1e-6):
+        w = np.asarray(weights, dtype=float) if weights is not None else np.empty(0)
+        super().__init__(w, eps)
+
+    def sort_population(self, population: Population) -> np.ndarray:
+        """Sort by Pareto front rank; infeasible individuals come last."""
+        f = population.get("f")
+        cv = population.get("cv")
+        feasible = np.where(cv <= self.eps)[0]
+        infeasible = np.where(cv > self.eps)[0]
+
+        sorted_feasible = np.empty(0, int)
+        if len(feasible):
+            ranks, _ = non_dominated_sort(f[feasible])
+            order = np.argsort(ranks, kind="stable")
+            sorted_feasible = feasible[order]
+
+        sorted_infeasible = np.empty(0, int)
+        if len(infeasible):
+            sorted_infeasible = infeasible[np.argsort(cv[infeasible])]
+
+        return np.concatenate([sorted_feasible, sorted_infeasible]).astype(int)
+
+    def compare_population(self, population: Population, idx_a: int, idx_b: int) -> int:
+        """Compare via Pareto dominance; -1=a dominates, 1=b dominates, 0=non-dominated."""
+        f = population.get("f")
+        cv = population.get("cv")
+        cv_a, cv_b = float(cv[idx_a]), float(cv[idx_b])
+
+        if cv_a > self.eps and cv_b > self.eps:
+            if cv_a < cv_b:
+                return -1
+            elif cv_a > cv_b:
+                return 1
+            return 0
+        elif cv_a > self.eps:
+            return 1
+        elif cv_b > self.eps:
+            return -1
+
+        if _pareto_dominates(f[idx_a], f[idx_b]):
+            return -1
+        if _pareto_dominates(f[idx_b], f[idx_a]):
+            return 1
+        return 0
+
+
+class NSGA2Comparator(ParetoComparator):
     """
     Comparator for multi-objective optimization via NSGA-II style ranking.
 
-    Implements NSGA-II style ranking:
+    Extends ParetoComparator with crowding-distance-based secondary ordering:
     - sort_population: non-dominated sorting + crowding distance
-    - compare_population: Pareto dominance (-1 = a dominates b, 1 = b
-      dominates a, 0 = non-dominated)
+    - compare_population: inherited from ParetoComparator (Pareto dominance)
 
     Infeasible individuals (cv > eps) are always ranked after feasible
     ones, ordered by ascending constraint violation.
@@ -531,8 +604,7 @@ class NSGA2Comparator(Comparator):
     """
 
     def __init__(self, weights: np.ndarray | None = None, eps: float = 1e-6):
-        w = np.asarray(weights, dtype=float) if weights is not None else np.empty(0)
-        super().__init__(w, eps)
+        super().__init__(weights, eps)
 
     def sort_population(self, population: Population) -> np.ndarray:
         """Sort by Pareto front rank then crowding distance (NSGA-II style)."""
@@ -559,26 +631,3 @@ class NSGA2Comparator(Comparator):
         result = np.concatenate([sorted_feasible, sorted_infeasible]).astype(int)
         population.set_cache("pareto_sort", result)
         return result
-
-    def compare_population(self, population: Population, idx_a: int, idx_b: int) -> int:
-        """Compare via Pareto dominance; -1=a dominates, 1=b dominates, 0=equal."""
-        f = population.get("f")
-        cv = population.get("cv")
-        cv_a, cv_b = float(cv[idx_a]), float(cv[idx_b])
-
-        if cv_a > self.eps and cv_b > self.eps:
-            if cv_a < cv_b:
-                return -1
-            elif cv_a > cv_b:
-                return 1
-            return 0
-        elif cv_a > self.eps:
-            return 1
-        elif cv_b > self.eps:
-            return -1
-
-        if _pareto_dominates(f[idx_a], f[idx_b]):
-            return -1
-        if _pareto_dominates(f[idx_b], f[idx_a]):
-            return 1
-        return 0

--- a/tests/test_moo.py
+++ b/tests/test_moo.py
@@ -35,7 +35,7 @@ from saealib import (
     non_dominated_sort,
 )
 from saealib.population import Population, PopulationAttribute
-from saealib.problem import NSGA2Comparator, SingleObjectiveComparator
+from saealib.problem import NSGA2Comparator, ParetoComparator, SingleObjectiveComparator
 
 logging.getLogger("saealib.surrogate.rbf").setLevel(logging.CRITICAL)
 
@@ -274,6 +274,116 @@ class TestWeightedSumComparator:
         # ascending order of f: idx=1(1.0), idx=0(2.0), idx=2(3.0)
         assert order[0] == 1
         assert order[-1] == 2
+
+
+# ===========================================================================
+# ParetoComparator Tests
+# ===========================================================================
+class TestParetoComparator:
+    """Tests for ParetoComparator (non-dominated sorting, no crowding distance)."""
+
+    def test_is_subclass_of_comparator(self) -> None:
+        from saealib import Comparator
+
+        assert issubclass(ParetoComparator, Comparator)
+
+    def test_nsga2_is_subclass_of_pareto(self) -> None:
+        assert issubclass(NSGA2Comparator, ParetoComparator)
+
+    def test_sort_population_first_front_first(self) -> None:
+        """Non-dominated solutions (front 0) appear before dominated ones."""
+        f = np.array([[0.0, 3.0], [3.0, 0.0], [2.0, 2.0]])
+        pop = _make_pop(f)
+        comp = ParetoComparator()
+        order = comp.sort_population(pop)
+        assert set(order[:2]) == {0, 1}
+        assert order[2] == 2
+
+    def test_sort_population_infeasible_last(self) -> None:
+        """Infeasible individuals appear after all feasible ones."""
+        f = np.array([[10.0, 10.0], [0.0, 0.0], [1.0, 1.0]])
+        cv = np.array([1.0, 0.0, 0.0])
+        pop = _make_pop(f, cv)
+        comp = ParetoComparator()
+        order = comp.sort_population(pop)
+        assert order[-1] == 0
+
+    def test_sort_population_infeasible_by_ascending_cv(self) -> None:
+        """Multiple infeasible individuals are sorted by ascending cv."""
+        f = np.array([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0]])
+        cv = np.array([2.0, 0.5, 1.0])
+        pop = _make_pop(f, cv)
+        comp = ParetoComparator()
+        order = comp.sort_population(pop)
+        assert list(order) == [1, 2, 0]
+
+    def test_sort_population_not_cached(self) -> None:
+        """ParetoComparator does not write to the pareto_sort cache."""
+        f = np.array([[0.0, 1.0], [1.0, 0.0]])
+        pop = _make_pop(f)
+        comp = ParetoComparator()
+        comp.sort_population(pop)
+        assert pop.get_cache("pareto_sort") is None
+
+    def test_sort_population_nan_last_among_feasible(self) -> None:
+        """NaN objective rows are placed last within the feasible block."""
+        f = np.array([[0.0, 0.0], [np.nan, np.nan], [1.0, 1.0]])
+        pop = _make_pop(f)
+        comp = ParetoComparator()
+        order = comp.sort_population(pop)
+        assert order[0] == 0
+        assert order[-1] == 1
+
+    def test_sort_population_output_is_int_array(self) -> None:
+        f = np.array([[0.0, 1.0], [1.0, 0.0], [0.5, 0.5]])
+        pop = _make_pop(f)
+        comp = ParetoComparator()
+        order = comp.sort_population(pop)
+        assert np.issubdtype(order.dtype, np.integer)
+
+    def test_compare_population_a_dominates_b(self) -> None:
+        f = np.array([[0.0, 0.0], [1.0, 1.0]])
+        pop = _make_pop(f)
+        comp = ParetoComparator()
+        assert comp.compare_population(pop, 0, 1) == -1
+
+    def test_compare_population_b_dominates_a(self) -> None:
+        f = np.array([[1.0, 1.0], [0.0, 0.0]])
+        pop = _make_pop(f)
+        comp = ParetoComparator()
+        assert comp.compare_population(pop, 0, 1) == 1
+
+    def test_compare_population_non_dominated(self) -> None:
+        f = np.array([[0.0, 1.0], [1.0, 0.0]])
+        pop = _make_pop(f)
+        comp = ParetoComparator()
+        assert comp.compare_population(pop, 0, 1) == 0
+
+    def test_compare_infeasible_vs_feasible(self) -> None:
+        """Feasible always beats infeasible regardless of objectives."""
+        f = np.array([[0.0, 0.0], [100.0, 100.0]])
+        cv = np.array([1.0, 0.0])
+        pop = _make_pop(f, cv)
+        comp = ParetoComparator()
+        assert comp.compare_population(pop, 0, 1) == 1
+
+    def test_compare_both_infeasible_lower_cv_wins(self) -> None:
+        f = np.array([[0.0, 0.0], [0.0, 0.0]])
+        cv = np.array([0.5, 2.0])
+        pop = _make_pop(f, cv)
+        comp = ParetoComparator()
+        assert comp.compare_population(pop, 0, 1) == -1
+
+    def test_weights_stored_but_not_used(self) -> None:
+        """Weights are stored for interface compatibility but ignored."""
+        f = np.array([[0.0, 1.0], [1.0, 0.0]])
+        pop = _make_pop(f)
+        comp_no_w = ParetoComparator()
+        comp_with_w = ParetoComparator(weights=np.array([1.0, 2.0]))
+        np.testing.assert_array_equal(
+            comp_no_w.sort_population(pop),
+            comp_with_w.sort_population(pop),
+        )
 
 
 # ===========================================================================


### PR DESCRIPTION
## Related Issue  
  Closes #51
                                                                                                                
  ## Overview
  `NSGA2Comparator` previously combined Pareto dominance logic (non-dominated sorting) with NSGA-II-specific    
  logic (crowding distance) in a single class. Since Pareto dominance is shared across multiple multi-objective 
  methods (SPEA2, HVI-based, etc.), this PR introduces `ParetoComparator` as an intermediate concrete base class
   and re-parents `NSGA2Comparator` to inherit from it. This establishes the hierarchy required by issues #012  
  and #015.                                             

  ## Changes
  - Add `ParetoComparator(Comparator)` to `problem.py`: implements rank-only non-dominated sorting
  (`sort_population`) and Pareto dominance comparison with constraint-domination rule (`compare_population`)    
  - Re-parent `NSGA2Comparator` from `Comparator` to `ParetoComparator`; remove the now-redundant
  `compare_population` override (byte-identical to the parent implementation)                                   
  - Export `ParetoComparator` from the public API (`__init__.py`: import block and `__all__`)
  - Add `TestParetoComparator` (14 tests) to `test_moo.py` covering `sort_population`, `compare_population`,    
  infeasibility handling, NaN placement, cache absence, and subclass relationships                              
                                                                                                                
  ## Verification Steps                                                                                         
  uv run pytest tests/test_moo.py -v                    
  52 passed

             
  ## Concerns                                                                                              
  - `ParetoComparator.sort_population` performs rank-only sorting with no crowding distance. When used as a     
  direct comparator (not via `NSGA2Comparator`), individuals within the same Pareto front are ordered           
  arbitrarily (stable argsort on ranks). This is intentional but should be noted when `ParetoComparator` is used
   directly in future comparators such as `SPEA2Comparator`.                      
  - The module-level utility functions (`non_dominated_sort`, `crowding_distance`,                              
  `crowding_distance_all_fronts`, `_pareto_dominates`) remain unchanged as module-level functions for backward
  compatibility.                                                                                                
                                                        
  ## Other
  The new hierarchy is:                                                                                         
  Comparator (ABC)
  ├── SingleObjectiveComparator                                                                                 
  ├── WeightedSumComparator                             
  └── ParetoComparator              ← new
      └── NSGA2Comparator