### PR TITLE
Dev issue#69

### DIFF
--- a/src/saealib/acquisition/ei.py
+++ b/src/saealib/acquisition/ei.py
@@ -81,7 +81,7 @@ class ExpectedImprovement(AcquisitionFunction):
                 "ExpectedImprovement requires a surrogate with uncertainty "
                 "estimates (prediction.std must not be None)."
             )
-        mu = prediction.mean[:, self.obj_idx]  # (n_samples,)
+        mu = prediction.value[:, self.obj_idx]  # (n_samples,)
         sigma = prediction.std[:, self.obj_idx]  # (n_samples,)
 
         ref = np.asarray(reference, dtype=float)

--- a/src/saealib/acquisition/lcb.py
+++ b/src/saealib/acquisition/lcb.py
@@ -77,6 +77,6 @@ class LowerConfidenceBound(AcquisitionFunction):
                 "LowerConfidenceBound requires a surrogate with uncertainty "
                 "estimates (prediction.std must not be None)."
             )
-        mu = prediction.mean[:, self.obj_idx]  # (n_samples,)
+        mu = prediction.value[:, self.obj_idx]  # (n_samples,)
         sigma = prediction.std[:, self.obj_idx]  # (n_samples,)
         return -(mu - self.kappa * sigma)  # negate: higher = better

--- a/src/saealib/acquisition/mean.py
+++ b/src/saealib/acquisition/mean.py
@@ -52,7 +52,7 @@ class MeanPrediction(AcquisitionFunction):
         Parameters
         ----------
         prediction : SurrogatePrediction
-            Surrogate predictions. prediction.mean shape: (n_samples, n_obj)
+            Surrogate predictions. prediction.value shape: (n_samples, n_obj)
         reference : Any
             Not used. Accepted for interface compatibility.
 
@@ -61,7 +61,7 @@ class MeanPrediction(AcquisitionFunction):
         np.ndarray
             Scores. shape: (n_samples,)
         """
-        m = prediction.mean  # (n_samples, n_obj)
+        m = prediction.value  # (n_samples, n_obj)
         if self.weights is not None:
             return m @ np.asarray(self.weights)  # (n_samples,)
         return m[:, 0]  # single-objective default

--- a/src/saealib/acquisition/pof.py
+++ b/src/saealib/acquisition/pof.py
@@ -74,7 +74,7 @@ class ProbabilityOfFeasibility(AcquisitionFunction):
                 "ProbabilityOfFeasibility requires a surrogate with uncertainty "
                 "estimates (prediction.std must not be None)."
             )
-        mu = prediction.mean[:, self.obj_idx]  # (n_samples,)
+        mu = prediction.value[:, self.obj_idx]  # (n_samples,)
         sigma = prediction.std[:, self.obj_idx]  # (n_samples,)
         sigma = np.maximum(sigma, 1e-9)
         return norm.cdf((0.0 - mu) / sigma)  # P(g(x) <= 0)

--- a/src/saealib/strategies/gb.py
+++ b/src/saealib/strategies/gb.py
@@ -50,7 +50,7 @@ class GenerationBasedStrategy(OptimizationStrategy):
                 offspring.x, ctx.archive, provider, ctx
             )
             for i, pred in enumerate(predictions):
-                offspring[i].f = pred.value[0]
+                offspring[i].f = pred.tell_f[0]
 
             provider.dispatch(
                 SurrogateEndEvent(ctx=ctx, provider=provider, offspring=offspring)

--- a/src/saealib/strategies/gb.py
+++ b/src/saealib/strategies/gb.py
@@ -50,7 +50,7 @@ class GenerationBasedStrategy(OptimizationStrategy):
                 offspring.x, ctx.archive, provider, ctx
             )
             for i, pred in enumerate(predictions):
-                offspring[i].f = pred.mean[0]
+                offspring[i].f = pred.value[0]
 
             provider.dispatch(
                 SurrogateEndEvent(ctx=ctx, provider=provider, offspring=offspring)

--- a/src/saealib/strategies/ib.py
+++ b/src/saealib/strategies/ib.py
@@ -59,7 +59,7 @@ class IndividualBasedStrategy(OptimizationStrategy):
             offspring.x, ctx.archive, provider, ctx
         )
         for i, pred in enumerate(predictions):
-            offspring[i].f = pred.value[0]  # assign predicted objectives (n_obj,)
+            offspring[i].f = pred.tell_f[0]  # assign predicted objectives (n_obj,)
 
         provider.dispatch(
             SurrogateEndEvent(ctx=ctx, provider=provider, offspring=offspring)

--- a/src/saealib/strategies/ib.py
+++ b/src/saealib/strategies/ib.py
@@ -59,7 +59,7 @@ class IndividualBasedStrategy(OptimizationStrategy):
             offspring.x, ctx.archive, provider, ctx
         )
         for i, pred in enumerate(predictions):
-            offspring[i].f = pred.mean[0]  # assign predicted objectives (n_obj,)
+            offspring[i].f = pred.value[0]  # assign predicted objectives (n_obj,)
 
         provider.dispatch(
             SurrogateEndEvent(ctx=ctx, provider=provider, offspring=offspring)

--- a/src/saealib/strategies/ps.py
+++ b/src/saealib/strategies/ps.py
@@ -56,7 +56,7 @@ class PreSelectionStrategy(OptimizationStrategy):
             candidates.x, ctx.archive, provider, ctx
         )
         for i, pred in enumerate(predictions):
-            candidates[i].f = pred.value[0]
+            candidates[i].f = pred.tell_f[0]
 
         provider.dispatch(
             SurrogateEndEvent(ctx=ctx, provider=provider, offspring=candidates)

--- a/src/saealib/strategies/ps.py
+++ b/src/saealib/strategies/ps.py
@@ -56,7 +56,7 @@ class PreSelectionStrategy(OptimizationStrategy):
             candidates.x, ctx.archive, provider, ctx
         )
         for i, pred in enumerate(predictions):
-            candidates[i].f = pred.mean[0]
+            candidates[i].f = pred.value[0]
 
         provider.dispatch(
             SurrogateEndEvent(ctx=ctx, provider=provider, offspring=candidates)

--- a/src/saealib/surrogate/base.py
+++ b/src/saealib/surrogate/base.py
@@ -42,7 +42,7 @@ class Surrogate(ABC):
         Returns
         -------
         SurrogatePrediction
-            prediction.mean shape: (n_samples, n_obj)
+            prediction.value shape: (n_samples, n_obj)
             prediction.std  shape: (n_samples, n_obj) or None
         """
         pass

