### PR TITLE
Dev issue#67

### DIFF
--- a/src/saealib/api.py
+++ b/src/saealib/api.py
@@ -115,20 +115,24 @@ def _resolve_surrogate(
         return surrogate
     if isinstance(surrogate, str):
         if surrogate.lower() == "rbf":
+            from saealib.surrogate.training_set import KNNObjectiveSet
+
             rbf = RBFsurrogate(gaussian_kernel, problem.dim)
             return LocalSurrogateManager(
                 rbf,
                 MeanPrediction(weights=problem.weight),
-                n_neighbors=n_neighbors,
+                training_set=KNNObjectiveSet(n_neighbors),
             )
         raise ValueError(
             f"Unknown surrogate: {surrogate!r}. "
             "Use 'rbf' or a Surrogate/SurrogateManager instance."
         )
+    from saealib.surrogate.training_set import KNNObjectiveSet
+
     return LocalSurrogateManager(
         surrogate,
         MeanPrediction(weights=problem.weight),
-        n_neighbors=n_neighbors,
+        training_set=KNNObjectiveSet(n_neighbors),
     )
 
 

--- a/src/saealib/optimizer.py
+++ b/src/saealib/optimizer.py
@@ -135,10 +135,12 @@ class Optimizer:
         Equivalent to ``set_surrogate_manager(LocalSurrogateManager(surrogate, ...))``.
         Provided for backward compatibility.
         """
+        from saealib.surrogate.training_set import KNNObjectiveSet
+
         self.surrogate_manager = LocalSurrogateManager(
             surrogate,
             MeanPrediction(weights=self.problem.weight),
-            n_neighbors=n_neighbors,
+            training_set=KNNObjectiveSet(n_neighbors=n_neighbors),
         )
         return self
 

--- a/src/saealib/surrogate/manager.py
+++ b/src/saealib/surrogate/manager.py
@@ -18,6 +18,11 @@ from saealib.acquisition.base import AcquisitionFunction
 from saealib.callback import PostSurrogateFitEvent
 from saealib.surrogate.base import Surrogate
 from saealib.surrogate.prediction import SurrogatePrediction
+from saealib.surrogate.training_set import (
+    ArchiveObjectiveSet,
+    KNNObjectiveSet,
+    TrainingSet,
+)
 
 if TYPE_CHECKING:
     from saealib.context import OptimizationContext
@@ -83,11 +88,22 @@ class GlobalSurrogateManager(SurrogateManager):
         Surrogate model instance.
     acquisition : AcquisitionFunction
         Acquisition function used to score predictions.
+    training_set : TrainingSet or None
+        Strategy object for building training data. Defaults to
+        ``ArchiveObjectiveSet()``, which preserves the previous behaviour.
     """
 
-    def __init__(self, surrogate: Surrogate, acquisition: AcquisitionFunction):
+    def __init__(
+        self,
+        surrogate: Surrogate,
+        acquisition: AcquisitionFunction,
+        training_set: TrainingSet | None = None,
+    ):
         self.surrogate = surrogate
         self.acquisition = acquisition
+        self.training_set: TrainingSet = (
+            training_set if training_set is not None else ArchiveObjectiveSet()
+        )
 
     def score_candidates(
         self,
@@ -97,17 +113,17 @@ class GlobalSurrogateManager(SurrogateManager):
         ctx: OptimizationContext | None = None,
     ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
         """Fit on full archive, predict and score all candidates at once."""
-        train_x = archive.x
-        train_f = archive.f  # (n_archive, n_obj)
-        self.surrogate.fit(train_x, train_f)
+        population = ctx.population if ctx is not None else None
+        data = self.training_set.build(archive, population, ctx, candidate_x=None)
+        self.surrogate.fit(data.train_x, data.train_y)
         if provider is not None and ctx is not None:
             provider.dispatch(
                 PostSurrogateFitEvent(
                     ctx=ctx,
                     provider=provider,
                     surrogate=self.surrogate,
-                    train_x=train_x,
-                    train_f=train_f,
+                    train_x=data.train_x,
+                    train_f=data.train_y,
                 )
             )
 
@@ -139,19 +155,25 @@ class LocalSurrogateManager(SurrogateManager):
         Surrogate model instance (re-fit per candidate).
     acquisition : AcquisitionFunction
         Acquisition function used to score predictions.
-    n_neighbors : int
-        Number of nearest neighbors for local model training.
+    training_set : TrainingSet or None
+        Strategy object for building training data per candidate. Defaults to
+        ``KNNObjectiveSet(n_neighbors=50)``, which preserves the previous
+        behaviour.
     """
 
     def __init__(
         self,
         surrogate: Surrogate,
         acquisition: AcquisitionFunction,
-        n_neighbors: int = 50,
+        training_set: TrainingSet | None = None,
     ):
         self.surrogate = surrogate
         self.acquisition = acquisition
-        self.n_neighbors = n_neighbors
+        self.training_set: TrainingSet = (
+            training_set
+            if training_set is not None
+            else KNNObjectiveSet(n_neighbors=50)
+        )
 
     def score_candidates(
         self,
@@ -164,20 +186,19 @@ class LocalSurrogateManager(SurrogateManager):
         predictions: list[SurrogatePrediction] = []
         _dispatch = provider is not None and ctx is not None
         reference = self.acquisition.compute_reference(archive)
+        population = ctx.population if ctx is not None else None
 
         for x in candidates_x:
-            train_idx, _ = archive.get_knn(x, self.n_neighbors)
-            train_x = archive.x[train_idx]
-            train_f = archive.f[train_idx]  # (n_neighbors, n_obj)
-            self.surrogate.fit(train_x, train_f)
+            data = self.training_set.build(archive, population, ctx, candidate_x=x)
+            self.surrogate.fit(data.train_x, data.train_y)
             if _dispatch:
                 provider.dispatch(
                     PostSurrogateFitEvent(
                         ctx=ctx,
                         provider=provider,
                         surrogate=self.surrogate,
-                        train_x=train_x,
-                        train_f=train_f,
+                        train_x=data.train_x,
+                        train_f=data.train_y,
                     )
                 )
             pred = self.surrogate.predict(x)  # mean: (1, n_obj)

--- a/src/saealib/surrogate/training_set.py
+++ b/src/saealib/surrogate/training_set.py
@@ -196,3 +196,118 @@ class FeasibilityClassificationSet(TrainingSet):
         eps = ctx.problem.eps if ctx is not None else 1e-6
         labels = (src.get_array("cv") <= eps).astype(float)
         return TrainingData(train_x=src.get_array("x"), train_y=labels)
+
+
+# ---------------------------------------------------------------------------
+# Rank-based labelling
+# ---------------------------------------------------------------------------
+
+
+class TopKBipartitionSet(TrainingSet):
+    """Binary labels from a sorted bipartition: 1 for top-*k*, 0 for the rest.
+
+    Individuals are sorted by ``ctx.comparator.sort_population`` (best-first),
+    then the top ``floor(n * top_ratio)`` receive label 1 (promising) and the
+    remainder receive label 0 (unpromising).
+
+    Literature patterns: CPS-MOEA (P2), CSEA / pre-selection (P5).
+
+    Parameters
+    ----------
+    source:
+        ``"archive"`` or ``"population"``.
+    top_ratio:
+        Fraction of individuals labelled as promising. Clamped to ``[0, 1]``.
+        At least one individual always receives label 1.
+
+    Raises
+    ------
+    ValueError
+        If ``ctx`` is ``None`` or ``source="population"`` with ``population=None``.
+    """
+
+    def __init__(self, source: str = "archive", top_ratio: float = 0.5) -> None:
+        self.source = source
+        self.top_ratio = top_ratio
+
+    def build(
+        self,
+        archive: Archive,
+        population: Population | None,
+        ctx: OptimizationContext | None,
+        candidate_x: np.ndarray | None = None,
+    ) -> TrainingData:
+        """Return bipartition labels based on sorted rank."""
+        if ctx is None:
+            raise ValueError("TopKBipartitionSet requires ctx.")
+        if self.source == "population":
+            if population is None:
+                raise ValueError(
+                    "TopKBipartitionSet: source='population' requires population."
+                )
+            src = population
+        else:
+            src = archive
+        sorted_idx = ctx.comparator.sort_population(src)
+        x = src.get_array("x")[sorted_idx]
+        n = len(x)
+        k = max(1, int(n * self.top_ratio))
+        labels = np.concatenate([np.ones(k), np.zeros(n - k)])
+        return TrainingData(train_x=x, train_y=labels)
+
+
+class LevelBasedSet(TrainingSet):
+    """Multi-class labels from equal-division of a sorted population (CA-LLSO, P1).
+
+    Individuals are sorted by ``ctx.comparator.sort_population`` (best-first),
+    then divided into ``n_levels`` equally-sized groups.  Group 0 (best) receives
+    label 0, group ``n_levels - 1`` (worst) receives the highest label.
+    Remainder individuals are appended to the last (worst) group.
+
+    Parameters
+    ----------
+    source:
+        ``"archive"`` or ``"population"``.
+    n_levels:
+        Number of classification levels (≥ 2).
+
+    Raises
+    ------
+    ValueError
+        If ``ctx`` is ``None`` or ``source="population"`` with ``population=None``.
+    """
+
+    def __init__(self, source: str = "population", n_levels: int = 5) -> None:
+        self.source = source
+        self.n_levels = n_levels
+
+    def build(
+        self,
+        archive: Archive,
+        population: Population | None,
+        ctx: OptimizationContext | None,
+        candidate_x: np.ndarray | None = None,
+    ) -> TrainingData:
+        """Return level labels from equal-size sorted groups."""
+        if ctx is None:
+            raise ValueError("LevelBasedSet requires ctx.")
+        if self.source == "population":
+            if population is None:
+                raise ValueError(
+                    "LevelBasedSet: source='population' requires population."
+                )
+            src = population
+        else:
+            src = archive
+        sorted_idx = ctx.comparator.sort_population(src)
+        x = src.get_array("x")[sorted_idx]
+        n = len(x)
+        per = n // self.n_levels
+        labels = np.repeat(np.arange(self.n_levels), per)
+        # Remainder goes to the last (worst) level
+        remainder = n - len(labels)
+        if remainder > 0:
+            labels = np.concatenate(
+                [labels, np.full(remainder, self.n_levels - 1)]
+            )
+        return TrainingData(train_x=x, train_y=labels.astype(float))

--- a/src/saealib/surrogate/training_set.py
+++ b/src/saealib/surrogate/training_set.py
@@ -145,3 +145,54 @@ class KNNObjectiveSet(TrainingSet):
             raise ValueError("KNNObjectiveSet requires candidate_x.")
         idx, _ = archive.get_knn(candidate_x, self.n_neighbors)
         return TrainingData(train_x=archive.x[idx], train_y=archive.f[idx])
+
+
+# ---------------------------------------------------------------------------
+# Constraint-based classification
+# ---------------------------------------------------------------------------
+
+
+class FeasibilityClassificationSet(TrainingSet):
+    """Binary labels derived from constraint violation: 1 if feasible, 0 otherwise.
+
+    A sample is feasible when ``cv <= eps``, where ``eps`` is taken from
+    ``ctx.problem.eps`` (defaults to ``1e-6`` when ``ctx`` is ``None``).
+
+    This set is algo-agnostic and works with any surrogate that accepts binary
+    classification targets (shape ``(n_train,)``).
+
+    Parameters
+    ----------
+    source:
+        ``"archive"`` to use the evaluated archive, or ``"population"`` to
+        use the current population.
+
+    Raises
+    ------
+    ValueError
+        If ``source="population"`` but ``population`` is ``None``.
+    """
+
+    def __init__(self, source: str = "archive") -> None:
+        self.source = source
+
+    def build(
+        self,
+        archive: Archive,
+        population: Population | None,
+        ctx: OptimizationContext | None,
+        candidate_x: np.ndarray | None = None,
+    ) -> TrainingData:
+        """Return feasibility binary labels (1 = feasible, 0 = infeasible)."""
+        if self.source == "population":
+            if population is None:
+                raise ValueError(
+                    "FeasibilityClassificationSet: source='population' requires "
+                    "population to be provided."
+                )
+            src = population
+        else:
+            src = archive
+        eps = ctx.problem.eps if ctx is not None else 1e-6
+        labels = (src.get_array("cv") <= eps).astype(float)
+        return TrainingData(train_x=src.get_array("x"), train_y=labels)

--- a/src/saealib/surrogate/training_set.py
+++ b/src/saealib/surrogate/training_set.py
@@ -307,9 +307,7 @@ class LevelBasedSet(TrainingSet):
         # Remainder goes to the last (worst) level
         remainder = n - len(labels)
         if remainder > 0:
-            labels = np.concatenate(
-                [labels, np.full(remainder, self.n_levels - 1)]
-            )
+            labels = np.concatenate([labels, np.full(remainder, self.n_levels - 1)])
         return TrainingData(train_x=x, train_y=labels.astype(float))
 
 
@@ -396,9 +394,7 @@ class PairwiseComparisonSet(TrainingSet):
                 if key not in seen:
                     seen.add(key)
                     pairs.append(key)
-        train_x = np.stack(
-            [np.concatenate([x[i], x[j]]) for i, j in pairs]
-        )
+        train_x = np.stack([np.concatenate([x[i], x[j]]) for i, j in pairs])
         train_y = np.array(
             [
                 1.0 if cmp.compare(f[i], cv[i], f[j], cv[j]) <= 0 else 0.0

--- a/src/saealib/surrogate/training_set.py
+++ b/src/saealib/surrogate/training_set.py
@@ -1,0 +1,147 @@
+"""
+Training set strategy objects for surrogate model fitting.
+
+A ``TrainingSet`` abstracts the construction of ``(train_x, train_y)`` pairs
+that are passed to ``Surrogate.fit``.  The two orthogonal axes are:
+
+* **Data source** (where samples come from):
+  archive, population, k-NN neighbourhood, pairs, per-individual reference points.
+* **Labelling rule** (how target values are assigned):
+  raw objectives (regression), binary classification, multi-level ranking,
+  pairwise comparison.
+
+Literature patterns covered by this module:
+
++----+----------------------------------------+----------------------------------+
+| P1 | CA-LLSO (Wei et al., 2021)             | ``LevelBasedSet``                |
++----+----------------------------------------+----------------------------------+
+| P2 | CPS-MOEA (Zhang et al., 2018)          | ``TopKBipartitionSet``           |
++----+----------------------------------------+----------------------------------+
+| P3 | Pairwise SAEA (Hao et al., 2024)       | ``PairwiseComparisonSet``        |
++----+----------------------------------------+----------------------------------+
+| P4 | SAPSO pbest (Tian et al., 2019)        | ``ReferencePointComparisonSet``  |
++----+----------------------------------------+----------------------------------+
+| P5 | CSEA / pre-selection (general)         | ``KNNObjectiveSet``,             |
+|    |                                        | ``ArchiveObjectiveSet``          |
++----+----------------------------------------+----------------------------------+
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from saealib.context import OptimizationContext
+    from saealib.population import Archive, Population
+
+
+@dataclass
+class TrainingData:
+    """Immutable container for the training data passed to ``Surrogate.fit``.
+
+    Attributes
+    ----------
+    train_x : np.ndarray
+        Design variable matrix. shape: ``(n_train, dim)``.
+        For ``PairwiseComparisonSet`` the shape is ``(n_train, 2 * dim)``.
+    train_y : np.ndarray
+        Target values. shape: ``(n_train, n_obj)`` for regression,
+        ``(n_train,)`` for classification or ranking.
+    """
+
+    train_x: np.ndarray
+    train_y: np.ndarray
+
+
+class TrainingSet(ABC):
+    """Strategy object that builds ``(train_x, train_y)`` for a surrogate.
+
+    Inject an instance into ``LocalSurrogateManager`` or
+    ``GlobalSurrogateManager`` via their ``training_set`` constructor argument.
+    """
+
+    @abstractmethod
+    def build(
+        self,
+        archive: Archive,
+        population: Population | None,
+        ctx: OptimizationContext | None,
+        candidate_x: np.ndarray | None = None,
+    ) -> TrainingData:
+        """Build and return the training data.
+
+        Parameters
+        ----------
+        archive:
+            Evaluated solutions archive.
+        population:
+            Current population. Not used by all implementations.
+        ctx:
+            Optimization context. Provides ``comparator``, ``problem.eps``,
+            etc. Required by ranking- and comparison-based implementations.
+        candidate_x:
+            Centre point for k-NN queries (shape ``(dim,)``). Passed by
+            ``LocalSurrogateManager`` for each candidate; ``None`` when called
+            from ``GlobalSurrogateManager``.
+
+        Returns
+        -------
+        TrainingData
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Regression defaults (backward-compatible)
+# ---------------------------------------------------------------------------
+
+
+class ArchiveObjectiveSet(TrainingSet):
+    """Use the entire archive as training data with raw objective values.
+
+    Default for ``GlobalSurrogateManager``.  Equivalent to the behaviour
+    before Issue #026.
+    """
+
+    def build(
+        self,
+        archive: Archive,
+        population: Population | None,
+        ctx: OptimizationContext | None,
+        candidate_x: np.ndarray | None = None,
+    ) -> TrainingData:
+        """Return all archive points with raw objective values."""
+        return TrainingData(train_x=archive.x, train_y=archive.f)
+
+
+class KNNObjectiveSet(TrainingSet):
+    """Retrieve the *k* nearest archive neighbours of ``candidate_x``.
+
+    Default for ``LocalSurrogateManager``.  Equivalent to the
+    ``n_neighbors``-based behaviour before Issue #026.
+
+    Parameters
+    ----------
+    n_neighbors:
+        Number of nearest neighbours to retrieve.
+    """
+
+    def __init__(self, n_neighbors: int = 50) -> None:
+        self.n_neighbors = n_neighbors
+
+    def build(
+        self,
+        archive: Archive,
+        population: Population | None,
+        ctx: OptimizationContext | None,
+        candidate_x: np.ndarray | None = None,
+    ) -> TrainingData:
+        """Return k nearest-neighbour archive points around ``candidate_x``."""
+        if candidate_x is None:
+            raise ValueError("KNNObjectiveSet requires candidate_x.")
+        idx, _ = archive.get_knn(candidate_x, self.n_neighbors)
+        return TrainingData(train_x=archive.x[idx], train_y=archive.f[idx])

--- a/src/saealib/surrogate/training_set.py
+++ b/src/saealib/surrogate/training_set.py
@@ -311,3 +311,98 @@ class LevelBasedSet(TrainingSet):
                 [labels, np.full(remainder, self.n_levels - 1)]
             )
         return TrainingData(train_x=x, train_y=labels.astype(float))
+
+
+# ---------------------------------------------------------------------------
+# Pairwise comparison
+# ---------------------------------------------------------------------------
+
+
+class PairwiseComparisonSet(TrainingSet):
+    """Pairwise labels: ``train_x`` is ``[x_a, x_b]``, label is 1 if *a* beats *b*.
+
+    For each pair ``(a, b)``, the feature vector is the concatenation
+    ``[x_a, x_b]`` (shape ``(n_pairs, 2 * dim)``), and the label is 1 if
+    ``comparator.compare(f_a, cv_a, f_b, cv_b) <= 0`` (a dominates or equals b),
+    0 otherwise.
+
+    .. warning::
+        ``train_x`` has shape ``(n_pairs, 2 * dim)``, which is incompatible with
+        standard regression surrogates (e.g. ``RBFsurrogate``).  Use a
+        pairwise-specific surrogate that expects concatenated feature pairs.
+
+    Parameters
+    ----------
+    source:
+        ``"archive"`` or ``"population"``.
+    n_pairs:
+        Number of pairs to sample.  ``None`` (default) uses all
+        ``n * (n-1) / 2`` pairs.  If the requested count exceeds the total
+        available pairs, all pairs are used.
+    rng:
+        Random number generator for pair sampling.  Falls back to
+        ``ctx.rng`` when ``ctx`` is provided, otherwise creates a new one.
+
+    Raises
+    ------
+    ValueError
+        If ``ctx`` is ``None`` (comparator required) or
+        ``source="population"`` with ``population=None``.
+    """
+
+    def __init__(
+        self,
+        source: str = "archive",
+        n_pairs: int | None = None,
+        rng: np.random.Generator | None = None,
+    ) -> None:
+        self.source = source
+        self.n_pairs = n_pairs
+        self.rng = rng
+
+    def build(
+        self,
+        archive: Archive,
+        population: Population | None,
+        ctx: OptimizationContext | None,
+        candidate_x: np.ndarray | None = None,
+    ) -> TrainingData:
+        """Return pairwise comparison training data."""
+        if ctx is None:
+            raise ValueError("PairwiseComparisonSet requires ctx.")
+        if self.source == "population":
+            if population is None:
+                raise ValueError(
+                    "PairwiseComparisonSet: source='population' requires population."
+                )
+            src = population
+        else:
+            src = archive
+        x = src.get_array("x")
+        f = src.get_array("f")
+        cv = src.get_array("cv")
+        cmp = ctx.comparator
+        rng = self.rng if self.rng is not None else ctx.rng
+        n = len(x)
+        n_all = n * (n - 1) // 2
+        if self.n_pairs is None or self.n_pairs >= n_all:
+            pairs = [(i, j) for i in range(n) for j in range(i + 1, n)]
+        else:
+            pairs: list[tuple[int, int]] = []
+            seen: set[tuple[int, int]] = set()
+            while len(pairs) < self.n_pairs:
+                idx = rng.choice(n, size=2, replace=False)
+                key = (int(min(idx[0], idx[1])), int(max(idx[0], idx[1])))
+                if key not in seen:
+                    seen.add(key)
+                    pairs.append(key)
+        train_x = np.stack(
+            [np.concatenate([x[i], x[j]]) for i, j in pairs]
+        )
+        train_y = np.array(
+            [
+                1.0 if cmp.compare(f[i], cv[i], f[j], cv[j]) <= 0 else 0.0
+                for i, j in pairs
+            ]
+        )
+        return TrainingData(train_x=train_x, train_y=train_y)

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -45,6 +45,7 @@ from saealib.surrogate.manager import (
     LocalSurrogateManager,
 )
 from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+from saealib.surrogate.training_set import KNNObjectiveSet
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -557,7 +558,9 @@ class TestPostSurrogateFitDispatch:
     ) -> None:
         prov = _MockProvider()
         manager = LocalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction(), n_neighbors=10
+            RBFsurrogate(gaussian_kernel, DIM),
+            MeanPrediction(),
+            training_set=KNNObjectiveSet(10),
         )
         manager.score_candidates(candidates, archive, provider=prov, ctx=ctx)
         fit_events = [
@@ -571,7 +574,9 @@ class TestPostSurrogateFitDispatch:
         candidates: np.ndarray,
     ) -> None:
         manager = LocalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction(), n_neighbors=10
+            RBFsurrogate(gaussian_kernel, DIM),
+            MeanPrediction(),
+            training_set=KNNObjectiveSet(10),
         )
         scores, _ = manager.score_candidates(candidates, archive)
         assert scores.shape == (len(candidates),)
@@ -587,7 +592,7 @@ class TestPostSurrogateFitDispatch:
         manager = LocalSurrogateManager(
             RBFsurrogate(gaussian_kernel, DIM),
             MeanPrediction(),
-            n_neighbors=n_neighbors,
+            training_set=KNNObjectiveSet(n_neighbors),
         )
         manager.score_candidates(candidates, archive, provider=prov, ctx=ctx)
         fit_events = [

--- a/tests/test_surrogate_manager.py
+++ b/tests/test_surrogate_manager.py
@@ -23,6 +23,7 @@ from saealib.surrogate.manager import (
 )
 from saealib.surrogate.prediction import SurrogatePrediction
 from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+from saealib.surrogate.training_set import KNNObjectiveSet
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -273,7 +274,7 @@ class TestLocalSurrogateManager:
         candidates: np.ndarray,
     ) -> None:
         manager = LocalSurrogateManager(
-            surrogate_1obj, MeanPrediction(), n_neighbors=10
+            surrogate_1obj, MeanPrediction(), training_set=KNNObjectiveSet(10)
         )
         result = manager.score_candidates(candidates, archive_1obj)
         assert isinstance(result, tuple) and len(result) == 2
@@ -285,7 +286,7 @@ class TestLocalSurrogateManager:
         candidates: np.ndarray,
     ) -> None:
         manager = LocalSurrogateManager(
-            surrogate_1obj, MeanPrediction(), n_neighbors=10
+            surrogate_1obj, MeanPrediction(), training_set=KNNObjectiveSet(10)
         )
         scores, _ = manager.score_candidates(candidates, archive_1obj)
         assert scores.shape == (len(candidates),)
@@ -297,7 +298,7 @@ class TestLocalSurrogateManager:
         candidates: np.ndarray,
     ) -> None:
         manager = LocalSurrogateManager(
-            surrogate_1obj, MeanPrediction(), n_neighbors=10
+            surrogate_1obj, MeanPrediction(), training_set=KNNObjectiveSet(10)
         )
         _, predictions = manager.score_candidates(candidates, archive_1obj)
         assert len(predictions) == len(candidates)
@@ -309,7 +310,7 @@ class TestLocalSurrogateManager:
         candidates: np.ndarray,
     ) -> None:
         manager = LocalSurrogateManager(
-            surrogate_1obj, MeanPrediction(), n_neighbors=10
+            surrogate_1obj, MeanPrediction(), training_set=KNNObjectiveSet(10)
         )
         _, predictions = manager.score_candidates(candidates, archive_1obj)
         for p in predictions:
@@ -321,9 +322,10 @@ class TestLocalSurrogateManager:
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
-        """Default n_neighbors=50 is clamped to archive size."""
+        """Default training_set is KNNObjectiveSet(50), clamped to archive size."""
         manager = LocalSurrogateManager(surrogate_1obj, MeanPrediction())
-        assert manager.n_neighbors == 50
+        assert isinstance(manager.training_set, KNNObjectiveSet)
+        assert manager.training_set.n_neighbors == 50
         # archive has only 20 points, get_knn should still work
         scores, _ = manager.score_candidates(candidates, archive_1obj)
         assert scores.shape == (len(candidates),)
@@ -335,7 +337,7 @@ class TestLocalSurrogateManager:
         candidates: np.ndarray,
     ) -> None:
         manager = LocalSurrogateManager(
-            surrogate_1obj, MeanPrediction(), n_neighbors=10
+            surrogate_1obj, MeanPrediction(), training_set=KNNObjectiveSet(10)
         )
         scores, _ = manager.score_candidates(candidates, archive_1obj)
         assert np.all(np.isfinite(scores))

--- a/tests/test_training_set.py
+++ b/tests/test_training_set.py
@@ -13,6 +13,8 @@ from saealib.surrogate.training_set import (
     ArchiveObjectiveSet,
     FeasibilityClassificationSet,
     KNNObjectiveSet,
+    LevelBasedSet,
+    TopKBipartitionSet,
     TrainingSet,
 )
 
@@ -222,4 +224,155 @@ class TestFeasibilityClassificationSet:
         arc = _make_archive_with_cv([0.0, 1.0])
         ts = FeasibilityClassificationSet(source="archive")
         data = ts.build(arc, None, None)
+        assert data.train_y.dtype == float
+
+
+# ===========================================================================
+# TopKBipartitionSet
+# ===========================================================================
+
+
+def _make_archive_with_f(
+    f_values: list[float], cvs: list[float] | None = None
+) -> Archive:
+    """Archive where each point has a prescribed scalar objective."""
+    if cvs is None:
+        cvs = [0.0] * len(f_values)
+    arc = Archive(_ATTRS, init_capacity=len(f_values) + 5)
+    rng = np.random.default_rng(2)
+    for fv, cv in zip(f_values, cvs):
+        x = rng.uniform(-2.0, 2.0, size=DIM)
+        arc.add(x=x, f=np.array([fv]), cv=float(cv))
+    return arc
+
+
+class TestTopKBipartitionSet:
+    def test_label_count(self) -> None:
+        arc = _make_archive_with_f([1.0, 2.0, 3.0, 4.0])
+        ctx = _make_ctx(archive=arc)
+        ts = TopKBipartitionSet(source="archive", top_ratio=0.5)
+        data = ts.build(arc, None, ctx)
+        assert data.train_y.shape == (4,)
+        assert int(data.train_y.sum()) == 2  # top 2 = label 1
+
+    def test_best_get_label_one(self) -> None:
+        """After sorting best-first, the first k entries should be label 1."""
+        # f=1.0 is best (minimization), f=4.0 is worst
+        arc = _make_archive_with_f([4.0, 1.0, 3.0, 2.0])
+        ctx = _make_ctx(archive=arc)
+        ts = TopKBipartitionSet(source="archive", top_ratio=0.5)
+        data = ts.build(arc, None, ctx)
+        # sorted order: f=1.0, f=2.0 → label 1; f=3.0, f=4.0 → label 0
+        np.testing.assert_array_equal(data.train_y[:2], [1.0, 1.0])
+        np.testing.assert_array_equal(data.train_y[2:], [0.0, 0.0])
+
+    def test_at_least_one_label_one(self) -> None:
+        """top_ratio=0 should still yield at least one label 1."""
+        arc = _make_archive_with_f([1.0, 2.0, 3.0])
+        ctx = _make_ctx(archive=arc)
+        ts = TopKBipartitionSet(source="archive", top_ratio=0.0)
+        data = ts.build(arc, None, ctx)
+        assert data.train_y.sum() >= 1.0
+
+    def test_ctx_none_raises(self) -> None:
+        arc = _make_archive_with_f([1.0, 2.0])
+        ts = TopKBipartitionSet(source="archive")
+        with pytest.raises(ValueError, match="ctx"):
+            ts.build(arc, None, None)
+
+    def test_source_population_none_raises(self) -> None:
+        arc = _make_archive_with_f([1.0, 2.0])
+        ctx = _make_ctx(archive=arc)
+        ts = TopKBipartitionSet(source="population")
+        with pytest.raises(ValueError, match="population"):
+            ts.build(arc, None, ctx)
+
+    def test_source_population(self) -> None:
+        pop = _make_population_with_cv([0.0, 0.0, 0.0, 0.0])
+        arc = _make_archive()
+        ctx = _make_ctx(archive=arc, population=pop)
+        ts = TopKBipartitionSet(source="population", top_ratio=0.5)
+        data = ts.build(arc, pop, ctx)
+        assert data.train_x.shape == (4, DIM)
+        assert data.train_y.shape == (4,)
+
+    def test_train_x_shape(self) -> None:
+        arc = _make_archive_with_f([1.0, 2.0, 3.0])
+        ctx = _make_ctx(archive=arc)
+        ts = TopKBipartitionSet(source="archive")
+        data = ts.build(arc, None, ctx)
+        assert data.train_x.shape == (3, DIM)
+
+    def test_labels_are_float(self) -> None:
+        arc = _make_archive_with_f([1.0, 2.0])
+        ctx = _make_ctx(archive=arc)
+        ts = TopKBipartitionSet(source="archive")
+        data = ts.build(arc, None, ctx)
+        assert data.train_y.dtype == float
+
+
+# ===========================================================================
+# LevelBasedSet
+# ===========================================================================
+
+
+class TestLevelBasedSet:
+    def test_three_levels_equal_split(self) -> None:
+        """6 individuals, 3 levels → 2 per level, labels [0,0,1,1,2,2]."""
+        arc = _make_archive_with_f([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        ctx = _make_ctx(archive=arc)
+        ts = LevelBasedSet(source="archive", n_levels=3)
+        data = ts.build(arc, None, ctx)
+        np.testing.assert_array_equal(data.train_y, [0.0, 0.0, 1.0, 1.0, 2.0, 2.0])
+
+    def test_remainder_goes_to_last_level(self) -> None:
+        """7 individuals, 3 levels → per=2; labels [0,0,1,1,2,2,2]."""
+        arc = _make_archive_with_f([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+        ctx = _make_ctx(archive=arc)
+        ts = LevelBasedSet(source="archive", n_levels=3)
+        data = ts.build(arc, None, ctx)
+        np.testing.assert_array_equal(
+            data.train_y, [0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 2.0]
+        )
+
+    def test_best_individuals_get_level_zero(self) -> None:
+        """Level 0 corresponds to best-sorted (smallest f for minimization)."""
+        arc = _make_archive_with_f([5.0, 1.0, 3.0, 2.0])
+        ctx = _make_ctx(archive=arc)
+        ts = LevelBasedSet(source="archive", n_levels=2)
+        data = ts.build(arc, None, ctx)
+        # sorted order: f=1.0, f=2.0 → level 0; f=3.0, f=5.0 → level 1
+        np.testing.assert_array_equal(data.train_y[:2], [0.0, 0.0])
+        np.testing.assert_array_equal(data.train_y[2:], [1.0, 1.0])
+
+    def test_default_n_levels(self) -> None:
+        ts = LevelBasedSet()
+        assert ts.n_levels == 5
+
+    def test_ctx_none_raises(self) -> None:
+        arc = _make_archive_with_f([1.0, 2.0])
+        ts = LevelBasedSet(source="archive")
+        with pytest.raises(ValueError, match="ctx"):
+            ts.build(arc, None, None)
+
+    def test_source_population_none_raises(self) -> None:
+        arc = _make_archive_with_f([1.0, 2.0])
+        ctx = _make_ctx(archive=arc)
+        ts = LevelBasedSet(source="population")
+        with pytest.raises(ValueError, match="population"):
+            ts.build(arc, None, ctx)
+
+    def test_train_x_shape(self) -> None:
+        arc = _make_archive_with_f([1.0, 2.0, 3.0, 4.0, 5.0])
+        ctx = _make_ctx(archive=arc)
+        ts = LevelBasedSet(source="archive", n_levels=5)
+        data = ts.build(arc, None, ctx)
+        assert data.train_x.shape == (5, DIM)
+        assert data.train_y.shape == (5,)
+
+    def test_labels_are_float(self) -> None:
+        arc = _make_archive_with_f([1.0, 2.0, 3.0])
+        ctx = _make_ctx(archive=arc)
+        ts = LevelBasedSet(source="archive", n_levels=3)
+        data = ts.build(arc, None, ctx)
         assert data.train_y.dtype == float

--- a/tests/test_training_set.py
+++ b/tests/test_training_set.py
@@ -14,6 +14,7 @@ from saealib.surrogate.training_set import (
     FeasibilityClassificationSet,
     KNNObjectiveSet,
     LevelBasedSet,
+    PairwiseComparisonSet,
     TopKBipartitionSet,
     TrainingSet,
 )
@@ -376,3 +377,94 @@ class TestLevelBasedSet:
         ts = LevelBasedSet(source="archive", n_levels=3)
         data = ts.build(arc, None, ctx)
         assert data.train_y.dtype == float
+
+
+# ===========================================================================
+# PairwiseComparisonSet
+# ===========================================================================
+
+
+class TestPairwiseComparisonSet:
+    def test_all_pairs_by_default(self) -> None:
+        """n_pairs=None → all n*(n-1)/2 pairs generated."""
+        arc = _make_archive_with_f([1.0, 2.0, 3.0, 4.0])
+        ctx = _make_ctx(archive=arc)
+        ts = PairwiseComparisonSet(source="archive")
+        data = ts.build(arc, None, ctx)
+        n = 4
+        assert data.train_x.shape == (n * (n - 1) // 2, DIM * 2)
+        assert data.train_y.shape == (n * (n - 1) // 2,)
+
+    def test_n_pairs_limits_count(self) -> None:
+        arc = _make_archive_with_f([1.0, 2.0, 3.0, 4.0, 5.0])
+        ctx = _make_ctx(archive=arc)
+        ts = PairwiseComparisonSet(source="archive", n_pairs=3)
+        data = ts.build(arc, None, ctx)
+        assert data.train_x.shape == (3, DIM * 2)
+        assert data.train_y.shape == (3,)
+
+    def test_n_pairs_exceeds_total_uses_all(self) -> None:
+        """n_pairs >= n*(n-1)/2 → all pairs used."""
+        arc = _make_archive_with_f([1.0, 2.0, 3.0])
+        ctx = _make_ctx(archive=arc)
+        ts = PairwiseComparisonSet(source="archive", n_pairs=999)
+        data = ts.build(arc, None, ctx)
+        assert data.train_x.shape == (3, DIM * 2)  # 3*(3-1)/2 = 3
+
+    def test_train_x_shape_is_2_dim(self) -> None:
+        arc = _make_archive_with_f([1.0, 2.0, 3.0])
+        ctx = _make_ctx(archive=arc)
+        ts = PairwiseComparisonSet(source="archive")
+        data = ts.build(arc, None, ctx)
+        assert data.train_x.shape[1] == DIM * 2
+
+    def test_label_ordering_best_vs_worst(self) -> None:
+        """For a pair (best, worst), label should be 1 (best wins)."""
+        arc = _make_archive_with_f([1.0, 10.0])  # idx 0 = best, idx 1 = worst
+        ctx = _make_ctx(archive=arc)
+        ts = PairwiseComparisonSet(source="archive")
+        data = ts.build(arc, None, ctx)
+        # Only one pair (0, 1): f=1.0 beats f=10.0 → label 1
+        assert data.train_y[0] == pytest.approx(1.0)
+
+    def test_labels_are_binary(self) -> None:
+        arc = _make_archive_with_f([1.0, 2.0, 3.0, 4.0])
+        ctx = _make_ctx(archive=arc)
+        ts = PairwiseComparisonSet(source="archive")
+        data = ts.build(arc, None, ctx)
+        assert set(data.train_y.tolist()).issubset({0.0, 1.0})
+
+    def test_ctx_none_raises(self) -> None:
+        arc = _make_archive_with_f([1.0, 2.0])
+        ts = PairwiseComparisonSet(source="archive")
+        with pytest.raises(ValueError, match="ctx"):
+            ts.build(arc, None, None)
+
+    def test_source_population_none_raises(self) -> None:
+        arc = _make_archive_with_f([1.0, 2.0])
+        ctx = _make_ctx(archive=arc)
+        ts = PairwiseComparisonSet(source="population")
+        with pytest.raises(ValueError, match="population"):
+            ts.build(arc, None, ctx)
+
+    def test_custom_rng(self) -> None:
+        """Custom rng produces reproducible sampling."""
+        arc = _make_archive_with_f([1.0, 2.0, 3.0, 4.0, 5.0])
+        ctx = _make_ctx(archive=arc)
+        rng1 = np.random.default_rng(99)
+        rng2 = np.random.default_rng(99)
+        ts1 = PairwiseComparisonSet(source="archive", n_pairs=4, rng=rng1)
+        ts2 = PairwiseComparisonSet(source="archive", n_pairs=4, rng=rng2)
+        d1 = ts1.build(arc, None, ctx)
+        d2 = ts2.build(arc, None, ctx)
+        np.testing.assert_array_equal(d1.train_x, d2.train_x)
+        np.testing.assert_array_equal(d1.train_y, d2.train_y)
+
+    def test_no_duplicate_pairs(self) -> None:
+        """Each (i, j) pair appears at most once."""
+        arc = _make_archive_with_f([1.0, 2.0, 3.0, 4.0, 5.0])
+        ctx = _make_ctx(archive=arc)
+        ts = PairwiseComparisonSet(source="archive", n_pairs=8)
+        data = ts.build(arc, None, ctx)
+        # Each row in train_x is unique (half-vector x_a or full [x_a, x_b])
+        assert len(data.train_x) == len(np.unique(data.train_x, axis=0))

--- a/tests/test_training_set.py
+++ b/tests/test_training_set.py
@@ -1,0 +1,225 @@
+"""Tests for surrogate training set strategy objects."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from saealib.comparators import SingleObjectiveComparator
+from saealib.context import OptimizationContext
+from saealib.population import Archive, Population, PopulationAttribute
+from saealib.problem import Problem
+from saealib.surrogate.training_set import (
+    ArchiveObjectiveSet,
+    FeasibilityClassificationSet,
+    KNNObjectiveSet,
+    TrainingSet,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+DIM = 2
+N_OBJ = 1
+
+_ATTRS = [
+    PopulationAttribute(name="x", dtype=np.float64, shape=(DIM,)),
+    PopulationAttribute(name="f", dtype=np.float64, shape=(N_OBJ,)),
+    PopulationAttribute(name="g", dtype=np.float64, shape=(0,)),
+    PopulationAttribute(name="cv", dtype=np.float64, shape=()),
+]
+
+
+def _make_problem(eps: float = 1e-6) -> Problem:
+    return Problem(
+        func=lambda x: np.array([np.sum(x**2)]),
+        dim=DIM,
+        n_obj=N_OBJ,
+        weight=np.array([-1.0]),
+        lb=[-5.0] * DIM,
+        ub=[5.0] * DIM,
+        eps=eps,
+        comparator=SingleObjectiveComparator(),
+    )
+
+
+def _make_archive(n: int = 10) -> Archive:
+    arc = Archive(_ATTRS, init_capacity=n + 5)
+    rng = np.random.default_rng(42)
+    for _ in range(n):
+        x = rng.uniform(-2.0, 2.0, size=DIM)
+        f = np.array([np.sum(x**2)])
+        arc.add(x=x, f=f, cv=0.0)
+    return arc
+
+
+def _make_archive_with_cv(cvs: list[float]) -> Archive:
+    """Archive where each point has a prescribed cv value."""
+    arc = Archive(_ATTRS, init_capacity=len(cvs) + 5)
+    rng = np.random.default_rng(0)
+    for cv in cvs:
+        x = rng.uniform(-2.0, 2.0, size=DIM)
+        f = np.array([np.sum(x**2)])
+        arc.add(x=x, f=f, cv=float(cv))
+    return arc
+
+
+def _make_population_with_cv(cvs: list[float]) -> Population:
+    """Population where each individual has a prescribed cv value."""
+    pop = Population(_ATTRS, init_capacity=len(cvs) + 5)
+    rng = np.random.default_rng(1)
+    xs = rng.uniform(-2.0, 2.0, size=(len(cvs), DIM))
+    fs = np.array([[np.sum(x**2)] for x in xs])
+    cv_arr = np.array(cvs, dtype=float)
+    pop.extend({"x": xs, "f": fs, "cv": cv_arr})
+    return pop
+
+
+def _make_ctx(
+    archive: Archive | None = None,
+    population: Population | None = None,
+    eps: float = 1e-6,
+) -> OptimizationContext:
+    problem = _make_problem(eps=eps)
+    arc = archive if archive is not None else _make_archive()
+    pop = population if population is not None else _make_population_with_cv([0.0] * 5)
+    return OptimizationContext(
+        problem=problem,
+        population=pop,
+        archive=arc,
+        rng=np.random.default_rng(0),
+        fe=10,
+        gen=1,
+    )
+
+
+# ===========================================================================
+# TrainingSet ABC
+# ===========================================================================
+class TestTrainingSetABC:
+    def test_cannot_instantiate_abstract(self) -> None:
+        with pytest.raises(TypeError):
+            TrainingSet()  # type: ignore[abstract]
+
+
+# ===========================================================================
+# ArchiveObjectiveSet
+# ===========================================================================
+class TestArchiveObjectiveSet:
+    def test_returns_all_archive_points(self) -> None:
+        arc = _make_archive(10)
+        ts = ArchiveObjectiveSet()
+        data = ts.build(arc, None, None)
+        assert data.train_x.shape == (10, DIM)
+        assert data.train_y.shape == (10, N_OBJ)
+
+    def test_values_match_archive(self) -> None:
+        arc = _make_archive(8)
+        ts = ArchiveObjectiveSet()
+        data = ts.build(arc, None, None)
+        np.testing.assert_array_equal(data.train_x, arc.x)
+        np.testing.assert_array_equal(data.train_y, arc.f)
+
+    def test_candidate_x_ignored(self) -> None:
+        arc = _make_archive(5)
+        ts = ArchiveObjectiveSet()
+        cand = np.zeros(DIM)
+        data = ts.build(arc, None, None, candidate_x=cand)
+        assert data.train_x.shape == (5, DIM)
+
+
+# ===========================================================================
+# KNNObjectiveSet
+# ===========================================================================
+class TestKNNObjectiveSet:
+    def test_returns_k_neighbours(self) -> None:
+        arc = _make_archive(20)
+        ts = KNNObjectiveSet(n_neighbors=5)
+        cand = np.zeros(DIM)
+        data = ts.build(arc, None, None, candidate_x=cand)
+        assert data.train_x.shape == (5, DIM)
+        assert data.train_y.shape == (5, N_OBJ)
+
+    def test_requires_candidate_x(self) -> None:
+        arc = _make_archive(10)
+        ts = KNNObjectiveSet(n_neighbors=5)
+        with pytest.raises(ValueError, match="requires candidate_x"):
+            ts.build(arc, None, None, candidate_x=None)
+
+    def test_default_n_neighbors(self) -> None:
+        ts = KNNObjectiveSet()
+        assert ts.n_neighbors == 50
+
+    def test_clamped_to_archive_size(self) -> None:
+        arc = _make_archive(8)
+        ts = KNNObjectiveSet(n_neighbors=50)
+        cand = np.zeros(DIM)
+        data = ts.build(arc, None, None, candidate_x=cand)
+        assert data.train_x.shape[0] <= 8
+
+
+# ===========================================================================
+# FeasibilityClassificationSet
+# ===========================================================================
+class TestFeasibilityClassificationSet:
+    def test_all_feasible(self) -> None:
+        arc = _make_archive_with_cv([0.0, 0.0, 0.0, 0.0])
+        ts = FeasibilityClassificationSet(source="archive")
+        data = ts.build(arc, None, None)
+        np.testing.assert_array_equal(data.train_y, np.ones(4))
+
+    def test_all_infeasible(self) -> None:
+        arc = _make_archive_with_cv([1.0, 2.0, 0.5])
+        ts = FeasibilityClassificationSet(source="archive")
+        data = ts.build(arc, None, None)
+        np.testing.assert_array_equal(data.train_y, np.zeros(3))
+
+    def test_mixed_labels(self) -> None:
+        arc = _make_archive_with_cv([0.0, 1.0, 0.0, 2.0])
+        ts = FeasibilityClassificationSet(source="archive")
+        data = ts.build(arc, None, None)
+        np.testing.assert_array_equal(data.train_y, [1.0, 0.0, 1.0, 0.0])
+
+    def test_eps_from_ctx(self) -> None:
+        """Boundary value: cv == eps is feasible."""
+        arc = _make_archive_with_cv([0.1, 0.2, 0.3])
+        ctx = _make_ctx(archive=arc, eps=0.15)
+        ts = FeasibilityClassificationSet(source="archive")
+        data = ts.build(arc, None, ctx)
+        # cv=0.1 <= 0.15 → 1, cv=0.2 > 0.15 → 0, cv=0.3 > 0.15 → 0
+        np.testing.assert_array_equal(data.train_y, [1.0, 0.0, 0.0])
+
+    def test_eps_default_when_ctx_none(self) -> None:
+        """Without ctx, eps defaults to 1e-6."""
+        arc = _make_archive_with_cv([0.0, 1e-7, 1e-5])
+        ts = FeasibilityClassificationSet(source="archive")
+        data = ts.build(arc, None, None)
+        # 0.0 <= 1e-6 → 1, 1e-7 <= 1e-6 → 1, 1e-5 > 1e-6 → 0
+        np.testing.assert_array_equal(data.train_y, [1.0, 1.0, 0.0])
+
+    def test_source_population(self) -> None:
+        pop = _make_population_with_cv([0.0, 0.5, 0.0])
+        arc = _make_archive()
+        ts = FeasibilityClassificationSet(source="population")
+        data = ts.build(arc, pop, None)
+        np.testing.assert_array_equal(data.train_y, [1.0, 0.0, 1.0])
+
+    def test_source_population_none_raises(self) -> None:
+        arc = _make_archive()
+        ts = FeasibilityClassificationSet(source="population")
+        with pytest.raises(ValueError, match="population"):
+            ts.build(arc, None, None)
+
+    def test_train_x_shape(self) -> None:
+        arc = _make_archive_with_cv([0.0, 1.0, 0.0])
+        ts = FeasibilityClassificationSet(source="archive")
+        data = ts.build(arc, None, None)
+        assert data.train_x.shape == (3, DIM)
+        assert data.train_y.shape == (3,)
+
+    def test_labels_are_float(self) -> None:
+        arc = _make_archive_with_cv([0.0, 1.0])
+        ts = FeasibilityClassificationSet(source="archive")
+        data = ts.build(arc, None, None)
+        assert data.train_y.dtype == float

--- a/tests/test_training_set.py
+++ b/tests/test_training_set.py
@@ -332,9 +332,7 @@ class TestLevelBasedSet:
         ctx = _make_ctx(archive=arc)
         ts = LevelBasedSet(source="archive", n_levels=3)
         data = ts.build(arc, None, ctx)
-        np.testing.assert_array_equal(
-            data.train_y, [0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 2.0]
-        )
+        np.testing.assert_array_equal(data.train_y, [0.0, 0.0, 1.0, 1.0, 2.0, 2.0, 2.0])
 
     def test_best_individuals_get_level_zero(self) -> None:
         """Level 0 corresponds to best-sorted (smallest f for minimization)."""


### PR DESCRIPTION
  ## Related Issue

  Closes #67

  ## Overview

  Introduce TrainingSet as a strategy object for constructing (train_x, train_y) pairs passed to Surrogate.fit,
   and add four labelling strategies covering literature patterns P1–P3.

  Previously, training data construction was embedded in SurrogateManager with no abstraction. This refactor
  decouples the labelling logic and makes it easy to swap strategies without modifying the manager.

 ## Changes

  - Add TrainingData dataclass as an immutable container for (train_x, train_y)
  - Refactor TrainingSet into an abstract strategy base class; update LocalSurrogateManager,
  GlobalSurrogateManager, api.py, and optimizer.py accordingly
  - Add FeasibilityClassificationSet: binary labels from constraint violation (cv <= eps)
  - Add TopKBipartitionSet: bipartition labels where the top k individuals (by comparator ranking) receive
  label 1 (literature P2: CPS-MOEA)
  - Add LevelBasedSet: multi-class labels from equal-division of a sorted population (literature P1: CA-LLSO)
  - Add PairwiseComparisonSet: pairwise comparison labels with concatenated feature pairs [x_a, x_b]
  (literature P3: Pairwise SAEA)
  - Add unit tests for all new classes in tests/test_training_set.py

 ## Verification Steps

  uv run pytest tests/test_training_set.py -v
  uv run pytest tests/test_surrogate_manager.py tests/test_callback.py -v

 ## Concerns

  - PairwiseComparisonSet produces train_x of shape (n_pairs, 2 * dim), which is incompatible with standard
  regression surrogates (e.g. RBFsurrogate). A pairwise-specific surrogate must be used alongside it.
  - All ranking/comparison strategies require ctx to be non-None at call time; passing ctx=None raises
  ValueError.