### PR TITLE
Dev issue#56

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ initializer = LHSInitializer(
 
 # Algorithm: Genetic Algorithm
 algorithm = GA(
-    crossover=CrossoverBLXAlpha(crossover_rate=0.7, gamma=0.4),
+    crossover=CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4),
     mutation=MutationUniform(mutation_rate=0.3),
     parent_selection=SequentialSelection(),
     survivor_selection=TruncationSelection(),

--- a/examples/sample_saga_rbf.py
+++ b/examples/sample_saga_rbf.py
@@ -50,7 +50,7 @@ def main():
         seed=seed,
     )
     algorithm = GA(
-        crossover=CrossoverBLXAlpha(crossover_rate=0.7, gamma=0.4),
+        crossover=CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4),
         mutation=MutationUniform(mutation_rate=0.3),
         parent_selection=SequentialSelection(),
         survivor_selection=TruncationSelection(),

--- a/examples/sample_saga_rbf_moo.py
+++ b/examples/sample_saga_rbf_moo.py
@@ -73,7 +73,7 @@ def main():
         seed=seed,
     )
     algorithm = GA(
-        crossover=CrossoverBLXAlpha(crossover_rate=0.7, gamma=0.4),
+        crossover=CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4),
         mutation=MutationUniform(mutation_rate=0.3),
         parent_selection=SequentialSelection(),
         survivor_selection=TruncationSelection(),

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -30,11 +30,19 @@ from saealib.callback import (
     logging_generation_hv,
 )
 from saealib.execution.initializer import Initializer, LHSInitializer