--- a/src/saealib/surrogate/manager.py
+++ b/src/saealib/surrogate/manager.py
@@ -69,7 +69,7 @@ class SurrogateManager(ABC):
             Acquisition scores. shape: (n_candidates,). Higher is better.
         predictions : list[SurrogatePrediction]
             Surrogate predictions for each candidate.
-            predictions[i].mean shape: (1, n_obj)
+            predictions[i].value shape: (1, n_obj)
         """
         ...
 
@@ -272,7 +272,7 @@ class EnsembleSurrogateManager(SurrogateManager):
 
 def _split_prediction(prediction: SurrogatePrediction) -> list[SurrogatePrediction]:
     """Split a batch SurrogatePrediction into per-sample SurrogatePrediction objects."""
-    n = prediction.mean.shape[0]
+    n = prediction.value.shape[0]
     result = []
     for i in range(n):
         std_i = prediction.std[i : i + 1] if prediction.std is not None else None
@@ -280,7 +280,7 @@ def _split_prediction(prediction: SurrogatePrediction) -> list[SurrogatePredicti
         tell_f_i = prediction._tell_f[i : i + 1] if prediction._tell_f is not None else None
         result.append(
             SurrogatePrediction(
-                mean=prediction.mean[i : i + 1],
+                value=prediction.value[i : i + 1],
                 std=std_i,
                 label=label_i,
                 _tell_f=tell_f_i,

--- a/src/saealib/surrogate/manager.py
+++ b/src/saealib/surrogate/manager.py
@@ -277,7 +277,9 @@ def _split_prediction(prediction: SurrogatePrediction) -> list[SurrogatePredicti
     for i in range(n):
         std_i = prediction.std[i : i + 1] if prediction.std is not None else None
         label_i = prediction.label[i : i + 1] if prediction.label is not None else None
-        tell_f_i = prediction._tell_f[i : i + 1] if prediction._tell_f is not None else None
+        tell_f_i = (
+            prediction._tell_f[i : i + 1] if prediction._tell_f is not None else None
+        )
         result.append(
             SurrogatePrediction(
                 value=prediction.value[i : i + 1],

--- a/src/saealib/surrogate/manager.py
+++ b/src/saealib/surrogate/manager.py
@@ -277,11 +277,13 @@ def _split_prediction(prediction: SurrogatePrediction) -> list[SurrogatePredicti
     for i in range(n):
         std_i = prediction.std[i : i + 1] if prediction.std is not None else None
         label_i = prediction.label[i : i + 1] if prediction.label is not None else None
+        tell_f_i = prediction._tell_f[i : i + 1] if prediction._tell_f is not None else None
         result.append(
             SurrogatePrediction(
                 mean=prediction.mean[i : i + 1],
                 std=std_i,
                 label=label_i,
+                _tell_f=tell_f_i,
                 metadata=prediction.metadata,
             )
         )

--- a/src/saealib/surrogate/prediction.py
+++ b/src/saealib/surrogate/prediction.py
@@ -23,6 +23,12 @@ class SurrogatePrediction:
     label : np.ndarray or None
         Predicted class labels. shape: (n_samples,).
         None unless the surrogate is a classification model.
+    tell_f : np.ndarray
+        Values to assign to offspring.f before calling algorithm.tell().
+        Falls back to ``mean`` when no override is set (``_tell_f is None``).
+        Pass ``_tell_f=np.full(..., np.nan)`` to prevent pbest corruption
+        when the surrogate returns non-objective values (e.g., class
+        probabilities, novelty scores).
     metadata : dict
         Implementation-specific additional information
         (e.g., SHAP values, gradient estimates).
@@ -31,6 +37,7 @@ class SurrogatePrediction:
     mean: np.ndarray
     std: np.ndarray | None = None
     label: np.ndarray | None = None
+    _tell_f: np.ndarray | None = field(default=None)
     metadata: dict = field(default_factory=dict)
     # Values that are conventionally used should be implemented
     # as attributes rather than metadata.
@@ -44,3 +51,13 @@ class SurrogatePrediction:
     def has_label(self) -> bool:
         """Return True if classification labels are available."""
         return self.label is not None
+
+    @property
+    def tell_f(self) -> np.ndarray:
+        """Return the override array if set, otherwise fall back to mean."""
+        return self._tell_f if self._tell_f is not None else self.mean
+
+    @property
+    def has_tell_f(self) -> bool:
+        """Return True if a dedicated tell_f override is set."""
+        return self._tell_f is not None

--- a/src/saealib/surrogate/prediction.py
+++ b/src/saealib/surrogate/prediction.py
@@ -14,8 +14,8 @@ class SurrogatePrediction:
 
     Attributes
     ----------
-    mean : np.ndarray
-        Predicted mean values. shape: (n_samples, n_obj)
+    value : np.ndarray
+        Predicted values. shape: (n_samples, n_obj)
     std : np.ndarray or None
         Predicted standard deviations (uncertainty).
         shape: (n_samples, n_obj). None if the surrogate does not
@@ -34,7 +34,7 @@ class SurrogatePrediction:
         (e.g., SHAP values, gradient estimates).
     """
 
