### PR TITLE
Dev issue#73

### DIFF
--- a/src/saealib/acquisition/base.py
+++ b/src/saealib/acquisition/base.py
@@ -29,6 +29,9 @@ class AcquisitionFunction(ABC):
     it knows nothing about how predictions are generated.
     """
 
+    # Optimizer.validate() cross-checks this with surrogate.provides_uncertainty.
+    requires_uncertainty: bool = False
+
     @abstractmethod
     def compute_reference(self, archive: Archive) -> Any:
         """

--- a/src/saealib/acquisition/ei.py
+++ b/src/saealib/acquisition/ei.py
@@ -39,6 +39,8 @@ class ExpectedImprovement(AcquisitionFunction):
         problems where EI is applied to a single objective. Default: 0.
     """
 
+    requires_uncertainty: bool = True
+
     def __init__(self, xi: float = 0.01, obj_idx: int = 0, reference: Any = None):
         self.xi = xi
         self.obj_idx = obj_idx

--- a/src/saealib/acquisition/lcb.py
+++ b/src/saealib/acquisition/lcb.py
@@ -38,6 +38,8 @@ class LowerConfidenceBound(AcquisitionFunction):
         problems where LCB is applied to a single objective. Default: 0.
     """
 
+    requires_uncertainty: bool = True
+
     def __init__(self, kappa: float = 2.0, obj_idx: int = 0, reference: Any = None):
         self.kappa = kappa
         self.obj_idx = obj_idx

--- a/src/saealib/acquisition/pof.py
+++ b/src/saealib/acquisition/pof.py
@@ -34,6 +34,8 @@ class ProbabilityOfFeasibility(AcquisitionFunction):
         Index of the predicted constraint to evaluate. Default: 0.
     """
 
+    requires_uncertainty: bool = True
+
     def __init__(self, obj_idx: int = 0, reference: Any = None):
         self.obj_idx = obj_idx
         self.reference = reference

--- a/src/saealib/acquisition/uncertainty.py
+++ b/src/saealib/acquisition/uncertainty.py
@@ -30,6 +30,8 @@ class MaxUncertainty(AcquisitionFunction):
         shape: (n_obj,). If None, uses the mean across objectives.
     """
 
+    requires_uncertainty: bool = True
+
     def __init__(self, weights: np.ndarray | None = None, reference: Any = None):
         self.weights = weights
         self.reference = reference

--- a/src/saealib/optimizer.py
+++ b/src/saealib/optimizer.py
@@ -167,6 +167,55 @@ class Optimizer:
 
     # --- run ---
 
+    def validate(self) -> list[str]:
+        """Check configuration consistency. Returns list of issues."""
+        issues: list[str] = []
+
+        algorithm         = getattr(self, "algorithm", None)
+        strategy          = getattr(self, "strategy", None)
+        termination       = getattr(self, "termination", None)
+        surrogate_manager = getattr(self, "surrogate_manager", None)
+
+        if algorithm is None:
+            issues.append("algorithm is not set; call set_algorithm()")
+        if strategy is None:
+            issues.append("strategy is not set; call set_strategy()")
+        if self.initializer is None:
+            issues.append("initializer is not set; call set_initializer()")
+        if termination is None:
+            issues.append("termination is not set; call set_termination()")
+
+        if strategy is not None and getattr(strategy, "requires_surrogate", False):
+            if surrogate_manager is None:
+                issues.append(
+                    f"{type(strategy).__name__} requires a surrogate_manager; "
+                    "call set_surrogate_manager() or set_surrogate()"
+                )
+
+        weights = getattr(self.problem.comparator, "weights", None)
+        if weights is not None and len(weights) != self.problem.n_obj:
+            issues.append(
+                f"comparator.weights length ({len(weights)}) does not match "
+                f"problem.n_obj ({self.problem.n_obj})"
+            )
+
+        if surrogate_manager is not None:
+            acq  = getattr(surrogate_manager, "acquisition", None)
+            surr = getattr(surrogate_manager, "surrogate", None)
+            if (
+                acq is not None
+                and surr is not None
+                and getattr(acq, "requires_uncertainty", False)
+                and not getattr(surr, "provides_uncertainty", False)
+            ):
+                issues.append(
+                    f"{type(acq).__name__} requires uncertainty estimates but "
+                    f"{type(surr).__name__} does not provide them "
+                    "(provides_uncertainty=False)"
+                )
+
+        return issues
+
     def iterate(self) -> Generator[OptimizationContext, None, None]:
         """
         Iterate the optimization process.
@@ -176,6 +225,11 @@ class Optimizer:
         Generator[OptimizationContext]
             Generator of OptimizationContext.
         """