-from saealib.operators.crossover import Crossover, CrossoverBLXAlpha
-from saealib.operators.mutation import Mutation, MutationUniform
+from saealib.operators.crossover import (
+    Crossover,
+    CrossoverBLXAlpha,
+    CrossoverOnePoint,
+    CrossoverSBX,
+    CrossoverTwoPoint,
+    CrossoverUniform,
+)
+from saealib.operators.mutation import Mutation, MutationGaussian, MutationPolynomial, MutationUniform
 from saealib.operators.repair import repair_clipping
 from saealib.operators.selection import (
     ParentSelection,
+    RouletteWheelSelection,
     SequentialSelection,
     SurvivorSelection,
     TournamentSelection,
@@ -87,6 +95,10 @@ __all__ = [
     "Constraint",
     "Crossover",
     "CrossoverBLXAlpha",
+    "CrossoverOnePoint",
+    "CrossoverSBX",
+    "CrossoverTwoPoint",
+    "CrossoverUniform",
     "EnsembleSurrogateManager",
     "Event",
     "ExpectedImprovement",
@@ -102,11 +114,14 @@ __all__ = [
     "MaxUncertainty",
     "MeanPrediction",
     "Mutation",
+    "MutationGaussian",
+    "MutationPolynomial",
     "MutationUniform",
     "NSGA2Comparator",
     "OptimizationStrategy",
     "Optimizer",
     "ParentSelection",
+    "RouletteWheelSelection",
     "ParetoComparator",
     "Population",
     "PopulationAttribute",

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -38,7 +38,12 @@ from saealib.operators.crossover import (
     CrossoverTwoPoint,
     CrossoverUniform,
 )
-from saealib.operators.mutation import Mutation, MutationGaussian, MutationPolynomial, MutationUniform
+from saealib.operators.mutation import (
+    Mutation,
+    MutationGaussian,
+    MutationPolynomial,
+    MutationUniform,
+)
 from saealib.operators.repair import repair_clipping
 from saealib.operators.selection import (
     ParentSelection,
@@ -121,7 +126,6 @@ __all__ = [
     "OptimizationStrategy",
     "Optimizer",
     "ParentSelection",
-    "RouletteWheelSelection",
     "ParetoComparator",
     "Population",
     "PopulationAttribute",
@@ -134,6 +138,7 @@ __all__ = [
     "Problem",
     "RBFsurrogate",
     "RepairFunc",
+    "RouletteWheelSelection",
     "RunEndEvent",
     "RunStartEvent",
     "SequentialSelection",

--- a/src/saealib/algorithms/ga.py
+++ b/src/saealib/algorithms/ga.py
@@ -132,7 +132,7 @@ class GA(Algorithm):
             ctx,
             ctx.population,
             n_pair=n_pair,
-            n_parents=2,  # TODO: receive n_parents from Crossover
+            n_parents=self.crossover.n_parents,
             rng=ctx.rng,
         )
         for i in range(n_pair):

--- a/src/saealib/operators/crossover.py
+++ b/src/saealib/operators/crossover.py
@@ -10,7 +10,17 @@ import numpy as np
 
 
 class Crossover(ABC):
-    """Base class for crossover operators."""
+    """Base class for crossover operators.
+
+    Attributes
+    ----------
+    n_parents : int
+        Number of parents required per crossover call. Default is 2.
+        Subclasses may override this class attribute if they require a
+        different number of parents.
+    """
+
+    n_parents: int = 2
 
     @abstractmethod
     def crossover(self, parent: np.ndarray, rng=np.random.default_rng()) -> np.ndarray:
@@ -84,4 +94,210 @@ class CrossoverBLXAlpha(Crossover):
         c2 = (1 - blend) * p1 + blend * p2
         return np.array([c1, c2])
 
+
+class CrossoverSBX(Crossover):
+    """
+    Simulated Binary Crossover (SBX) operator.
+
+    Attributes
+    ----------
+    crossover_rate : float
+        Crossover rate.
+    eta : float
+        Distribution index. Larger values produce offspring closer to parents.
+    """
+
+    def __init__(self, crossover_rate: float, eta: float):
+        """
+        Initialize SBX crossover operator.
+
+        Parameters
+        ----------
+        crossover_rate : float
+            Crossover rate.
+        eta : float
+            Distribution index.
+        """
+        super().__init__()
+        self.crossover_rate = crossover_rate
+        self.eta = eta
+
+    def crossover(self, p: np.ndarray, rng=np.random.default_rng()) -> np.ndarray:
+        """
+        Execute SBX crossover.
+
+        Parameters
+        ----------
+        p : np.ndarray
+            Parent individuals. shape = (2, dim)
+        rng : np.random.Generator, optional
+            Random number generator, by default np.random.default_rng()
+
+        Returns
+        -------
+        np.ndarray
+            Offspring individuals. shape = (2, dim)
+        """
+        p1 = p[0]
+        p2 = p[1]
+        dim = len(p1)
+        u = rng.uniform(0.0, 1.0, size=dim)
+        beta_q = np.where(
+            u <= 0.5,
+            (2.0 * u) ** (1.0 / (self.eta + 1)),
+            (1.0 / (2.0 * (1.0 - u))) ** (1.0 / (self.eta + 1)),
+        )
+        mid = 0.5 * (p1 + p2)
+        half_diff = 0.5 * beta_q * (p2 - p1)
+        c1 = mid - half_diff
+        c2 = mid + half_diff
+        return np.array([c1, c2])
+
+
+class CrossoverUniform(Crossover):
+    """
+    Uniform crossover operator.
+
+    Each dimension is independently swapped between parents with probability
+    ``swap_rate``.
+
+    Attributes
+    ----------
+    crossover_rate : float
+        Crossover rate.
+    swap_rate : float
+        Per-dimension swap probability. Default is 0.5.
+    """
+
+    def __init__(self, crossover_rate: float, swap_rate: float = 0.5):
+        """
+        Initialize uniform crossover operator.
+
+        Parameters
+        ----------
+        crossover_rate : float
+            Crossover rate.
+        swap_rate : float, optional
+            Per-dimension swap probability, by default 0.5.
+        """
+        super().__init__()
+        self.crossover_rate = crossover_rate
+        self.swap_rate = swap_rate
+
+    def crossover(self, p: np.ndarray, rng=np.random.default_rng()) -> np.ndarray:
+        """
+        Execute uniform crossover.
+
+        Parameters
+        ----------
+        p : np.ndarray
+            Parent individuals. shape = (2, dim)
+        rng : np.random.Generator, optional
+            Random number generator, by default np.random.default_rng()
+
+        Returns
+        -------
+        np.ndarray
+            Offspring individuals. shape = (2, dim)
+        """
+        p1 = p[0]
+        p2 = p[1]
+        mask = rng.random(len(p1)) < self.swap_rate
+        c1 = np.where(mask, p2, p1)
+        c2 = np.where(mask, p1, p2)
+        return np.array([c1, c2])
+
+
+class CrossoverOnePoint(Crossover):
+    """
+    One-point crossover operator.
+
+    Attributes
+    ----------
+    crossover_rate : float
+        Crossover rate.
+    """
+
+    def __init__(self, crossover_rate: float):
+        """
+        Initialize one-point crossover operator.
+
+        Parameters
+        ----------
+        crossover_rate : float
+            Crossover rate.
+        """
+        super().__init__()
+        self.crossover_rate = crossover_rate
+
+    def crossover(self, p: np.ndarray, rng=np.random.default_rng()) -> np.ndarray:
+        """
+        Execute one-point crossover.
+
+        Parameters
+        ----------
+        p : np.ndarray
+            Parent individuals. shape = (2, dim)
+        rng : np.random.Generator, optional
+            Random number generator, by default np.random.default_rng()
+
+        Returns
+        -------
+        np.ndarray
+            Offspring individuals. shape = (2, dim)
+        """
+        p1 = p[0]
+        p2 = p[1]
+        dim = len(p1)
+        point = rng.integers(1, dim)
+        c1 = np.concatenate([p1[:point], p2[point:]])
+        c2 = np.concatenate([p2[:point], p1[point:]])
+        return np.array([c1, c2])
+
+
+class CrossoverTwoPoint(Crossover):
+    """
+    Two-point crossover operator.
+
+    Attributes
+    ----------
+    crossover_rate : float
+        Crossover rate.
+    """
+
+    def __init__(self, crossover_rate: float):
+        """
+        Initialize two-point crossover operator.
+
+        Parameters
+        ----------
+        crossover_rate : float
+            Crossover rate.
+        """
+        super().__init__()
+        self.crossover_rate = crossover_rate
+
+    def crossover(self, p: np.ndarray, rng=np.random.default_rng()) -> np.ndarray:
+        """
+        Execute two-point crossover.
+
+        Parameters
+        ----------
+        p : np.ndarray
+            Parent individuals. shape = (2, dim)
+        rng : np.random.Generator, optional
+            Random number generator, by default np.random.default_rng()
+
+        Returns
+        -------
+        np.ndarray
+            Offspring individuals. shape = (2, dim)
+        """
+        p1 = p[0]
+        p2 = p[1]
+        dim = len(p1)
+        pts = np.sort(rng.choice(dim + 1, size=2, replace=False))
+        pt1, pt2 = pts[0], pts[1]
+        c1 = np.concatenate([p1[:pt1], p2[pt1:pt2], p1[pt2:]])
+        c2 = np.concatenate([p2[:pt1], p1[pt1:pt2], p2[pt2:]])
         return np.array([c1, c2])

--- a/src/saealib/operators/crossover.py
+++ b/src/saealib/operators/crossover.py
@@ -40,11 +40,12 @@ class CrossoverBLXAlpha(Crossover):
     ----------
     crossover_rate : float
         Crossover rate.
-    gamma : float
-        Gamma parameter for BLX-alpha crossover.
+    alpha : float
+        Alpha parameter for BLX-alpha crossover. Controls how far outside
+        the parents' range offspring can be generated.
     """
 
-    def __init__(self, crossover_rate: float, gamma: float):
+    def __init__(self, crossover_rate: float, alpha: float):
         """
         Initialize BLX-alpha crossover operator.
 
@@ -52,12 +53,12 @@ class CrossoverBLXAlpha(Crossover):
         ----------
         crossover_rate : float
             Crossover rate.
-        gamma : float
-            Gamma parameter for BLX-alpha crossover.
+        alpha : float
+            Alpha parameter for BLX-alpha crossover.
         """
         super().__init__()
         self.crossover_rate = crossover_rate
-        self.gamma = gamma
+        self.alpha = alpha
 
     def crossover(self, p: np.ndarray, rng=np.random.default_rng()) -> np.ndarray:
         """
@@ -78,7 +79,9 @@ class CrossoverBLXAlpha(Crossover):
         p1 = p[0]
         p2 = p[1]
         dim = len(p1)
-        alpha = rng.uniform(-self.gamma, 1 + self.gamma, size=dim)
-        c1 = alpha * p1 + (1 - alpha) * p2
-        c2 = (1 - alpha) * p1 + alpha * p2
+        blend = rng.uniform(-self.alpha, 1 + self.alpha, size=dim)
+        c1 = blend * p1 + (1 - blend) * p2
+        c2 = (1 - blend) * p1 + blend * p2
+        return np.array([c1, c2])
+
         return np.array([c1, c2])

--- a/src/saealib/operators/mutation.py
+++ b/src/saealib/operators/mutation.py
@@ -142,12 +142,13 @@ class MutationPolynomial(Mutation):
                 delta = min(c[i] - lb[i], ub[i] - c[i]) / (ub[i] - lb[i])
                 u = rng.random()
                 if u <= 0.5:
-                    delta_q = (2.0 * u + (1.0 - 2.0 * u) * (1.0 - delta) ** (self.eta + 1)) ** (
-                        1.0 / (self.eta + 1)
-                    ) - 1.0
+                    delta_q = (
+                        2.0 * u + (1.0 - 2.0 * u) * (1.0 - delta) ** (self.eta + 1)
+                    ) ** (1.0 / (self.eta + 1)) - 1.0
                 else:
                     delta_q = 1.0 - (
-                        2.0 * (1.0 - u) + 2.0 * (u - 0.5) * (1.0 - delta) ** (self.eta + 1)
+                        2.0 * (1.0 - u)
+                        + 2.0 * (u - 0.5) * (1.0 - delta) ** (self.eta + 1)
                     ) ** (1.0 / (self.eta + 1))
                 c[i] = np.clip(c[i] + delta_q * (ub[i] - lb[i]), lb[i], ub[i])
         return c

--- a/src/saealib/operators/mutation.py
+++ b/src/saealib/operators/mutation.py
@@ -86,3 +86,122 @@ class MutationUniform(Mutation):
             if rng.random() < self.mutation_rate:
                 c[i] = rng.uniform(lb[i], ub[i])
         return c
+
+
+class MutationPolynomial(Mutation):
+    """
+    Polynomial mutation operator.
+
+    Attributes
+    ----------
+    mutation_rate : float
+        The probability of mutating each dimension.
+    eta : float
+        Distribution index. Larger values produce smaller perturbations.
+    """
+
+    def __init__(self, mutation_rate: float, eta: float):
+        """
+        Initialize polynomial mutation operator.
+
+        Parameters
+        ----------
+        mutation_rate : float
+            The probability of mutating each dimension.
+        eta : float
+            Distribution index.
+        """
+        super().__init__()
+        self.mutation_rate = mutation_rate
+        self.eta = eta
+
+    def mutate(
+        self, p: np.ndarray, mutate_range: tuple, rng=np.random.default_rng()
+    ) -> np.ndarray:
+        """
+        Execute polynomial mutation.
+
+        Parameters
+        ----------
+        p : np.ndarray
+            Parent individual. shape = (dim,)
+        mutate_range : tuple
+            Tuple of (lower_bound, upper_bound) for mutation.
+        rng : np.random.Generator, optional
+            Random number generator, by default np.random.default_rng()
+
+        Returns
+        -------
+        np.ndarray
+            Mutated individual.
+        """
+        c = p.copy()
+        lb, ub = mutate_range
+        for i in range(len(p)):
+            if rng.random() < self.mutation_rate:
+                delta = min(c[i] - lb[i], ub[i] - c[i]) / (ub[i] - lb[i])
+                u = rng.random()
+                if u <= 0.5:
+                    delta_q = (2.0 * u + (1.0 - 2.0 * u) * (1.0 - delta) ** (self.eta + 1)) ** (
+                        1.0 / (self.eta + 1)
+                    ) - 1.0
+                else:
+                    delta_q = 1.0 - (
+                        2.0 * (1.0 - u) + 2.0 * (u - 0.5) * (1.0 - delta) ** (self.eta + 1)
+                    ) ** (1.0 / (self.eta + 1))
+                c[i] = np.clip(c[i] + delta_q * (ub[i] - lb[i]), lb[i], ub[i])
+        return c
+
+
+class MutationGaussian(Mutation):
+    """
+    Gaussian mutation operator.
+
+    Attributes
+    ----------
+    mutation_rate : float
+        The probability of mutating each dimension.
+    sigma : float
+        Standard deviation of the Gaussian perturbation.
+    """
+
+    def __init__(self, mutation_rate: float, sigma: float):
+        """
+        Initialize Gaussian mutation operator.
+
+        Parameters
+        ----------
+        mutation_rate : float
+            The probability of mutating each dimension.
+        sigma : float
+            Standard deviation of the Gaussian perturbation.
+        """
+        super().__init__()
+        self.mutation_rate = mutation_rate
+        self.sigma = sigma
+
+    def mutate(
+        self, p: np.ndarray, mutate_range: tuple, rng=np.random.default_rng()
+    ) -> np.ndarray:
+        """
+        Execute Gaussian mutation.
+
+        Parameters
+        ----------
+        p : np.ndarray
+            Parent individual. shape = (dim,)
+        mutate_range : tuple
+            Tuple of (lower_bound, upper_bound) for mutation.
+        rng : np.random.Generator, optional
+            Random number generator, by default np.random.default_rng()
+
+        Returns
+        -------
+        np.ndarray
+            Mutated individual.
+        """
+        c = p.copy()
+        for i in range(len(p)):
+            if rng.random() < self.mutation_rate:
+                c[i] = c[i] + rng.normal(0.0, self.sigma)
+        return c

--- a/src/saealib/operators/selection.py
+++ b/src/saealib/operators/selection.py
@@ -87,7 +87,7 @@ class TournamentSelection(ParentSelection):
         np.ndarray
             Selected parent indices. shape = (n_pair, n_parents)
         """
-        n_pop = population.n_ind
+        n_pop = len(population)
         cmp = ctx.comparator
         selected_idx = np.zeros((n_pair, n_parents), dtype=int)
         for i in range(n_pair):
@@ -154,6 +154,59 @@ class SequentialSelection(ParentSelection):
         )
         selected_idx = i_grid * n_parents + j_grid
         return selected_idx
+
+
+class RouletteWheelSelection(ParentSelection):
+    """
+    Roulette wheel selection operator using linear rank-based probabilities.
+
+    Selection probability is proportional to rank: the best individual has
+    the highest probability and the worst has the lowest. This avoids
+    numerical issues with raw fitness values (negative values, scale
+    sensitivity) while preserving a fitness-proportionate behaviour.
+    """
+
+    def __init__(self):
+        """Initialize roulette wheel selection operator."""
+        super().__init__()
+
+    def select(
+        self,
+        ctx: OptimizationContext,
+        population: Population,
+        n_pair: int,
+        n_parents: int,
+        rng=np.random.default_rng(),
+    ) -> np.ndarray:
+        """
+        Execute roulette wheel selection.
+
+        Parameters
+        ----------
+        ctx : OptimizationContext
+            Optimization context.
+        population : Population
+            Population to select from.
+        n_pair : int
+            Number of pairs to select.
+        n_parents : int
+            Number of parents per pair.
+        rng : np.random.Generator, optional
+            Random number generator, by default np.random.default_rng()
+
+        Returns
+        -------
+        np.ndarray
+            Selected parent indices. shape = (n_pair, n_parents)
+        """
+        n_pop = len(population)
+        sorted_idx = ctx.comparator.sort_population(population)
+        weights = np.arange(n_pop, 0, -1, dtype=float)
+        probs = weights / weights.sum()
+        rank_probs = np.empty(n_pop)
+        rank_probs[sorted_idx] = probs
+        chosen = rng.choice(n_pop, size=n_pair * n_parents, p=rank_probs)
+        return chosen.reshape(n_pair, n_parents)
 
 
 class SurvivorSelection(ABC):

--- a/tests/scripts/generate_test_integration.py
+++ b/tests/scripts/generate_test_integration.py
@@ -72,7 +72,7 @@ def run_benchmark(seed: int):
         seed=seed,
     )
     algorithm = GA(
-        crossover=CrossoverBLXAlpha(crossover_rate=0.7, gamma=0.4),
+        crossover=CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4),
         mutation=MutationUniform(mutation_rate=0.3),
         parent_selection=SequentialSelection(),
         survivor_selection=TruncationSelection(),

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -685,7 +685,7 @@ class TestPostEvaluationDispatch:
             )
             .set_algorithm(
                 GA(
-                    crossover=CrossoverBLXAlpha(crossover_rate=0.9, gamma=0.5),
+                    crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.5),
                     mutation=MutationUniform(mutation_rate=0.1),
                     parent_selection=SequentialSelection(),
                     survivor_selection=TruncationSelection(),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -83,7 +83,7 @@ def test_integration(seed_str: str, expected_f: float):
         seed=seed,
     )
     algorithm = GA(
-        crossover=CrossoverBLXAlpha(crossover_rate=0.7, gamma=0.4),
+        crossover=CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4),
         mutation=MutationUniform(mutation_rate=0.3),
         parent_selection=SequentialSelection(),
         survivor_selection=TruncationSelection(),

--- a/tests/test_moo.py
+++ b/tests/test_moo.py
@@ -569,7 +569,7 @@ class TestMOOIntegration:
             seed=seed,
         )
         algorithm = GA(
-            crossover=CrossoverBLXAlpha(crossover_rate=0.7, gamma=0.4),
+            crossover=CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4),
             mutation=MutationUniform(mutation_rate=0.3),
             parent_selection=SequentialSelection(),
             survivor_selection=TruncationSelection(),

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -23,7 +23,10 @@ from saealib.operators.crossover import (
     CrossoverTwoPoint,
     CrossoverUniform,
 )
-from saealib.operators.mutation import MutationGaussian, MutationPolynomial, MutationUniform
+from saealib.operators.mutation import (
+    MutationGaussian,
+    MutationPolynomial,
+)
 from saealib.operators.selection import RouletteWheelSelection
 from saealib.population import Archive, Population, PopulationAttribute
 from saealib.problem import Problem, SingleObjectiveComparator

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,0 +1,326 @@
+"""
+Tests for evolutionary operators (Issue #010).
+
+Tests cover:
+- CrossoverBLXAlpha: alpha rename, output shape, determinism
+- CrossoverSBX: output shape, center preservation, determinism
+- CrossoverUniform: output shape, swap_rate=0/1 boundary cases
+- CrossoverOnePoint: output shape, segment integrity
+- CrossoverTwoPoint: output shape, segment integrity
+- MutationPolynomial: output shape, within-bounds, zero-rate
+- MutationGaussian: output shape, zero-rate, zero-sigma
+- RouletteWheelSelection: output shape, probability bias
+"""
+
+import numpy as np
+import pytest
+
+from saealib.context import OptimizationContext
+from saealib.operators.crossover import (
+    CrossoverBLXAlpha,
+    CrossoverOnePoint,
+    CrossoverSBX,
+    CrossoverTwoPoint,
+    CrossoverUniform,
+)
+from saealib.operators.mutation import MutationGaussian, MutationPolynomial, MutationUniform
+from saealib.operators.selection import RouletteWheelSelection
+from saealib.population import Archive, Population, PopulationAttribute
+from saealib.problem import Problem, SingleObjectiveComparator
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+DIM = 6
+_ATTRS = [
+    PopulationAttribute(name="x", dtype=np.float64, shape=(DIM,)),
+    PopulationAttribute(name="f", dtype=np.float64, shape=(1,)),
+    PopulationAttribute(name="g", dtype=np.float64, shape=(0,)),
+    PopulationAttribute(name="cv", dtype=np.float64, shape=()),
+]
+
+
+def _make_parents(rng: np.random.Generator) -> np.ndarray:
+    """Two parent individuals, shape=(2, DIM)."""
+    return rng.uniform(-1.0, 1.0, size=(2, DIM))
+
+
+def _make_problem() -> Problem:
+    return Problem(
+        func=lambda x: np.array([np.sum(x**2)]),
+        dim=DIM,
+        n_obj=1,
+        weight=np.array([-1.0]),
+        lb=[-5.0] * DIM,
+        ub=[5.0] * DIM,
+        comparator=SingleObjectiveComparator(),
+    )
+
+
+def _make_ctx(n_pop: int = 10, rng_seed: int = 0) -> OptimizationContext:
+    problem = _make_problem()
+    rng = np.random.default_rng(rng_seed)
+    pop = Population(_ATTRS, init_capacity=n_pop + 5)
+    xs = rng.uniform(-3.0, 3.0, size=(n_pop, DIM))
+    fs = np.array([[np.sum(x**2)] for x in xs])
+    gs = np.zeros((n_pop, 0))
+    cvs = np.zeros(n_pop)
+    pop.extend({"x": xs, "f": fs, "g": gs, "cv": cvs})
+    arc = Archive(_ATTRS, init_capacity=5)
+    return OptimizationContext(
+        problem=problem,
+        population=pop,
+        archive=arc,
+        rng=np.random.default_rng(rng_seed),
+    )
+
+
+# ---------------------------------------------------------------------------
+# CrossoverBLXAlpha
+# ---------------------------------------------------------------------------
+
+
+class TestCrossoverBLXAlpha:
+    def test_alpha_attribute(self):
+        op = CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4)
+        assert op.alpha == pytest.approx(0.4)
+
+    def test_output_shape(self):
+        op = CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4)
+        rng = np.random.default_rng(0)
+        p = _make_parents(rng)
+        c = op.crossover(p, rng=rng)
+        assert c.shape == (2, DIM)
+
+    def test_deterministic_with_seed(self):
+        op = CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4)
+        p = _make_parents(np.random.default_rng(1))
+        c1 = op.crossover(p, rng=np.random.default_rng(42))
+        c2 = op.crossover(p, rng=np.random.default_rng(42))
+        np.testing.assert_array_equal(c1, c2)
+
+
+# ---------------------------------------------------------------------------
+# CrossoverSBX
+# ---------------------------------------------------------------------------
+
+
+class TestCrossoverSBX:
+    def test_output_shape(self):
+        op = CrossoverSBX(crossover_rate=0.9, eta=2.0)
+        rng = np.random.default_rng(0)
+        p = _make_parents(rng)
+        c = op.crossover(p, rng=rng)
+        assert c.shape == (2, DIM)
+
+    def test_center_preservation(self):
+        """Mid-point of children equals mid-point of parents (SBX property)."""
+        op = CrossoverSBX(crossover_rate=0.9, eta=2.0)
+        rng = np.random.default_rng(5)
+        p = _make_parents(rng)
+        c = op.crossover(p, rng=rng)
+        np.testing.assert_allclose((c[0] + c[1]) / 2, (p[0] + p[1]) / 2, atol=1e-10)
+
+    def test_deterministic_with_seed(self):
+        op = CrossoverSBX(crossover_rate=0.9, eta=2.0)
+        p = _make_parents(np.random.default_rng(1))
+        c1 = op.crossover(p, rng=np.random.default_rng(42))
+        c2 = op.crossover(p, rng=np.random.default_rng(42))
+        np.testing.assert_array_equal(c1, c2)
+
+
+# ---------------------------------------------------------------------------
+# CrossoverUniform
+# ---------------------------------------------------------------------------
+
+
+class TestCrossoverUniform:
+    def test_output_shape(self):
+        op = CrossoverUniform(crossover_rate=0.8)
+        rng = np.random.default_rng(0)
+        p = _make_parents(rng)
+        c = op.crossover(p, rng=rng)
+        assert c.shape == (2, DIM)
+
+    def test_swap_rate_zero(self):
+        """swap_rate=0: c1==p1 and c2==p2."""
+        op = CrossoverUniform(crossover_rate=0.8, swap_rate=0.0)
+        rng = np.random.default_rng(0)
+        p = _make_parents(rng)
+        c = op.crossover(p, rng=rng)
+        np.testing.assert_array_equal(c[0], p[0])
+        np.testing.assert_array_equal(c[1], p[1])
+
+    def test_swap_rate_one(self):
+        """swap_rate=1: c1==p2 and c2==p1."""
+        op = CrossoverUniform(crossover_rate=0.8, swap_rate=1.0)
+        rng = np.random.default_rng(0)
+        p = _make_parents(rng)
+        c = op.crossover(p, rng=rng)
+        np.testing.assert_array_equal(c[0], p[1])
+        np.testing.assert_array_equal(c[1], p[0])
+
+
+# ---------------------------------------------------------------------------
+# CrossoverOnePoint
+# ---------------------------------------------------------------------------
+
+
+class TestCrossoverOnePoint:
+    def test_output_shape(self):
+        op = CrossoverOnePoint(crossover_rate=0.8)
+        rng = np.random.default_rng(0)
+        p = _make_parents(rng)
+        c = op.crossover(p, rng=rng)
+        assert c.shape == (2, DIM)
+
+    def test_segment_intact(self):
+        """Before cut point, c1 == p1; from cut point onward, c1 == p2."""
+        op = CrossoverOnePoint(crossover_rate=0.8)
+        rng = np.random.default_rng(0)
+        p = _make_parents(rng)
+        # Fix cut point by seeding: integers(1, DIM) with seed=7 gives a known value
+        rng2 = np.random.default_rng(7)
+        point = rng2.integers(1, DIM)
+        rng3 = np.random.default_rng(7)
+        c = op.crossover(p, rng=rng3)
+        np.testing.assert_array_equal(c[0, :point], p[0, :point])
+        np.testing.assert_array_equal(c[0, point:], p[1, point:])
+        np.testing.assert_array_equal(c[1, :point], p[1, :point])
+        np.testing.assert_array_equal(c[1, point:], p[0, point:])
+
+
+# ---------------------------------------------------------------------------
+# CrossoverTwoPoint
+# ---------------------------------------------------------------------------
+
+
+class TestCrossoverTwoPoint:
+    def test_output_shape(self):
+        op = CrossoverTwoPoint(crossover_rate=0.8)
+        rng = np.random.default_rng(0)
+        p = _make_parents(rng)
+        c = op.crossover(p, rng=rng)
+        assert c.shape == (2, DIM)
+
+    def test_segment_intact(self):
+        """Between the two cut points, c1 == p2; outside, c1 == p1."""
+        op = CrossoverTwoPoint(crossover_rate=0.8)
+        rng2 = np.random.default_rng(3)
+        pts = np.sort(rng2.choice(DIM + 1, size=2, replace=False))
+        pt1, pt2 = pts[0], pts[1]
+        rng3 = np.random.default_rng(3)
+        p = _make_parents(np.random.default_rng(99))
+        c = op.crossover(p, rng=rng3)
+        np.testing.assert_array_equal(c[0, :pt1], p[0, :pt1])
+        np.testing.assert_array_equal(c[0, pt1:pt2], p[1, pt1:pt2])
+        np.testing.assert_array_equal(c[0, pt2:], p[0, pt2:])
+
+
+# ---------------------------------------------------------------------------
+# MutationPolynomial
+# ---------------------------------------------------------------------------
+
+
+class TestMutationPolynomial:
+    def _range(self):
+        lb = np.full(DIM, -5.0)
+        ub = np.full(DIM, 5.0)
+        return lb, ub
+
+    def test_output_shape(self):
+        op = MutationPolynomial(mutation_rate=0.5, eta=20.0)
+        rng = np.random.default_rng(0)
+        p = rng.uniform(-2.0, 2.0, size=DIM)
+        c = op.mutate(p, self._range(), rng=rng)
+        assert c.shape == (DIM,)
+
+    def test_within_bounds(self):
+        op = MutationPolynomial(mutation_rate=1.0, eta=20.0)
+        lb, ub = self._range()
+        rng = np.random.default_rng(0)
+        for _ in range(20):
+            p = rng.uniform(-4.0, 4.0, size=DIM)
+            c = op.mutate(p, (lb, ub), rng=rng)
+            assert np.all(c >= lb) and np.all(c <= ub)
+
+    def test_zero_rate_no_change(self):
+        op = MutationPolynomial(mutation_rate=0.0, eta=20.0)
+        rng = np.random.default_rng(0)
+        p = rng.uniform(-2.0, 2.0, size=DIM)
+        c = op.mutate(p, self._range(), rng=rng)
+        np.testing.assert_array_equal(c, p)
+
+
+# ---------------------------------------------------------------------------
+# MutationGaussian
+# ---------------------------------------------------------------------------
+
+
+class TestMutationGaussian:
+    def _range(self):
+        lb = np.full(DIM, -5.0)
+        ub = np.full(DIM, 5.0)
+        return lb, ub
+
+    def test_output_shape(self):
+        op = MutationGaussian(mutation_rate=0.5, sigma=0.1)
+        rng = np.random.default_rng(0)
+        p = rng.uniform(-2.0, 2.0, size=DIM)
+        c = op.mutate(p, self._range(), rng=rng)
+        assert c.shape == (DIM,)
+
+    def test_zero_rate_no_change(self):
+        op = MutationGaussian(mutation_rate=0.0, sigma=1.0)
+        rng = np.random.default_rng(0)
+        p = rng.uniform(-2.0, 2.0, size=DIM)
+        c = op.mutate(p, self._range(), rng=rng)
+        np.testing.assert_array_equal(c, p)
+
+    def test_zero_sigma_no_change(self):
+        op = MutationGaussian(mutation_rate=1.0, sigma=0.0)
+        rng = np.random.default_rng(0)
+        p = rng.uniform(-2.0, 2.0, size=DIM)
+        c = op.mutate(p, self._range(), rng=rng)
+        np.testing.assert_array_equal(c, p)
+
+
+# ---------------------------------------------------------------------------
+# RouletteWheelSelection
+# ---------------------------------------------------------------------------
+
+
+class TestRouletteWheelSelection:
+    def test_output_shape(self):
+        op = RouletteWheelSelection()
+        ctx = _make_ctx(n_pop=10)
+        rng = np.random.default_rng(0)
+        idx = op.select(ctx, ctx.population, n_pair=4, n_parents=2, rng=rng)
+        assert idx.shape == (4, 2)
+
+    def test_indices_in_range(self):
+        op = RouletteWheelSelection()
+        ctx = _make_ctx(n_pop=10)
+        rng = np.random.default_rng(0)
+        idx = op.select(ctx, ctx.population, n_pair=5, n_parents=2, rng=rng)
+        assert np.all(idx >= 0) and np.all(idx < len(ctx.population))
+
+    def test_best_selected_more_often(self):
+        """Best individual (lowest f) should appear more than worst over many trials."""
+        op = RouletteWheelSelection()
+        n_pop = 10
+        ctx = _make_ctx(n_pop=n_pop, rng_seed=0)
+        # Identify best and worst indices via comparator
+        sorted_idx = ctx.comparator.sort_population(ctx.population)
+        best_idx = sorted_idx[0]
+        worst_idx = sorted_idx[-1]
+
+        rng = np.random.default_rng(1)
+        counts = np.zeros(n_pop, dtype=int)
+        for _ in range(500):
+            idx = op.select(ctx, ctx.population, n_pair=10, n_parents=1, rng=rng)
+            for i in idx.flatten():
+                counts[i] += 1
+
+        assert counts[best_idx] > counts[worst_idx]


### PR DESCRIPTION
## Related Issue
                                                                                                                
  Closes #56           

## Overview

  Implements the additional evolutionary operators required for the initial release. Adds SBX / Uniform /       
  One-point / Two-point crossover, Polynomial / Gaussian mutation, and Roulette Wheel Selection. Also renames
  the misnamed gamma parameter in CrossoverBLXAlpha to the standard alpha, and adds a n_parents attribute to the
   Crossover base class so that GA can read the required parent count directly from the operator.

## Changes

  - refactor: Rename CrossoverBLXAlpha.gamma → alpha; rename local variable alpha → blend inside crossover() to 
  eliminate the naming conflict
  - feat: Add CrossoverSBX, CrossoverUniform, CrossoverOnePoint, CrossoverTwoPoint                              
  - feat: Add MutationPolynomial, MutationGaussian                                                              
  - feat: Add RouletteWheelSelection (linear rank-based proportionate selection)
  - feat: Add Crossover.n_parents class attribute (default 2); wire into GA.ask() to remove hardcoded value     
  - fix: Replace population.n_ind (non-existent attribute) with len(population) in TournamentSelection and      
  RouletteWheelSelection                                                                                        
  - feat: Export all new classes from the top-level saealib package                                             
  - test: Add tests/test_operators.py with 22 unit tests covering all new and updated operators                 
                                                                                                                
## Verification Steps                                                                                            
                                                                                                                
  1. Run the operator unit tests: uv run pytest tests/test_operators.py -v
  2. Run the full test suite (excluding environment-dependent integration tests): uv run pytest tests/ 
  --ignore=tests/test_integration.py                                                                            
  3. Confirm that existing GA-based tests (test_callback.py, test_moo.py) still pass after the gamma → alpha
  rename                                                                                                        
                  
## Concerns                                                                                                      
                  
  - CrossoverBLXAlpha(gamma=...) is a breaking change. Any user code passing gamma= as a keyword argument must  
  be updated to alpha=. All in-repo call sites have been updated.
  - TournamentSelection.n_ind was a latent bug (the attribute does not exist on Population). The fix is included
   in this PR, but it means TournamentSelection behaviour is now correctly testable for the first time.         
  - MutationGaussian does not clip output to bounds; downstream repair (e.g. repair_clipping) is assumed.
  - RouletteWheelSelection uses linear rank-based probabilities rather than raw fitness values, which avoids    
  scale sensitivity and negative-fitness issues but differs from the classic fitness-proportionate definition.  
                                                                                                                