-    mean: np.ndarray
+    value: np.ndarray
     std: np.ndarray | None = None
     label: np.ndarray | None = None
     _tell_f: np.ndarray | None = field(default=None)
@@ -55,7 +55,7 @@ class SurrogatePrediction:
     @property
     def tell_f(self) -> np.ndarray:
         """Return the override array if set, otherwise fall back to mean."""
-        return self._tell_f if self._tell_f is not None else self.mean
+        return self._tell_f if self._tell_f is not None else self.value
 
     @property
     def has_tell_f(self) -> bool:

--- a/src/saealib/surrogate/rbf.py
+++ b/src/saealib/surrogate/rbf.py
@@ -168,9 +168,9 @@ class RBFsurrogate(Surrogate):
         Returns
         -------
         SurrogatePrediction
-            prediction.mean shape: (n_samples, n_obj)
+            prediction.value shape: (n_samples, n_obj)
             prediction.std  is None (RBF interpolation provides no uncertainty)
         """
         preds = [m.predict(test_x) for m in self._models]
-        mean = np.column_stack(preds)  # (n_samples, n_obj)
-        return SurrogatePrediction(mean=mean)
+        value = np.column_stack(preds)  # (n_samples, n_obj)
+        return SurrogatePrediction(value=value)

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -28,11 +28,11 @@ from saealib.surrogate.prediction import SurrogatePrediction
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-def _pred(mean, std=None):
+def _pred(value, std=None):
     """Build a SurrogatePrediction from plain arrays."""
-    m = np.asarray(mean, dtype=float)
+    m = np.asarray(value, dtype=float)
     s = np.asarray(std, dtype=float) if std is not None else None
-    return SurrogatePrediction(mean=m, std=s)
+    return SurrogatePrediction(value=m, std=s)
 
 
 # ===========================================================================
@@ -61,26 +61,26 @@ class TestMeanPrediction:
 
     def test_no_weights_returns_first_objective(self) -> None:
         """Without weights, returns prediction.mean[:, 0]."""
-        pred = _pred(mean=[[1.0, 5.0], [2.0, 6.0], [3.0, 7.0]])
+        pred = _pred(value=[[1.0, 5.0], [2.0, 6.0], [3.0, 7.0]])
         scores = MeanPrediction().score(pred, reference=None)
         np.testing.assert_array_equal(scores, [1.0, 2.0, 3.0])
 
     def test_with_weights_returns_dot_product(self) -> None:
         """With weights, returns mean @ weights."""
-        pred = _pred(mean=[[1.0, 2.0], [3.0, 4.0]])
+        pred = _pred(value=[[1.0, 2.0], [3.0, 4.0]])
         weights = np.array([-1.0, -1.0])
         scores = MeanPrediction(weights=weights).score(pred, reference=None)
         np.testing.assert_array_almost_equal(scores, [-3.0, -7.0])
 
     def test_output_shape(self) -> None:
         rng = np.random.default_rng(0)
-        pred = _pred(mean=rng.random((5, 2)))
+        pred = _pred(value=rng.random((5, 2)))
         scores = MeanPrediction().score(pred, reference=None)
         assert scores.shape == (5,)
 
     def test_output_shape_with_weights(self) -> None:
         rng = np.random.default_rng(0)
-        pred = _pred(mean=rng.random((7, 3)))
+        pred = _pred(value=rng.random((7, 3)))
         scores = MeanPrediction(weights=np.array([-1.0, -1.0, -1.0])).score(
             pred, reference=None
         )
@@ -88,19 +88,19 @@ class TestMeanPrediction:
 
     def test_reference_not_used(self) -> None:
         """reference parameter is accepted but ignored."""
-        pred = _pred(mean=[[2.0]])
+        pred = _pred(value=[[2.0]])
         s1 = MeanPrediction().score(pred, reference=None)
         s2 = MeanPrediction().score(pred, reference=np.array([99.0]))
         np.testing.assert_array_equal(s1, s2)
 
     def test_single_sample(self) -> None:
-        pred = _pred(mean=[[4.0]])
+        pred = _pred(value=[[4.0]])
         scores = MeanPrediction().score(pred, reference=None)
         assert scores.shape == (1,)
         assert scores[0] == pytest.approx(4.0)
 
     def test_single_objective_with_weight(self) -> None:
-        pred = _pred(mean=[[3.0]])
+        pred = _pred(value=[[3.0]])
         scores = MeanPrediction(weights=np.array([-1.0])).score(pred, reference=None)
         assert scores[0] == pytest.approx(-3.0)
 
@@ -114,7 +114,7 @@ class TestMaxUncertainty:
     def test_no_weights_returns_mean_std(self) -> None:
         """Without weights, returns std.mean(axis=1)."""
         pred = _pred(
-            mean=[[0.0, 0.0], [0.0, 0.0]],
+            value=[[0.0, 0.0], [0.0, 0.0]],
             std=[[1.0, 3.0], [2.0, 4.0]],
         )
         scores = MaxUncertainty().score(pred, reference=None)
@@ -122,7 +122,7 @@ class TestMaxUncertainty:
 
     def test_with_weights(self) -> None:
         pred = _pred(
-            mean=[[0.0, 0.0]],
+            value=[[0.0, 0.0]],
             std=[[1.0, 2.0]],
         )
         scores = MaxUncertainty(weights=np.array([1.0, 0.0])).score(
@@ -131,20 +131,20 @@ class TestMaxUncertainty:
         assert scores[0] == pytest.approx(1.0)
 
     def test_requires_uncertainty(self) -> None:
-        pred = _pred(mean=[[1.0, 2.0]])
+        pred = _pred(value=[[1.0, 2.0]])
         with pytest.raises(TypeError, match="uncertainty"):
             MaxUncertainty().score(pred, reference=None)
 
     def test_output_shape(self) -> None:
         pred = _pred(
-            mean=np.zeros((6, 2)),
+            value=np.zeros((6, 2)),
             std=np.ones((6, 2)),
         )
         scores = MaxUncertainty().score(pred, reference=None)
         assert scores.shape == (6,)
 
     def test_single_objective(self) -> None:
-        pred = _pred(mean=[[0.0]], std=[[0.5]])
+        pred = _pred(value=[[0.0]], std=[[0.5]])
         scores = MaxUncertainty().score(pred, reference=None)
         assert scores[0] == pytest.approx(0.5)
 
@@ -156,12 +156,12 @@ class TestExpectedImprovement:
     """Tests for ExpectedImprovement acquisition function."""
 
     def test_requires_uncertainty(self) -> None:
-        pred = _pred(mean=[[1.0]])
+        pred = _pred(value=[[1.0]])
         with pytest.raises(TypeError, match="uncertainty"):
             ExpectedImprovement().score(pred, reference=1.0)
 
     def test_output_shape(self) -> None:
-        pred = _pred(mean=np.zeros((5, 1)), std=np.ones((5, 1)))
+        pred = _pred(value=np.zeros((5, 1)), std=np.ones((5, 1)))
         scores = ExpectedImprovement().score(pred, reference=0.0)
         assert scores.shape == (5,)
 
@@ -170,7 +170,7 @@ class TestExpectedImprovement:
         rng = np.random.default_rng(0)
         mean = rng.standard_normal((20, 1))
         std = np.abs(rng.standard_normal((20, 1))) + 0.1
-        pred = _pred(mean=mean, std=std)
+        pred = _pred(value=mean, std=std)
         scores = ExpectedImprovement().score(pred, reference=0.0)
         assert np.all(scores >= 0.0)
 
@@ -178,7 +178,7 @@ class TestExpectedImprovement:
         """Candidate with lower mean scores higher EI."""
         # reference best = 2.0; mean=1.5 should score higher than mean=3.0
         pred = _pred(
-            mean=[[3.0], [1.5]],
+            value=[[3.0], [1.5]],
             std=[[0.5], [0.5]],
         )
         scores = ExpectedImprovement(xi=0.0).score(pred, reference=2.0)
@@ -186,7 +186,7 @@ class TestExpectedImprovement:
 
     def test_ei_zero_for_worse_candidate(self) -> None:
         """EI is clipped to 0 when mu >> f_best."""
-        pred = _pred(mean=[[100.0]], std=[[0.001]])
+        pred = _pred(value=[[100.0]], std=[[0.001]])
         scores = ExpectedImprovement(xi=0.0).score(pred, reference=1.0)
         assert scores[0] == pytest.approx(0.0, abs=1e-6)
 
@@ -195,14 +195,14 @@ class TestExpectedImprovement:
         mu, sigma, f_best, xi = 1.0, 0.5, 2.0, 0.01
         z = (f_best - mu - xi) / sigma
         expected = (f_best - mu - xi) * norm.cdf(z) + sigma * norm.pdf(z)
-        pred = _pred(mean=[[mu]], std=[[sigma]])
+        pred = _pred(value=[[mu]], std=[[sigma]])
         scores = ExpectedImprovement(xi=xi).score(pred, reference=f_best)
         assert scores[0] == pytest.approx(max(expected, 0.0), rel=1e-5)
 
     def test_ei_obj_idx(self) -> None:
         """obj_idx selects which objective to compute EI for."""
         pred = _pred(
-            mean=[[10.0, 1.0]],
+            value=[[10.0, 1.0]],
             std=[[0.5, 0.5]],
         )
         score_obj0 = ExpectedImprovement(obj_idx=0).score(
@@ -216,7 +216,7 @@ class TestExpectedImprovement:
 
     def test_ei_xi_increases_exploration(self) -> None:
         """Higher xi shifts Z down, generally reducing score near f_best."""
-        pred = _pred(mean=[[1.9]], std=[[0.1]])
+        pred = _pred(value=[[1.9]], std=[[0.1]])
         score_low_xi = ExpectedImprovement(xi=0.0).score(pred, reference=2.0)
         score_high_xi = ExpectedImprovement(xi=1.0).score(pred, reference=2.0)
         # xi=1.0 makes z=(2.0-1.9-1.0)/0.1 negative → lower EI
@@ -230,45 +230,45 @@ class TestLowerConfidenceBound:
     """Tests for LowerConfidenceBound acquisition function."""
 
     def test_requires_uncertainty(self) -> None:
-        pred = _pred(mean=[[1.0]])
+        pred = _pred(value=[[1.0]])
         with pytest.raises(TypeError, match="uncertainty"):
             LowerConfidenceBound().score(pred, reference=None)
 
     def test_output_shape(self) -> None:
-        pred = _pred(mean=np.zeros((4, 1)), std=np.ones((4, 1)))
+        pred = _pred(value=np.zeros((4, 1)), std=np.ones((4, 1)))
         scores = LowerConfidenceBound().score(pred, reference=None)
         assert scores.shape == (4,)
 
     def test_negated_lcb_formula(self) -> None:
         """score = -(mu - kappa * sigma) = -mu + kappa * sigma."""
         mu, sigma, kappa = 2.0, 0.5, 3.0
-        pred = _pred(mean=[[mu]], std=[[sigma]])
+        pred = _pred(value=[[mu]], std=[[sigma]])
         scores = LowerConfidenceBound(kappa=kappa).score(pred, reference=None)
         expected = -(mu - kappa * sigma)
         assert scores[0] == pytest.approx(expected)
 
     def test_higher_score_for_lower_mean(self) -> None:
         """Candidate with lower predicted mean gets a higher score."""
-        pred = _pred(mean=[[1.0], [3.0]], std=[[0.1], [0.1]])
+        pred = _pred(value=[[1.0], [3.0]], std=[[0.1], [0.1]])
         scores = LowerConfidenceBound(kappa=0.0).score(pred, reference=None)
         # kappa=0 → score = -mu; lower mu → higher score
         assert scores[0] > scores[1]
 
     def test_higher_score_for_higher_uncertainty(self) -> None:
         """Candidate with higher std gets a higher score (exploration)."""
-        pred = _pred(mean=[[1.0], [1.0]], std=[[0.1], [1.0]])
+        pred = _pred(value=[[1.0], [1.0]], std=[[0.1], [1.0]])
         scores = LowerConfidenceBound(kappa=2.0).score(pred, reference=None)
         assert scores[1] > scores[0]
 
     def test_kappa_zero_equals_negative_mean(self) -> None:
-        pred = _pred(mean=[[2.5], [3.5]], std=[[0.5], [0.5]])
+        pred = _pred(value=[[2.5], [3.5]], std=[[0.5], [0.5]])
         scores = LowerConfidenceBound(kappa=0.0).score(pred, reference=None)
         np.testing.assert_array_almost_equal(scores, [-2.5, -3.5])
 
     def test_obj_idx(self) -> None:
         """obj_idx selects which objective to compute LCB for."""
         pred = _pred(
-            mean=[[1.0, 5.0]],
+            value=[[1.0, 5.0]],
             std=[[0.1, 0.1]],
         )
         s0 = LowerConfidenceBound(kappa=0.0, obj_idx=0).score(pred, reference=None)
@@ -284,12 +284,12 @@ class TestProbabilityOfFeasibility:
     """Tests for ProbabilityOfFeasibility acquisition function."""
 
     def test_requires_uncertainty(self) -> None:
-        pred = _pred(mean=[[0.5]])
+        pred = _pred(value=[[0.5]])
         with pytest.raises(TypeError, match="uncertainty"):
             ProbabilityOfFeasibility().score(pred, reference=None)
 
     def test_output_shape(self) -> None:
-        pred = _pred(mean=np.zeros((5, 1)), std=np.ones((5, 1)))
+        pred = _pred(value=np.zeros((5, 1)), std=np.ones((5, 1)))
         scores = ProbabilityOfFeasibility().score(pred, reference=None)
         assert scores.shape == (5,)
 
@@ -297,7 +297,7 @@ class TestProbabilityOfFeasibility:
         """PoF scores are always in [0, 1]."""
         rng = np.random.default_rng(1)
         pred = _pred(
-            mean=rng.standard_normal((20, 1)),
+            value=rng.standard_normal((20, 1)),
             std=np.abs(rng.standard_normal((20, 1))) + 0.01,
         )
         scores = ProbabilityOfFeasibility().score(pred, reference=None)
@@ -308,26 +308,26 @@ class TestProbabilityOfFeasibility:
         """PoF = Phi(-mu / sigma)."""
         mu, sigma = -1.0, 0.5
         expected = norm.cdf((0.0 - mu) / sigma)
-        pred = _pred(mean=[[mu]], std=[[sigma]])
+        pred = _pred(value=[[mu]], std=[[sigma]])
         scores = ProbabilityOfFeasibility().score(pred, reference=None)
         assert scores[0] == pytest.approx(expected, rel=1e-5)
 
     def test_feasible_candidate_scores_near_one(self) -> None:
         """If mu << 0 (clearly feasible), PoF is near 1."""
-        pred = _pred(mean=[[-10.0]], std=[[0.1]])
+        pred = _pred(value=[[-10.0]], std=[[0.1]])
         scores = ProbabilityOfFeasibility().score(pred, reference=None)
         assert scores[0] > 0.99
 
     def test_infeasible_candidate_scores_near_zero(self) -> None:
         """If mu >> 0 (clearly infeasible), PoF is near 0."""
-        pred = _pred(mean=[[10.0]], std=[[0.1]])
+        pred = _pred(value=[[10.0]], std=[[0.1]])
         scores = ProbabilityOfFeasibility().score(pred, reference=None)
         assert scores[0] < 0.01
 
     def test_obj_idx(self) -> None:
         """obj_idx selects which objective (constraint) to evaluate."""
         pred = _pred(
-            mean=[[-5.0, 5.0]],
+            value=[[-5.0, 5.0]],
             std=[[0.1, 0.1]],
         )
         s0 = ProbabilityOfFeasibility(obj_idx=0).score(pred, reference=None)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -107,6 +107,7 @@ class _MockProvider:
         pass
 
 
+
 # ---------------------------------------------------------------------------
 # GenerationBasedStrategy
 # ---------------------------------------------------------------------------
@@ -155,6 +156,7 @@ class TestGenerationBasedStrategy:
         strategy.step(ctx, provider)
         assert ctx.gen == 1
         assert ctx.fe == len(ctx.population)
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -107,7 +107,6 @@ class _MockProvider:
         pass
 
 
-
 # ---------------------------------------------------------------------------
 # GenerationBasedStrategy
 # ---------------------------------------------------------------------------
@@ -156,7 +155,6 @@ class TestGenerationBasedStrategy:
         strategy.step(ctx, provider)
         assert ctx.gen == 1
         assert ctx.fe == len(ctx.population)
-
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -88,7 +88,7 @@ class _MockSurrogateManager:
         scores = np.linspace(1.0, 0.0, n)
         predictions = [
             SurrogatePrediction(
-                mean=np.array([[1.0]]),
+                value=np.array([[1.0]]),
                 std=None,
                 label=None,
                 metadata={},

--- a/tests/test_surrogate_manager.py
+++ b/tests/test_surrogate_manager.py
@@ -88,40 +88,40 @@ class TestSplitPrediction:
     """Tests for the _split_prediction helper."""
 
     def test_splits_into_correct_count(self) -> None:
-        pred = SurrogatePrediction(mean=np.zeros((4, 2)))
+        pred = SurrogatePrediction(value=np.zeros((4, 2)))
         parts = _split_prediction(pred)
         assert len(parts) == 4
 
     def test_each_part_has_shape_1_nobj(self) -> None:
-        pred = SurrogatePrediction(mean=np.arange(6).reshape(3, 2).astype(float))
+        pred = SurrogatePrediction(value=np.arange(6).reshape(3, 2).astype(float))
         parts = _split_prediction(pred)
         for p in parts:
-            assert p.mean.shape == (1, 2)
+            assert p.value.shape == (1, 2)
 
     def test_values_preserved(self) -> None:
         mean = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
-        pred = SurrogatePrediction(mean=mean)
+        pred = SurrogatePrediction(value=mean)
         parts = _split_prediction(pred)
         for i, p in enumerate(parts):
-            np.testing.assert_array_equal(p.mean[0], mean[i])
+            np.testing.assert_array_equal(p.value[0], mean[i])
 
     def test_std_split_correctly(self) -> None:
         std = np.array([[0.1, 0.2], [0.3, 0.4]])
-        pred = SurrogatePrediction(mean=np.zeros((2, 2)), std=std)
+        pred = SurrogatePrediction(value=np.zeros((2, 2)), std=std)
         parts = _split_prediction(pred)
         assert parts[0].std is not None
         assert parts[0].std.shape == (1, 2)
         np.testing.assert_array_almost_equal(parts[0].std[0], [0.1, 0.2])
 
     def test_std_none_propagates(self) -> None:
-        pred = SurrogatePrediction(mean=np.zeros((3, 1)))
+        pred = SurrogatePrediction(value=np.zeros((3, 1)))
         parts = _split_prediction(pred)
         for p in parts:
             assert p.std is None
 
     def test_label_split_correctly(self) -> None:
         label = np.array([0.0, 1.0, 2.0])
-        pred = SurrogatePrediction(mean=np.zeros((3, 1)), label=label)
+        pred = SurrogatePrediction(value=np.zeros((3, 1)), label=label)
         parts = _split_prediction(pred)
         for i, p in enumerate(parts):
             assert p.label is not None
@@ -130,14 +130,14 @@ class TestSplitPrediction:
     def test_metadata_shared(self) -> None:
         """metadata dict is shared (not deep-copied) across splits."""
         meta = {"key": "val"}
-        pred = SurrogatePrediction(mean=np.zeros((2, 1)), metadata=meta)
+        pred = SurrogatePrediction(value=np.zeros((2, 1)), metadata=meta)
         parts = _split_prediction(pred)
         for p in parts:
             assert p.metadata is meta
 
     def test_tell_f_split_correctly(self) -> None:
         tell_f = np.array([[10.0], [20.0], [30.0]])
-        pred = SurrogatePrediction(mean=np.zeros((3, 1)), _tell_f=tell_f)
+        pred = SurrogatePrediction(value=np.zeros((3, 1)), _tell_f=tell_f)
         parts = _split_prediction(pred)
         assert parts[0].has_tell_f
         assert parts[0].tell_f.shape == (1, 1)
@@ -146,14 +146,14 @@ class TestSplitPrediction:
         np.testing.assert_array_almost_equal(parts[2].tell_f[0], [30.0])
 
     def test_tell_f_none_propagates(self) -> None:
-        pred = SurrogatePrediction(mean=np.zeros((3, 1)))
+        pred = SurrogatePrediction(value=np.zeros((3, 1)))
         parts = _split_prediction(pred)
         for p in parts:
             assert not p.has_tell_f
 
     def test_tell_f_shape_preserved_after_split(self) -> None:
         tell_f = np.array([[1.0, 2.0], [3.0, 4.0]])
-        pred = SurrogatePrediction(mean=np.zeros((2, 2)), _tell_f=tell_f)
+        pred = SurrogatePrediction(value=np.zeros((2, 2)), _tell_f=tell_f)
         parts = _split_prediction(pred)
         assert parts[0].has_tell_f
         assert parts[0].tell_f.shape == (1, 2)
@@ -170,19 +170,19 @@ class TestSurrogatePredictionProperties:
     """Tests for tell_f property and has_tell_f."""
 
     def test_tell_f_uses_override_when_set(self) -> None:
-        pred = SurrogatePrediction(mean=np.array([[0.0]]), _tell_f=np.array([[99.0]]))
+        pred = SurrogatePrediction(value=np.array([[0.0]]), _tell_f=np.array([[99.0]]))
         np.testing.assert_array_almost_equal(pred.tell_f, [[99.0]])
 
     def test_tell_f_falls_back_to_mean(self) -> None:
-        pred = SurrogatePrediction(mean=np.array([[42.0]]))
+        pred = SurrogatePrediction(value=np.array([[42.0]]))
         np.testing.assert_array_almost_equal(pred.tell_f, [[42.0]])
 
     def test_has_tell_f_true_when_set(self) -> None:
-        pred = SurrogatePrediction(mean=np.array([[0.0]]), _tell_f=np.array([[1.0]]))
+        pred = SurrogatePrediction(value=np.array([[0.0]]), _tell_f=np.array([[1.0]]))
         assert pred.has_tell_f is True
 
     def test_has_tell_f_false_when_none(self) -> None:
-        pred = SurrogatePrediction(mean=np.array([[0.0]]))
+        pred = SurrogatePrediction(value=np.array([[0.0]]))
         assert pred.has_tell_f is False
 
 
@@ -282,7 +282,7 @@ class TestGlobalSurrogateManager:
         manager = GlobalSurrogateManager(surrogate_1obj, MeanPrediction())
         _, predictions = manager.score_candidates(candidates, archive_1obj)
         for p in predictions:
-            assert p.mean.shape == (1, N_OBJ)
+            assert p.value.shape == (1, N_OBJ)
 
     def test_scores_finite(
         self,
@@ -308,7 +308,7 @@ class TestGlobalSurrogateManager:
         scores, predictions = manager.score_candidates(candidates, archive_2obj)
         assert scores.shape == (len(candidates),)
         for p in predictions:
-            assert p.mean.shape == (1, 2)
+            assert p.value.shape == (1, 2)
 
 
 # ===========================================================================
@@ -364,7 +364,7 @@ class TestLocalSurrogateManager:
         )
         _, predictions = manager.score_candidates(candidates, archive_1obj)
         for p in predictions:
-            assert p.mean.shape == (1, N_OBJ)
+            assert p.value.shape == (1, N_OBJ)
 
     def test_n_neighbors_default(
         self,

--- a/tests/test_surrogate_manager.py
+++ b/tests/test_surrogate_manager.py
@@ -135,6 +135,56 @@ class TestSplitPrediction:
         for p in parts:
             assert p.metadata is meta
 
+    def test_tell_f_split_correctly(self) -> None:
+        tell_f = np.array([[10.0], [20.0], [30.0]])
+        pred = SurrogatePrediction(mean=np.zeros((3, 1)), _tell_f=tell_f)
+        parts = _split_prediction(pred)
+        assert parts[0].has_tell_f
+        assert parts[0].tell_f.shape == (1, 1)
+        np.testing.assert_array_almost_equal(parts[0].tell_f[0], [10.0])
+        np.testing.assert_array_almost_equal(parts[1].tell_f[0], [20.0])
+        np.testing.assert_array_almost_equal(parts[2].tell_f[0], [30.0])
+
+    def test_tell_f_none_propagates(self) -> None:
+        pred = SurrogatePrediction(mean=np.zeros((3, 1)))
+        parts = _split_prediction(pred)
+        for p in parts:
+            assert not p.has_tell_f
+
+    def test_tell_f_shape_preserved_after_split(self) -> None:
+        tell_f = np.array([[1.0, 2.0], [3.0, 4.0]])
+        pred = SurrogatePrediction(mean=np.zeros((2, 2)), _tell_f=tell_f)
+        parts = _split_prediction(pred)
+        assert parts[0].has_tell_f
+        assert parts[0].tell_f.shape == (1, 2)
+        np.testing.assert_array_almost_equal(parts[0].tell_f[0], [1.0, 2.0])
+        assert parts[1].has_tell_f
+        assert parts[1].tell_f.shape == (1, 2)
+        np.testing.assert_array_almost_equal(parts[1].tell_f[0], [3.0, 4.0])
+
+
+# ===========================================================================
+# SurrogatePrediction Properties Tests
+# ===========================================================================
+class TestSurrogatePredictionProperties:
+    """Tests for tell_f property and has_tell_f."""
+
+    def test_tell_f_uses_override_when_set(self) -> None:
+        pred = SurrogatePrediction(mean=np.array([[0.0]]), _tell_f=np.array([[99.0]]))
+        np.testing.assert_array_almost_equal(pred.tell_f, [[99.0]])
+
+    def test_tell_f_falls_back_to_mean(self) -> None:
+        pred = SurrogatePrediction(mean=np.array([[42.0]]))
+        np.testing.assert_array_almost_equal(pred.tell_f, [[42.0]])
+
+    def test_has_tell_f_true_when_set(self) -> None:
+        pred = SurrogatePrediction(mean=np.array([[0.0]]), _tell_f=np.array([[1.0]]))
+        assert pred.has_tell_f is True
+
+    def test_has_tell_f_false_when_none(self) -> None:
+        pred = SurrogatePrediction(mean=np.array([[0.0]]))
+        assert pred.has_tell_f is False
+
 
 # ===========================================================================
 # _rank_normalize Tests


### PR DESCRIPTION
## Related Issue
Closes #69

## Overview
PSO's personal best (pbest) is updated inside `algorithm.tell()` based on the value stored in `offspring[i].f`.
Previously, all three strategy classes assigned the surrogate's raw `mean` prediction directly to `offspring[i].f` before calling `tell()`.
When the surrogate returns non-objective values (e.g., classification probabilities, novelty scores), this silently corrupts pbest.

This PR decouples the two responsibilities of the surrogate output:

1. **`SurrogatePrediction.value`** — what the surrogate actually predicted (renamed from `mean`, which was misleading for non-Gaussian surrogates such as RBF or classifiers).
2. **`SurrogatePrediction.tell_f`** — the value that strategies should pass to `algorithm.tell()`. Falls back to `value` when no override is set (`_tell_f is None`). Surrogate implementations that want to prevent pbest corruption can set `_tell_f` to a NaN array; PSO already skips pbest updates when `f` contains NaN.

The strategies (`ib.py`, `ps.py`, `gb.py`) now read `pred.tell_f[0]` instead of the raw predicted value, so the override takes effect transparently.

## Changes
- **`SurrogatePrediction`**: renamed field `mean` → `value` for accuracy across all surrogate types; added private field `_tell_f`, property `tell_f` (returns `_tell_f` if set, else `value`), and `has_tell_f` predicate
- **`_split_prediction()`** (`manager.py`): slices `_tell_f` per sample alongside `std` and `label`
- **`ib.py`, `ps.py`, `gb.py`**: use `pred.tell_f[0]` when assigning `offspring[i].f` before `algorithm.tell()`
- **All acquisition functions** (`mean.py`, `ei.py`, `lcb.py`, `pof.py`): updated `prediction.mean` → `prediction.value`
- **Tests**: added `TestSurrogatePredictionProperties` and extended `TestSplitPrediction` in `test_surrogate_manager.py`; updated all test fixtures to use `value=` keyword

## Verification Steps
```bash
uv run pytest tests/test_surrogate_manager.py tests/test_acquisition.py tests/test_strategies.py -v
```
All 88 tests pass. Existing tests remain green due to `_tell_f=None` default (backward-compatible).

## Concerns
- `SurrogatePrediction.value` is a breaking rename from `mean`. Any downstream code or notebooks that access `.mean` directly will need updating.
- The `_tell_f` field uses a leading underscore to signal that it is an implementation detail rather than primary interface. Callers set it via the constructor keyword `_tell_f=...`, which is slightly unconventional for a dataclass but avoids exposing two public names for the same concept.

## Other
Prerequisite for the ArchiveBasedManager implementation, which demonstrates pbest isolation via `_tell_f=NaN`.