+        issues = self.validate()
+        if issues:
+            raise ValueError(
+                "Optimizer misconfigured:\n" + "\n".join(f"  - {m}" for m in issues)
+            )
         return Runner(self).iterate()
 
     def run(self) -> OptimizationContext:
@@ -187,4 +241,9 @@ class Optimizer:
         OptimizationContext
             The optimization context.
         """
+        issues = self.validate()
+        if issues:
+            raise ValueError(
+                "Optimizer misconfigured:\n" + "\n".join(f"  - {m}" for m in issues)
+            )
         return Runner(self).run()

--- a/src/saealib/optimizer.py
+++ b/src/saealib/optimizer.py
@@ -171,9 +171,9 @@ class Optimizer:
         """Check configuration consistency. Returns list of issues."""
         issues: list[str] = []
 
-        algorithm         = getattr(self, "algorithm", None)
-        strategy          = getattr(self, "strategy", None)
-        termination       = getattr(self, "termination", None)
+        algorithm = getattr(self, "algorithm", None)
+        strategy = getattr(self, "strategy", None)
+        termination = getattr(self, "termination", None)
         surrogate_manager = getattr(self, "surrogate_manager", None)
 
         if algorithm is None:
@@ -185,12 +185,15 @@ class Optimizer:
         if termination is None:
             issues.append("termination is not set; call set_termination()")
 
-        if strategy is not None and getattr(strategy, "requires_surrogate", False):
-            if surrogate_manager is None:
-                issues.append(
-                    f"{type(strategy).__name__} requires a surrogate_manager; "
-                    "call set_surrogate_manager() or set_surrogate()"
-                )
+        if (
+            strategy is not None
+            and getattr(strategy, "requires_surrogate", False)
+            and surrogate_manager is None
+        ):
+            issues.append(
+                f"{type(strategy).__name__} requires a surrogate_manager; "
+                "call set_surrogate_manager() or set_surrogate()"
+            )
 
         weights = getattr(self.problem.comparator, "weights", None)
         if weights is not None and len(weights) != self.problem.n_obj:
@@ -200,7 +203,7 @@ class Optimizer:
             )
 
         if surrogate_manager is not None:
-            acq  = getattr(surrogate_manager, "acquisition", None)
+            acq = getattr(surrogate_manager, "acquisition", None)
             surr = getattr(surrogate_manager, "surrogate", None)
             if (
                 acq is not None

--- a/src/saealib/strategies/base.py
+++ b/src/saealib/strategies/base.py
@@ -38,6 +38,9 @@ def assign_tell_f(
 class OptimizationStrategy(ABC):
     """Base class for optimization strategies."""
 
+    # Optimizer.validate() checks this to ensure surrogate_manager is configured.
+    requires_surrogate: bool = False
+
     @abstractmethod
     def step(self, ctx: OptimizationContext, provider: ComponentProvider) -> None:
         """

--- a/src/saealib/strategies/gb.py
+++ b/src/saealib/strategies/gb.py
@@ -14,6 +14,8 @@ from saealib.strategies.base import OptimizationStrategy, assign_tell_f
 class GenerationBasedStrategy(OptimizationStrategy):
     """Generation-based strategy."""
 
+    requires_surrogate: bool = True
+
     def __init__(self, gen_ctrl: int):
         """
         Initialize GenerationBasedStrategy.

--- a/src/saealib/strategies/ib.py
+++ b/src/saealib/strategies/ib.py
@@ -16,6 +16,8 @@ from saealib.strategies.base import OptimizationStrategy, assign_tell_f
 class IndividualBasedStrategy(OptimizationStrategy):
     """Individual-based strategy."""
 
+    requires_surrogate: bool = True
+
     def __init__(self, evaluation_ratio: float = 0.1):
         """
         Initialize IndividualBasedStrategy.

--- a/src/saealib/strategies/ps.py
+++ b/src/saealib/strategies/ps.py
@@ -16,6 +16,8 @@ from saealib.strategies.base import OptimizationStrategy, assign_tell_f
 class PreSelectionStrategy(OptimizationStrategy):
     """Pre-selection strategy."""
 
+    requires_surrogate: bool = True
+
     def __init__(self, n_candidates: int, n_select: int):
         """
         Initialize PreSelectionStrategy.

--- a/src/saealib/surrogate/base.py
+++ b/src/saealib/surrogate/base.py
@@ -10,6 +10,9 @@ from saealib.surrogate.prediction import SurrogatePrediction
 class Surrogate(ABC):
     """Base class for surrogate models."""
 
+    # GP implementation will override this with True.
+    provides_uncertainty: bool = False
+
     @abstractmethod
     def fit(self, train_x: np.ndarray, train_y: np.ndarray) -> None:
         """

--- a/tests/test_optimizer_validate.py
+++ b/tests/test_optimizer_validate.py
@@ -1,0 +1,171 @@
+"""Tests for Optimizer.validate() — Issue #73."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from saealib.acquisition.ei import ExpectedImprovement
+from saealib.acquisition.mean import MeanPrediction
+from saealib.comparators import SingleObjectiveComparator
+from saealib.optimizer import Optimizer
+from saealib.problem import Problem
+from saealib.strategies.base import OptimizationStrategy
+from saealib.strategies.ib import IndividualBasedStrategy
+from saealib.surrogate.manager import GlobalSurrogateManager
+from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+
+DIM = 2
+N_OBJ = 1
+
+
+def _make_problem(n_obj: int = N_OBJ) -> Problem:
+    return Problem(
+        func=lambda x: np.zeros(n_obj),
+        dim=DIM,
+        n_obj=n_obj,
+        weight=np.array([-1.0] * n_obj),
+        lb=[-5.0] * DIM,
+        ub=[5.0] * DIM,
+        comparator=SingleObjectiveComparator(),
+    )
+
+
+def _stub_strategy(requires_surrogate: bool = False) -> OptimizationStrategy:
+    m = MagicMock(spec=OptimizationStrategy)
+    m.requires_surrogate = requires_surrogate
+    return m
+
+
+def _fully_configured() -> Optimizer:
+    opt = Optimizer(_make_problem())
+    opt.set_algorithm(MagicMock())
+    opt.set_strategy(_stub_strategy(requires_surrogate=False))
+    opt.initializer = MagicMock()
+    opt.set_termination(MagicMock())
+    return opt
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_fully_configured_returns_empty():
+    assert _fully_configured().validate() == []
+
+
+# ---------------------------------------------------------------------------
+# Missing required components
+# ---------------------------------------------------------------------------
+
+
+def test_missing_algorithm():
+    opt = _fully_configured()
+    del opt.algorithm
+    assert any("algorithm" in m for m in opt.validate())
+
+
+def test_missing_strategy():
+    opt = _fully_configured()
+    del opt.strategy
+    assert any("strategy" in m for m in opt.validate())
+
+
+def test_missing_initializer():
+    opt = _fully_configured()
+    opt.initializer = None
+    assert any("initializer" in m for m in opt.validate())
+
+
+def test_missing_termination():
+    opt = _fully_configured()
+    del opt.termination
+    assert any("termination" in m for m in opt.validate())
+
+
+def test_multiple_issues_reported_together():
+    opt = Optimizer(_make_problem())
+    issues = opt.validate()
+    for kw in ("algorithm", "strategy", "initializer", "termination"):
+        assert any(kw in m for m in issues), f"expected issue about '{kw}'"
+
+
+# ---------------------------------------------------------------------------
+# Strategy × Surrogate
+# ---------------------------------------------------------------------------
+
+
+def test_strategy_requires_surrogate_missing():
+    opt = _fully_configured()
+    opt.set_strategy(IndividualBasedStrategy())
+    assert any("surrogate_manager" in m for m in opt.validate())
+
+
+def test_strategy_requires_surrogate_present():
+    opt = _fully_configured()
+    opt.set_strategy(IndividualBasedStrategy())
+    opt.set_surrogate_manager(
+        GlobalSurrogateManager(
+            RBFsurrogate(kernel=gaussian_kernel, dim=DIM),
+            MeanPrediction(),
+        )
+    )
+    assert not any("surrogate_manager" in m for m in opt.validate())
+
+
+# ---------------------------------------------------------------------------
+# Comparator × n_obj
+# ---------------------------------------------------------------------------
+
+
+def test_comparator_weight_mismatch():
+    opt = _fully_configured()
+    opt.problem.comparator.weights = np.array([1.0, 1.0])  # len 2 != n_obj=1
+    assert any("weights" in m for m in opt.validate())
+
+
+# ---------------------------------------------------------------------------
+# Acquisition × Surrogate uncertainty
+# ---------------------------------------------------------------------------
+
+
+def test_acquisition_uncertainty_mismatch():
+    opt = _fully_configured()
+    opt.set_surrogate_manager(
+        GlobalSurrogateManager(
+            RBFsurrogate(kernel=gaussian_kernel, dim=DIM),
+            ExpectedImprovement(),
+        )
+    )
+    assert any("uncertainty" in m for m in opt.validate())
+
+
+def test_mean_prediction_with_rbf_ok():
+    opt = _fully_configured()
+    opt.set_surrogate_manager(
+        GlobalSurrogateManager(
+            RBFsurrogate(kernel=gaussian_kernel, dim=DIM),
+            MeanPrediction(),
+        )
+    )
+    assert opt.validate() == []
+
+
+# ---------------------------------------------------------------------------
+# run() / iterate() raise on misconfiguration
+# ---------------------------------------------------------------------------
+
+
+def test_run_raises_on_misconfiguration():
+    opt = Optimizer(_make_problem())
+    with pytest.raises(ValueError, match="Optimizer misconfigured"):
+        opt.run()
+
+
+def test_iterate_raises_on_misconfiguration():
+    opt = Optimizer(_make_problem())
+    with pytest.raises(ValueError, match="Optimizer misconfigured"):
+        opt.iterate()

--- a/tests/test_optimizer_validate.py
+++ b/tests/test_optimizer_validate.py
@@ -23,7 +23,7 @@ N_OBJ = 1
 
 def _make_problem(n_obj: int = N_OBJ) -> Problem:
     return Problem(
-        func=lambda x: np.zeros(n_obj),
+        func=lambda _: np.zeros(n_obj),
         dim=DIM,
         n_obj=n_obj,
         weight=np.array([-1.0] * n_obj),
@@ -94,7 +94,7 @@ def test_multiple_issues_reported_together():
 
 
 # ---------------------------------------------------------------------------
-# Strategy × Surrogate
+# Strategy x Surrogate
 # ---------------------------------------------------------------------------
 
 
@@ -117,7 +117,7 @@ def test_strategy_requires_surrogate_present():
 
 
 # ---------------------------------------------------------------------------
-# Comparator × n_obj
+# Comparator x n_obj
 # ---------------------------------------------------------------------------
 
 
@@ -128,7 +128,7 @@ def test_comparator_weight_mismatch():
 
 
 # ---------------------------------------------------------------------------
-# Acquisition × Surrogate uncertainty
+# Acquisition x Surrogate uncertainty
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Related Issue
  Closes #73

  ## Overview
  `Optimizer.run()` / `iterate()` previously failed with an `AttributeError` when required components were not
  configured. This PR adds a pre-run validation stage that detects all configuration errors upfront and reports
  them as a single `ValueError`, making misconfiguration much easier to debug.

  ## Changes
  - Add `requires_surrogate: bool` class attribute to `OptimizationStrategy` base and set it to `True` on
  `IndividualBasedStrategy`, `GroupBasedStrategy`, and `PopulationSamplingStrategy`
  - Add `requires_uncertainty: bool` class attribute to `AcquisitionFunction` base and set it to `True` on
  `ExpectedImprovement`, `LowerConfidenceBound`, `UncertaintyAcquisition`, and `ProbabilityOfFeasibility`
  - Add `provides_uncertainty: bool = False` class attribute to `Surrogate` base (to be overridden by GP in #78)
  - Implement `Optimizer.validate() -> list[str]` that checks: required components (algorithm, strategy,
  initializer, termination), strategy × surrogate dependency, comparator weight × `n_obj` consistency, and
  acquisition × surrogate uncertainty compatibility
  - Call `validate()` at the start of `run()` and `iterate()`; raise `ValueError` with a consolidated issue list
   if any problems are found
  - Add `tests/test_optimizer_validate.py` covering all check paths

  ## Verification Steps
  ```bash
  uv run pytest tests/test_optimizer_validate.py -v
  uv run pytest tests/ -x --ignore=tests/test_integration.py
```

  Concerns

  - EnsembleSurrogateManager does not expose .acquisition / .surrogate attributes, so the acquisition ×
  surrogate uncertainty check is silently skipped for it (noted as out-of-scope)
  - Algorithm × Strategy type-dependency checks are not included
  - Re-validation on mid-run component replacement is not supported
