### PR TITLE
[FEAT] Add surrogate models (sklearn, torch adapter) (#72)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ convention = "numpy"
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
-"tests/*" = ["D", "N802"]
+"tests/*" = ["D", "N802", "N806"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ classifiers = [
     "Typing :: Typed",
 ]
 
+[project.optional-dependencies]
+sklearn = ["scikit-learn>=1.0.0"]
+xgboost = ["xgboost>=1.7.0"]
+lightgbm = ["lightgbm>=3.0.0"]
+torch = ["torch>=2.0.0"]
+
 [project.urls]
 Homepage = "https://github.com/shlka/saealib"
 Repository = "https://github.com/shlka/saealib"
@@ -47,6 +53,10 @@ dev = [
     "pytest>=9.0.2",
     "setuptools>=80.9.0",
     "ruff",
+    "scikit-learn>=1.0.0",
+    "xgboost>=1.7.0",
+    "lightgbm>=3.0.0",
+    "torch>=2.0.0",
 ]
 docs = [
     "furo>=2025.12.19",

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -98,7 +98,17 @@ from saealib.surrogate.manager import (
     SurrogateManager,
 )
 from saealib.surrogate.prediction import SurrogatePrediction
+from saealib.surrogate.per_objective import PerObjectiveSurrogate
 from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+from saealib.surrogate.sklearn_surrogate import (
+    DTSurrogate,
+    LGBMSurrogate,
+    NNSurrogate,
+    SklearnSurrogate,
+    SVMSurrogate,
+    XGBSurrogate,
+)
+from saealib.surrogate.torch_surrogate import TorchSurrogate
 from saealib.termination import Termination, max_fe, max_gen
 from saealib.utils.indicators import hypervolume
 
@@ -121,6 +131,7 @@ __all__ = [
     "CrossoverSBX",
     "CrossoverTwoPoint",
     "CrossoverUniform",
+    "DTSurrogate",
     "DensityManager",
     "EnsembleSurrogateManager",
     "Event",
@@ -132,6 +143,7 @@ __all__ = [
     "Individual",
     "IndividualBasedStrategy",
     "Initializer",
+    "LGBMSurrogate",
     "LHSInitializer",
     "LocalSurrogateManager",
     "LowerConfidenceBound",
@@ -141,6 +153,7 @@ __all__ = [
     "MutationGaussian",
     "MutationPolynomial",
     "MutationUniform",
+    "NNSurrogate",
     "NSGA2Comparator",
     "NichingManager",
     "NoveltyManager",
@@ -148,6 +161,7 @@ __all__ = [
     "Optimizer",
     "ParentSelection",
     "ParetoComparator",
+    "PerObjectiveSurrogate",
     "Population",
     "PopulationAttribute",
     "PostAskEvent",
@@ -164,8 +178,10 @@ __all__ = [
     "RouletteWheelSelection",
     "RunEndEvent",
     "RunStartEvent",
+    "SVMSurrogate",
     "SequentialSelection",
     "SingleObjectiveComparator",
+    "SklearnSurrogate",
     "Surrogate",
     "SurrogateEndEvent",
     "SurrogateManager",
@@ -173,9 +189,11 @@ __all__ = [
     "SurrogateStartEvent",
     "SurvivorSelection",
     "Termination",
+    "TorchSurrogate",
     "TournamentSelection",
     "TruncationSelection",
     "WeightedSumComparator",
+    "XGBSurrogate",
     "crowding_distance",
     "crowding_distance_all_fronts",
     "gaussian_kernel",

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -97,8 +97,8 @@ from saealib.surrogate.manager import (
     LocalSurrogateManager,
     SurrogateManager,
 )
-from saealib.surrogate.prediction import SurrogatePrediction
 from saealib.surrogate.per_objective import PerObjectiveSurrogate
+from saealib.surrogate.prediction import SurrogatePrediction
 from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
 from saealib.surrogate.sklearn_surrogate import (
     DTSurrogate,

--- a/src/saealib/surrogate/per_objective.py
+++ b/src/saealib/surrogate/per_objective.py
@@ -1,0 +1,87 @@
+"""PerObjectiveSurrogate: assign a different surrogate per objective."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from saealib.surrogate.base import Surrogate
+from saealib.surrogate.prediction import SurrogatePrediction
+
+
+class PerObjectiveSurrogate(Surrogate):
+    """
+    Assigns a different surrogate model to each objective function.
+
+    Each surrogate in ``surrogates`` is fitted on the corresponding column
+    of ``train_y``. Predictions are concatenated along the objective axis.
+
+    If every surrogate has ``provides_uncertainty = True``, the returned
+    ``SurrogatePrediction.std`` is populated by stacking each surrogate's
+    ``std`` output; otherwise ``std`` is ``None``.
+
+    Parameters
+    ----------
+    surrogates : list[Surrogate]
+        One surrogate per objective. Must be non-empty.
+
+    Raises
+    ------
+    ValueError
+        If ``surrogates`` is empty, or if the number of objectives in
+        ``train_y`` does not match ``len(surrogates)`` at fit time.
+    """
+
+    def __init__(self, surrogates: list[Surrogate]) -> None:
+        if not surrogates:
+            raise ValueError("PerObjectiveSurrogate requires at least one surrogate.")
+        self.surrogates = surrogates
+
+    @property
+    def provides_uncertainty(self) -> bool:
+        """True only when every constituent surrogate provides uncertainty."""
+        return all(s.provides_uncertainty for s in self.surrogates)
+
+    def fit(self, train_x: np.ndarray, train_y: np.ndarray) -> None:
+        """
+        Fit each surrogate on its corresponding objective column.
+
+        Parameters
+        ----------
+        train_x : np.ndarray
+            Training input data. shape: (n_samples, n_features)
+        train_y : np.ndarray
+            Training output data. shape: (n_samples, n_obj) or (n_samples,).
+        """
+        arr = np.asarray(train_y, dtype=float)
+        if arr.ndim == 1:
+            arr = arr.reshape(-1, 1)
+        n_obj = arr.shape[1]
+        if n_obj != len(self.surrogates):
+            raise ValueError(
+                f"n_obj={n_obj} does not match len(surrogates)={len(self.surrogates)}"
+            )
+        for i, s in enumerate(self.surrogates):
+            s.fit(train_x, arr[:, i])
+
+    def predict(self, test_x: np.ndarray) -> SurrogatePrediction:
+        """
+        Predict by combining each surrogate's output.
+
+        Parameters
+        ----------
+        test_x : np.ndarray
+            Input data. shape: (n_samples, n_features) or (n_features,)
+
+        Returns
+        -------
+        SurrogatePrediction
+            prediction.value shape: (n_samples, n_obj)
+            prediction.std shape: (n_samples, n_obj) if all surrogates provide
+            uncertainty, otherwise None.
+        """
+        preds = [s.predict(test_x) for s in self.surrogates]
+        value = np.column_stack([p.value for p in preds])
+        std = None
+        if self.provides_uncertainty:
+            std = np.column_stack([p.std for p in preds])
+        return SurrogatePrediction(value=value, std=std)

--- a/src/saealib/surrogate/sklearn_surrogate.py
+++ b/src/saealib/surrogate/sklearn_surrogate.py
@@ -1,0 +1,89 @@
+"""Scikit-learn surrogate adapter and convenience classes."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from saealib.surrogate.base import Surrogate
+from saealib.surrogate.prediction import SurrogatePrediction
+
+
+class SklearnSurrogate(Surrogate):
+    """
+    Surrogate adapter for scikit-learn compatible estimators.
+
+    Wraps any estimator that implements ``fit(X, y)`` and ``predict(X)``.
+    Multi-objective problems are handled by fitting one cloned estimator
+    per objective, following the same pattern as ``RBFsurrogate``.
+
+    Parameters
+    ----------
+    estimator : sklearn estimator
+        A scikit-learn compatible regressor instance (e.g. ``SVR()``).
+        The estimator is cloned once per objective on the first ``fit`` call.
+
+    Raises
+    ------
+    ImportError
+        If scikit-learn is not installed.
+    """
+
+    def __init__(self, estimator: object) -> None:
+        try:
+            import sklearn  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "scikit-learn is required for SklearnSurrogate. "
+                "Install it with: pip install saealib[sklearn]"
+            ) from e
+        self.estimator = estimator
+        self._models: list | None = None
+        self.n_obj: int | None = None
+
+    def fit(self, train_x: np.ndarray, train_y: np.ndarray) -> None:
+        """
+        Fit the surrogate model.
+
+        Parameters
+        ----------
+        train_x : np.ndarray
+            Training input data. shape: (n_samples, n_features)
+        train_y : np.ndarray
+            Training output data. shape: (n_samples, n_obj) or (n_samples,).
+        """
+        from sklearn.base import clone
+
+        arr = np.asarray(train_y, dtype=float)
+        if arr.ndim == 1:
+            arr = arr.reshape(-1, 1)
+        n_obj = arr.shape[1]
+
+        if self._models is None or n_obj != self.n_obj:
+            self.n_obj = n_obj
+            self._models = [clone(self.estimator) for _ in range(n_obj)]
+
+        for i, model in enumerate(self._models):
+            model.fit(train_x, arr[:, i])
+
+    def predict(self, test_x: np.ndarray) -> SurrogatePrediction:
+        """
+        Predict using the surrogate model.
+
+        Parameters
+        ----------
+        test_x : np.ndarray
+            Input data. shape: (n_samples, n_features) or (n_features,)
+
+        Returns
+        -------
+        SurrogatePrediction
+            prediction.value shape: (n_samples, n_obj)
+            prediction.std is None
+        """
+        test = np.asarray(test_x)
+        if test.ndim == 1:
+            test = test.reshape(1, -1)
+        preds = [m.predict(test) for m in self._models]
+        value = np.column_stack(preds)
+        return SurrogatePrediction(value=value)
+

--- a/src/saealib/surrogate/sklearn_surrogate.py
+++ b/src/saealib/surrogate/sklearn_surrogate.py
@@ -87,3 +87,118 @@ class SklearnSurrogate(Surrogate):
         value = np.column_stack(preds)
         return SurrogatePrediction(value=value)
 
+
+class SVMSurrogate(SklearnSurrogate):
+    """
+    Support Vector Regression surrogate.
+
+    Convenience wrapper around ``SklearnSurrogate`` using
+    ``sklearn.svm.SVR``.
+
+    Parameters
+    ----------
+    **kwargs
+        Keyword arguments forwarded to ``sklearn.svm.SVR``.
+    """
+
+    def __init__(self, **kwargs: object) -> None:
+        from sklearn.svm import SVR
+
+        super().__init__(SVR(**kwargs))
+
+
+class NNSurrogate(SklearnSurrogate):
+    """
+    Multi-layer Perceptron surrogate.
+
+    Convenience wrapper around ``SklearnSurrogate`` using
+    ``sklearn.neural_network.MLPRegressor``.
+
+    Parameters
+    ----------
+    **kwargs
+        Keyword arguments forwarded to ``sklearn.neural_network.MLPRegressor``.
+    """
+
+    def __init__(self, **kwargs: object) -> None:
+        from sklearn.neural_network import MLPRegressor
+
+        super().__init__(MLPRegressor(**kwargs))
+
+
+class DTSurrogate(SklearnSurrogate):
+    """
+    Random Forest surrogate.
+
+    Convenience wrapper around ``SklearnSurrogate`` using
+    ``sklearn.ensemble.RandomForestRegressor``.
+
+    Parameters
+    ----------
+    **kwargs
+        Keyword arguments forwarded to
+        ``sklearn.ensemble.RandomForestRegressor``.
+    """
+
+    def __init__(self, **kwargs: object) -> None:
+        from sklearn.ensemble import RandomForestRegressor
+
+        super().__init__(RandomForestRegressor(**kwargs))
+
+
+class XGBSurrogate(SklearnSurrogate):
+    """
+    XGBoost surrogate.
+
+    Convenience wrapper around ``SklearnSurrogate`` using
+    ``xgboost.XGBRegressor``.
+
+    Parameters
+    ----------
+    **kwargs
+        Keyword arguments forwarded to ``xgboost.XGBRegressor``.
+
+    Raises
+    ------
+    ImportError
+        If xgboost is not installed.
+    """
+
+    def __init__(self, **kwargs: object) -> None:
+        try:
+            from xgboost import XGBRegressor
+        except ImportError as e:
+            raise ImportError(
+                "xgboost is required for XGBSurrogate. "
+                "Install it with: pip install saealib[xgboost]"
+            ) from e
+        super().__init__(XGBRegressor(**kwargs))
+
+
+class LGBMSurrogate(SklearnSurrogate):
+    """
+    LightGBM surrogate.
+
+    Convenience wrapper around ``SklearnSurrogate`` using
+    ``lightgbm.LGBMRegressor``.
+
+    Parameters
+    ----------
+    **kwargs
+        Keyword arguments forwarded to ``lightgbm.LGBMRegressor``.
+
+    Raises
+    ------
+    ImportError
+        If lightgbm is not installed.
+    """
+
+    def __init__(self, **kwargs: object) -> None:
+        try:
+            from lightgbm import LGBMRegressor
+        except ImportError as e:
+            raise ImportError(
+                "lightgbm is required for LGBMSurrogate. "
+                "Install it with: pip install saealib[lightgbm]"
+            ) from e
+        super().__init__(LGBMRegressor(**kwargs))

--- a/src/saealib/surrogate/torch_surrogate.py
+++ b/src/saealib/surrogate/torch_surrogate.py
@@ -1,0 +1,132 @@
+"""PyTorch surrogate adapter."""
+
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+
+from saealib.surrogate.base import Surrogate
+from saealib.surrogate.prediction import SurrogatePrediction
+
+
+class TorchSurrogate(Surrogate):
+    """
+    Surrogate adapter for PyTorch ``nn.Module`` models.
+
+    Wraps any ``torch.nn.Module`` that maps ``(n_samples, n_features)`` to
+    ``(n_samples, n_obj)``. The model is trained from scratch on each ``fit``
+    call by resetting to the weights captured at construction time, so this
+    adapter is safe to use with ``LocalSurrogateManager`` (which re-fits per
+    candidate).
+
+    Parameters
+    ----------
+    model : torch.nn.Module
+        Neural network model. Its output shape must be ``(n_samples, n_obj)``.
+    optimizer_cls : type or None
+        Optimizer class (e.g. ``torch.optim.Adam``).
+        Defaults to ``torch.optim.Adam``.
+    optimizer_kwargs : dict or None
+        Keyword arguments forwarded to the optimizer constructor.
+        Defaults to ``{}``.
+    loss_fn : callable or None
+        Loss function. Defaults to ``torch.nn.MSELoss()``.
+    epochs : int
+        Number of training epochs per ``fit`` call. Default: 100.
+
+    Raises
+    ------
+    ImportError
+        If PyTorch is not installed.
+    """
+
+    def __init__(
+        self,
+        model: object,
+        optimizer_cls: type | None = None,
+        optimizer_kwargs: dict | None = None,
+        loss_fn: object | None = None,
+        epochs: int = 100,
+    ) -> None:
+        try:
+            import torch  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "PyTorch is required for TorchSurrogate. "
+                "Install it with: pip install saealib[torch]"
+            ) from e
+        self.model = model
+        self._initial_state = copy.deepcopy(model.state_dict())  # type: ignore[union-attr]
+        self.optimizer_cls = optimizer_cls
+        self.optimizer_kwargs = optimizer_kwargs or {}
+        self.loss_fn = loss_fn
+        self.epochs = epochs
+        self.n_obj: int | None = None
+
+    def fit(self, train_x: np.ndarray, train_y: np.ndarray) -> None:
+        """
+        Fit the surrogate model.
+
+        Resets model weights to their initial values before training.
+
+        Parameters
+        ----------
+        train_x : np.ndarray
+            Training input data. shape: (n_samples, n_features)
+        train_y : np.ndarray
+            Training output data. shape: (n_samples, n_obj) or (n_samples,).
+        """
+        import torch
+
+        self.model.load_state_dict(copy.deepcopy(self._initial_state))  # type: ignore[union-attr]
+        self.model.train()  # type: ignore[union-attr]
+
+        arr = np.asarray(train_y, dtype=float)
+        if arr.ndim == 1:
+            arr = arr.reshape(-1, 1)
+        self.n_obj = arr.shape[1]
+
+        x_tensor = torch.tensor(train_x, dtype=torch.float32)
+        y_tensor = torch.tensor(arr, dtype=torch.float32)
+
+        optimizer_cls = self.optimizer_cls or torch.optim.Adam
+        optimizer = optimizer_cls(self.model.parameters(), **self.optimizer_kwargs)  # type: ignore[union-attr]
+        loss_fn = self.loss_fn or torch.nn.MSELoss()
+
+        for _ in range(self.epochs):
+            optimizer.zero_grad()
+            pred = self.model(x_tensor)  # type: ignore[operator]
+            loss = loss_fn(pred, y_tensor)
+            loss.backward()
+            optimizer.step()
+
+    def predict(self, test_x: np.ndarray) -> SurrogatePrediction:
+        """
+        Predict using the surrogate model.
+
+        Parameters
+        ----------
+        test_x : np.ndarray
+            Input data. shape: (n_samples, n_features) or (n_features,)
+
+        Returns
+        -------
+        SurrogatePrediction
+            prediction.value shape: (n_samples, n_obj)
+            prediction.std is None
+        """
+        import torch
+
+        test = np.asarray(test_x)
+        if test.ndim == 1:
+            test = test.reshape(1, -1)
+
+        self.model.eval()  # type: ignore[union-attr]
+        with torch.no_grad():
+            x_tensor = torch.tensor(test, dtype=torch.float32)
+            pred = self.model(x_tensor).numpy()  # type: ignore[operator]
+
+        if pred.ndim == 1:
+            pred = pred.reshape(-1, 1)
+        return SurrogatePrediction(value=pred)

--- a/src/saealib/surrogate/torch_surrogate.py
+++ b/src/saealib/surrogate/torch_surrogate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import copy
-
 import numpy as np
 
 from saealib.surrogate.base import Surrogate
@@ -57,7 +55,7 @@ class TorchSurrogate(Surrogate):
                 "Install it with: pip install saealib[torch]"
             ) from e
         self.model = model
-        self._initial_state = copy.deepcopy(model.state_dict())  # type: ignore[union-attr]
+        self._initial_state = {k: v.clone() for k, v in model.state_dict().items()}  # type: ignore[union-attr]
         self.optimizer_cls = optimizer_cls
         self.optimizer_kwargs = optimizer_kwargs or {}
         self.loss_fn = loss_fn
@@ -79,7 +77,7 @@ class TorchSurrogate(Surrogate):
         """
         import torch
 
-        self.model.load_state_dict(copy.deepcopy(self._initial_state))  # type: ignore[union-attr]
+        self.model.load_state_dict(self._initial_state)  # type: ignore[union-attr]
         self.model.train()  # type: ignore[union-attr]
 
         arr = np.asarray(train_y, dtype=float)

--- a/src/saealib/surrogate/torch_surrogate.py
+++ b/src/saealib/surrogate/torch_surrogate.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
+
+if TYPE_CHECKING:
+    import torch
 
 from saealib.surrogate.base import Surrogate
 from saealib.surrogate.prediction import SurrogatePrediction
@@ -41,7 +46,7 @@ class TorchSurrogate(Surrogate):
 
     def __init__(
         self,
-        model: object,
+        model: torch.nn.Module,
         optimizer_cls: type | None = None,
         optimizer_kwargs: dict | None = None,
         loss_fn: object | None = None,
@@ -55,7 +60,7 @@ class TorchSurrogate(Surrogate):
                 "Install it with: pip install saealib[torch]"
             ) from e
         self.model = model
-        self._initial_state = {k: v.clone() for k, v in model.state_dict().items()}  # type: ignore[union-attr]
+        self._initial_state = {k: v.clone() for k, v in model.state_dict().items()}
         self.optimizer_cls = optimizer_cls
         self.optimizer_kwargs = optimizer_kwargs or {}
         self.loss_fn = loss_fn
@@ -77,20 +82,20 @@ class TorchSurrogate(Surrogate):
         """
         import torch
 
-        self.model.load_state_dict(self._initial_state)  # type: ignore[union-attr]
-        self.model.train()  # type: ignore[union-attr]
+        self.model.load_state_dict(self._initial_state)
+        self.model.train()
 
         arr = np.asarray(train_y, dtype=float)
         if arr.ndim == 1:
             arr = arr.reshape(-1, 1)
         self.n_obj = arr.shape[1]
 
-        device = next(self.model.parameters()).device  # type: ignore[union-attr]
+        device = next(self.model.parameters()).device
         x_tensor = torch.tensor(train_x, dtype=torch.float32).to(device)
         y_tensor = torch.tensor(arr, dtype=torch.float32).to(device)
 
         optimizer_cls = self.optimizer_cls or torch.optim.Adam
-        optimizer = optimizer_cls(self.model.parameters(), **self.optimizer_kwargs)  # type: ignore[union-attr]
+        optimizer = optimizer_cls(self.model.parameters(), **self.optimizer_kwargs)
         loss_fn = self.loss_fn or torch.nn.MSELoss()
 
         for _ in range(self.epochs):
@@ -121,9 +126,9 @@ class TorchSurrogate(Surrogate):
         if test.ndim == 1:
             test = test.reshape(1, -1)
 
-        self.model.eval()  # type: ignore[union-attr]
+        self.model.eval()
         with torch.no_grad():
-            device = next(self.model.parameters()).device  # type: ignore[union-attr]
+            device = next(self.model.parameters()).device
             x_tensor = torch.tensor(test, dtype=torch.float32).to(device)
             pred = self.model(x_tensor).detach().cpu().numpy()  # type: ignore[operator]
 

--- a/src/saealib/surrogate/torch_surrogate.py
+++ b/src/saealib/surrogate/torch_surrogate.py
@@ -87,8 +87,9 @@ class TorchSurrogate(Surrogate):
             arr = arr.reshape(-1, 1)
         self.n_obj = arr.shape[1]
 
-        x_tensor = torch.tensor(train_x, dtype=torch.float32)
-        y_tensor = torch.tensor(arr, dtype=torch.float32)
+        device = next(self.model.parameters()).device  # type: ignore[union-attr]
+        x_tensor = torch.tensor(train_x, dtype=torch.float32).to(device)
+        y_tensor = torch.tensor(arr, dtype=torch.float32).to(device)
 
         optimizer_cls = self.optimizer_cls or torch.optim.Adam
         optimizer = optimizer_cls(self.model.parameters(), **self.optimizer_kwargs)  # type: ignore[union-attr]
@@ -124,7 +125,8 @@ class TorchSurrogate(Surrogate):
 
         self.model.eval()  # type: ignore[union-attr]
         with torch.no_grad():
-            x_tensor = torch.tensor(test, dtype=torch.float32)
+            device = next(self.model.parameters()).device  # type: ignore[union-attr]
+            x_tensor = torch.tensor(test, dtype=torch.float32).to(device)
             pred = self.model(x_tensor).numpy()  # type: ignore[operator]
 
         if pred.ndim == 1:

--- a/src/saealib/surrogate/torch_surrogate.py
+++ b/src/saealib/surrogate/torch_surrogate.py
@@ -127,7 +127,7 @@ class TorchSurrogate(Surrogate):
         with torch.no_grad():
             device = next(self.model.parameters()).device  # type: ignore[union-attr]
             x_tensor = torch.tensor(test, dtype=torch.float32).to(device)
-            pred = self.model(x_tensor).numpy()  # type: ignore[operator]
+            pred = self.model(x_tensor).detach().cpu().numpy()  # type: ignore[operator]
 
         if pred.ndim == 1:
             pred = pred.reshape(-1, 1)

--- a/tests/test_per_objective.py
+++ b/tests/test_per_objective.py
@@ -103,18 +103,14 @@ class TestPerObjectiveSurrogate:
         with pytest.raises(ValueError, match="at least one"):
             PerObjectiveSurrogate([])
 
-    def test_fit_predict_1obj_single_surrogate(
-        self, train_data_1obj, test_x
-    ) -> None:
+    def test_fit_predict_1obj_single_surrogate(self, train_data_1obj, test_x) -> None:
         X, y = train_data_1obj
         s = PerObjectiveSurrogate([RBFsurrogate(gaussian_kernel, DIM)])
         s.fit(X, y)
         pred = s.predict(test_x)
         assert pred.value.shape == (5, 1)
 
-    def test_fit_predict_2obj_two_surrogates(
-        self, train_data_2obj, test_x
-    ) -> None:
+    def test_fit_predict_2obj_two_surrogates(self, train_data_2obj, test_x) -> None:
         X, y = train_data_2obj
         s = PerObjectiveSurrogate(
             [RBFsurrogate(gaussian_kernel, DIM), RBFsurrogate(gaussian_kernel, DIM)]

--- a/tests/test_per_objective.py
+++ b/tests/test_per_objective.py
@@ -1,0 +1,202 @@
+"""
+Tests for PerObjectiveSurrogate.
+
+Covers:
+- Empty surrogates raises ValueError
+- fit/predict with single surrogate (1-obj)
+- fit/predict with multiple surrogates (2-obj, mixed types)
+- n_obj mismatch raises ValueError at fit time
+- provides_uncertainty: False when any surrogate lacks it
+- provides_uncertainty: True when all surrogates provide it, std is populated
+- Integration with GlobalSurrogateManager
+"""
+
+import numpy as np
+import pytest
+
+from saealib.acquisition import MeanPrediction
+from saealib.population import Archive, PopulationAttribute
+from saealib.surrogate.base import Surrogate
+from saealib.surrogate.manager import GlobalSurrogateManager
+from saealib.surrogate.per_objective import PerObjectiveSurrogate
+from saealib.surrogate.prediction import SurrogatePrediction
+from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+from saealib.surrogate.sklearn_surrogate import DTSurrogate, SVMSurrogate
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+DIM = 2
+N_SAMPLES = 20
+
+
+@pytest.fixture
+def train_data_2obj():
+    rng = np.random.default_rng(1)
+    X = rng.uniform(0.0, 2.0, size=(N_SAMPLES, DIM))
+    y = np.column_stack([np.sum(X**2, axis=1), np.sum((X - 2.0) ** 2, axis=1)])
+    return X, y
+
+
+@pytest.fixture
+def train_data_1obj():
+    rng = np.random.default_rng(0)
+    X = rng.uniform(-2.0, 2.0, size=(N_SAMPLES, DIM))
+    y = np.sum(X**2, axis=1)
+    return X, y
+
+
+@pytest.fixture
+def test_x():
+    rng = np.random.default_rng(7)
+    return rng.uniform(-1.0, 1.0, size=(5, DIM))
+
+
+@pytest.fixture
+def archive_2obj():
+    attrs = [
+        PopulationAttribute(name="x", dtype=np.float64, shape=(DIM,)),
+        PopulationAttribute(name="f", dtype=np.float64, shape=(2,)),
+    ]
+    arc = Archive(attrs, init_capacity=30)
+    rng = np.random.default_rng(0)
+    for _ in range(N_SAMPLES):
+        x = rng.uniform(0.0, 2.0, size=DIM)
+        f = np.array([np.sum(x**2), np.sum((x - 2.0) ** 2)])
+        arc.add(x=x, f=f)
+    return arc
+
+
+@pytest.fixture
+def candidates():
+    rng = np.random.default_rng(7)
+    return rng.uniform(-1.0, 1.0, size=(5, DIM))
+
+
+# ---------------------------------------------------------------------------
+# Stub surrogate with uncertainty
+# ---------------------------------------------------------------------------
+class _StubSurrogateWithUncertainty(Surrogate):
+    """Stub that always returns a fixed mean and std."""
+
+    provides_uncertainty = True
+
+    def fit(self, train_x, train_y) -> None:
+        pass
+
+    def predict(self, test_x) -> SurrogatePrediction:
+        test = np.asarray(test_x)
+        if test.ndim == 1:
+            test = test.reshape(1, -1)
+        n = len(test)
+        return SurrogatePrediction(
+            value=np.ones((n, 1)),
+            std=np.full((n, 1), 0.1),
+        )
+
+
+# ===========================================================================
+# PerObjectiveSurrogate Tests
+# ===========================================================================
+class TestPerObjectiveSurrogate:
+    def test_empty_surrogates_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least one"):
+            PerObjectiveSurrogate([])
+
+    def test_fit_predict_1obj_single_surrogate(
+        self, train_data_1obj, test_x
+    ) -> None:
+        X, y = train_data_1obj
+        s = PerObjectiveSurrogate([RBFsurrogate(gaussian_kernel, DIM)])
+        s.fit(X, y)
+        pred = s.predict(test_x)
+        assert pred.value.shape == (5, 1)
+
+    def test_fit_predict_2obj_two_surrogates(
+        self, train_data_2obj, test_x
+    ) -> None:
+        X, y = train_data_2obj
+        s = PerObjectiveSurrogate(
+            [RBFsurrogate(gaussian_kernel, DIM), RBFsurrogate(gaussian_kernel, DIM)]
+        )
+        s.fit(X, y)
+        pred = s.predict(test_x)
+        assert pred.value.shape == (5, 2)
+
+    def test_mixed_surrogate_types(self, train_data_2obj, test_x) -> None:
+        X, y = train_data_2obj
+        s = PerObjectiveSurrogate(
+            [SVMSurrogate(), DTSurrogate(n_estimators=5, random_state=0)]
+        )
+        s.fit(X, y)
+        pred = s.predict(test_x)
+        assert pred.value.shape == (5, 2)
+
+    def test_nobj_mismatch_raises(self, train_data_2obj) -> None:
+        X, y = train_data_2obj
+        s = PerObjectiveSurrogate([RBFsurrogate(gaussian_kernel, DIM)])
+        with pytest.raises(ValueError, match="n_obj=2"):
+            s.fit(X, y)
+
+    def test_predict_1d_input(self, train_data_1obj) -> None:
+        X, y = train_data_1obj
+        s = PerObjectiveSurrogate([RBFsurrogate(gaussian_kernel, DIM)])
+        s.fit(X, y)
+        pred = s.predict(X[0])
+        assert pred.value.shape == (1, 1)
+
+    def test_std_none_when_no_uncertainty(self, train_data_2obj, test_x) -> None:
+        X, y = train_data_2obj
+        s = PerObjectiveSurrogate(
+            [RBFsurrogate(gaussian_kernel, DIM), RBFsurrogate(gaussian_kernel, DIM)]
+        )
+        s.fit(X, y)
+        assert s.predict(test_x).std is None
+
+    def test_provides_uncertainty_false_if_any_missing(self) -> None:
+        s = PerObjectiveSurrogate(
+            [_StubSurrogateWithUncertainty(), RBFsurrogate(gaussian_kernel, DIM)]
+        )
+        assert s.provides_uncertainty is False
+
+    def test_provides_uncertainty_true_if_all_provide(self) -> None:
+        s = PerObjectiveSurrogate(
+            [_StubSurrogateWithUncertainty(), _StubSurrogateWithUncertainty()]
+        )
+        assert s.provides_uncertainty is True
+
+    def test_std_populated_when_all_provide_uncertainty(self, test_x) -> None:
+        rng = np.random.default_rng(0)
+        X = rng.uniform(-1.0, 1.0, size=(10, DIM))
+        y = np.column_stack([np.ones(10), np.zeros(10)])
+
+        s = PerObjectiveSurrogate(
+            [_StubSurrogateWithUncertainty(), _StubSurrogateWithUncertainty()]
+        )
+        s.fit(X, y)
+        pred = s.predict(test_x)
+        assert pred.std is not None
+        assert pred.std.shape == (5, 2)
+
+    def test_1d_train_y_accepted(self, train_data_1obj, test_x) -> None:
+        X, y = train_data_1obj
+        assert y.ndim == 1
+        s = PerObjectiveSurrogate([RBFsurrogate(gaussian_kernel, DIM)])
+        s.fit(X, y)
+        assert s.predict(test_x).value.shape == (5, 1)
+
+
+# ===========================================================================
+# Integration: GlobalSurrogateManager
+# ===========================================================================
+class TestPerObjectiveSurrogateIntegration:
+    def test_global_manager_2obj(self, archive_2obj, candidates) -> None:
+        s = PerObjectiveSurrogate(
+            [SVMSurrogate(), DTSurrogate(n_estimators=10, random_state=0)]
+        )
+        weights = np.array([-1.0, -1.0])
+        manager = GlobalSurrogateManager(s, MeanPrediction(weights=weights))
+        scores, preds = manager.score_candidates(candidates, archive_2obj)
+        assert scores.shape == (len(candidates),)
+        for p in preds:
+            assert p.value.shape == (1, 2)

--- a/tests/test_sklearn_surrogate.py
+++ b/tests/test_sklearn_surrogate.py
@@ -116,7 +116,9 @@ class TestSklearnSurrogate:
         s.fit(X, y)
         assert s.predict(test_x).std is None
 
-    def test_refit_different_nobj(self, train_data_1obj, train_data_2obj, test_x) -> None:
+    def test_refit_different_nobj(
+        self, train_data_1obj, train_data_2obj, test_x
+    ) -> None:
         from sklearn.linear_model import Ridge
 
         X1, y1 = train_data_1obj

--- a/tests/test_sklearn_surrogate.py
+++ b/tests/test_sklearn_surrogate.py
@@ -1,0 +1,288 @@
+"""
+Tests for sklearn-based surrogate adapters.
+
+Covers:
+- SklearnSurrogate: fit/predict, single/multi-objective, missing sklearn
+- SVMSurrogate, NNSurrogate, DTSurrogate: smoke tests
+- XGBSurrogate, LGBMSurrogate: smoke tests
+- Integration with GlobalSurrogateManager
+"""
+
+import sys
+
+import numpy as np
+import pytest
+
+from saealib.acquisition import MeanPrediction
+from saealib.population import Archive, PopulationAttribute
+from saealib.surrogate.manager import GlobalSurrogateManager
+from saealib.surrogate.prediction import SurrogatePrediction
+from saealib.surrogate.sklearn_surrogate import (
+    DTSurrogate,
+    LGBMSurrogate,
+    NNSurrogate,
+    SklearnSurrogate,
+    SVMSurrogate,
+    XGBSurrogate,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+DIM = 2
+N_SAMPLES = 20
+
+
+@pytest.fixture
+def train_data_1obj():
+    rng = np.random.default_rng(0)
+    X = rng.uniform(-2.0, 2.0, size=(N_SAMPLES, DIM))
+    y = np.sum(X**2, axis=1)
+    return X, y
+
+
+@pytest.fixture
+def train_data_2obj():
+    rng = np.random.default_rng(1)
+    X = rng.uniform(0.0, 2.0, size=(N_SAMPLES, DIM))
+    y = np.column_stack([np.sum(X**2, axis=1), np.sum((X - 2.0) ** 2, axis=1)])
+    return X, y
+
+
+@pytest.fixture
+def test_x():
+    rng = np.random.default_rng(7)
+    return rng.uniform(-1.0, 1.0, size=(5, DIM))
+
+
+@pytest.fixture
+def archive_1obj():
+    attrs = [
+        PopulationAttribute(name="x", dtype=np.float64, shape=(DIM,)),
+        PopulationAttribute(name="f", dtype=np.float64, shape=(1,)),
+    ]
+    arc = Archive(attrs, init_capacity=30)
+    rng = np.random.default_rng(42)
+    for _ in range(N_SAMPLES):
+        x = rng.uniform(-2.0, 2.0, size=DIM)
+        f = np.array([np.sum(x**2)])
+        arc.add(x=x, f=f)
+    return arc
+
+
+@pytest.fixture
+def candidates():
+    rng = np.random.default_rng(7)
+    return rng.uniform(-1.0, 1.0, size=(5, DIM))
+
+
+# ===========================================================================
+# SklearnSurrogate Tests
+# ===========================================================================
+class TestSklearnSurrogate:
+    def test_fit_predict_1obj(self, train_data_1obj, test_x) -> None:
+        from sklearn.linear_model import Ridge
+
+        X, y = train_data_1obj
+        s = SklearnSurrogate(Ridge())
+        s.fit(X, y)
+        pred = s.predict(test_x)
+        assert isinstance(pred, SurrogatePrediction)
+        assert pred.value.shape == (5, 1)
+
+    def test_fit_predict_2obj(self, train_data_2obj, test_x) -> None:
+        from sklearn.linear_model import Ridge
+
+        X, y = train_data_2obj
+        s = SklearnSurrogate(Ridge())
+        s.fit(X, y)
+        pred = s.predict(test_x)
+        assert pred.value.shape == (5, 2)
+
+    def test_predict_1d_input(self, train_data_1obj) -> None:
+        from sklearn.linear_model import Ridge
+
+        X, y = train_data_1obj
+        s = SklearnSurrogate(Ridge())
+        s.fit(X, y)
+        pred = s.predict(X[0])  # 1D input
+        assert pred.value.shape == (1, 1)
+
+    def test_std_is_none(self, train_data_1obj, test_x) -> None:
+        from sklearn.linear_model import Ridge
+
+        X, y = train_data_1obj
+        s = SklearnSurrogate(Ridge())
+        s.fit(X, y)
+        assert s.predict(test_x).std is None
+
+    def test_refit_different_nobj(self, train_data_1obj, train_data_2obj, test_x) -> None:
+        from sklearn.linear_model import Ridge
+
+        X1, y1 = train_data_1obj
+        X2, y2 = train_data_2obj
+        s = SklearnSurrogate(Ridge())
+        s.fit(X1, y1)
+        s.fit(X2, y2)
+        pred = s.predict(test_x)
+        assert pred.value.shape == (5, 2)
+
+    def test_missing_sklearn_raises(self, monkeypatch) -> None:
+        monkeypatch.setitem(sys.modules, "sklearn", None)
+        monkeypatch.setitem(sys.modules, "sklearn.base", None)
+        with pytest.raises(ImportError, match="scikit-learn"):
+            from sklearn.linear_model import Ridge
+
+            SklearnSurrogate(Ridge())
+
+    def test_estimator_is_cloned_per_objective(self, train_data_2obj) -> None:
+        from sklearn.linear_model import Ridge
+
+        X, y = train_data_2obj
+        estimator = Ridge()
+        s = SklearnSurrogate(estimator)
+        s.fit(X, y)
+        assert s._models[0] is not s._models[1]
+        assert s._models[0] is not estimator
+
+
+# ===========================================================================
+# SVMSurrogate Tests
+# ===========================================================================
+class TestSVMSurrogate:
+    def test_fit_predict_1obj(self, train_data_1obj, test_x) -> None:
+        s = SVMSurrogate()
+        X, y = train_data_1obj
+        s.fit(X, y)
+        pred = s.predict(test_x)
+        assert pred.value.shape == (5, 1)
+
+    def test_fit_predict_2obj(self, train_data_2obj, test_x) -> None:
+        s = SVMSurrogate()
+        X, y = train_data_2obj
+        s.fit(X, y)
+        assert s.predict(test_x).value.shape == (5, 2)
+
+    def test_kwargs_forwarded(self) -> None:
+        from sklearn.svm import SVR
+
+        s = SVMSurrogate(kernel="linear", C=10.0)
+        assert isinstance(s.estimator, SVR)
+        assert s.estimator.kernel == "linear"
+        assert s.estimator.C == 10.0
+
+
+# ===========================================================================
+# NNSurrogate Tests
+# ===========================================================================
+class TestNNSurrogate:
+    def test_fit_predict_1obj(self, train_data_1obj, test_x) -> None:
+        s = NNSurrogate(max_iter=200, random_state=0)
+        X, y = train_data_1obj
+        s.fit(X, y)
+        pred = s.predict(test_x)
+        assert pred.value.shape == (5, 1)
+
+    def test_fit_predict_2obj(self, train_data_2obj, test_x) -> None:
+        s = NNSurrogate(max_iter=200, random_state=0)
+        X, y = train_data_2obj
+        s.fit(X, y)
+        assert s.predict(test_x).value.shape == (5, 2)
+
+
+# ===========================================================================
+# DTSurrogate Tests
+# ===========================================================================
+class TestDTSurrogate:
+    def test_fit_predict_1obj(self, train_data_1obj, test_x) -> None:
+        s = DTSurrogate(n_estimators=10, random_state=0)
+        X, y = train_data_1obj
+        s.fit(X, y)
+        pred = s.predict(test_x)
+        assert pred.value.shape == (5, 1)
+
+    def test_fit_predict_2obj(self, train_data_2obj, test_x) -> None:
+        s = DTSurrogate(n_estimators=10, random_state=0)
+        X, y = train_data_2obj
+        s.fit(X, y)
+        assert s.predict(test_x).value.shape == (5, 2)
+
+
+# ===========================================================================
+# XGBSurrogate Tests
+# ===========================================================================
+class TestXGBSurrogate:
+    def test_fit_predict_1obj(self, train_data_1obj, test_x) -> None:
+        s = XGBSurrogate(n_estimators=10, random_state=0, verbosity=0)
+        X, y = train_data_1obj
+        s.fit(X, y)
+        pred = s.predict(test_x)
+        assert pred.value.shape == (5, 1)
+
+    def test_fit_predict_2obj(self, train_data_2obj, test_x) -> None:
+        s = XGBSurrogate(n_estimators=10, random_state=0, verbosity=0)
+        X, y = train_data_2obj
+        s.fit(X, y)
+        assert s.predict(test_x).value.shape == (5, 2)
+
+    def test_missing_xgboost_raises(self, monkeypatch) -> None:
+        monkeypatch.setitem(sys.modules, "xgboost", None)
+        with pytest.raises(ImportError, match="xgboost"):
+            XGBSurrogate()
+
+
+# ===========================================================================
+# LGBMSurrogate Tests
+# ===========================================================================
+class TestLGBMSurrogate:
+    def test_fit_predict_1obj(self, train_data_1obj, test_x) -> None:
+        s = LGBMSurrogate(n_estimators=10, random_state=0, verbose=-1)
+        X, y = train_data_1obj
+        s.fit(X, y)
+        pred = s.predict(test_x)
+        assert pred.value.shape == (5, 1)
+
+    def test_fit_predict_2obj(self, train_data_2obj, test_x) -> None:
+        s = LGBMSurrogate(n_estimators=10, random_state=0, verbose=-1)
+        X, y = train_data_2obj
+        s.fit(X, y)
+        assert s.predict(test_x).value.shape == (5, 2)
+
+    def test_missing_lightgbm_raises(self, monkeypatch) -> None:
+        monkeypatch.setitem(sys.modules, "lightgbm", None)
+        with pytest.raises(ImportError, match="lightgbm"):
+            LGBMSurrogate()
+
+
+# ===========================================================================
+# Integration: GlobalSurrogateManager
+# ===========================================================================
+class TestSklearnSurrogateIntegration:
+    def test_global_manager_svm(self, archive_1obj, candidates) -> None:
+        manager = GlobalSurrogateManager(SVMSurrogate(), MeanPrediction())
+        scores, preds = manager.score_candidates(candidates, archive_1obj)
+        assert scores.shape == (len(candidates),)
+        assert len(preds) == len(candidates)
+        for p in preds:
+            assert p.value.shape == (1, 1)
+
+    def test_global_manager_dt(self, archive_1obj, candidates) -> None:
+        manager = GlobalSurrogateManager(
+            DTSurrogate(n_estimators=10, random_state=0), MeanPrediction()
+        )
+        scores, _ = manager.score_candidates(candidates, archive_1obj)
+        assert scores.shape == (len(candidates),)
+
+    def test_global_manager_xgb(self, archive_1obj, candidates) -> None:
+        manager = GlobalSurrogateManager(
+            XGBSurrogate(n_estimators=10, verbosity=0), MeanPrediction()
+        )
+        scores, _ = manager.score_candidates(candidates, archive_1obj)
+        assert scores.shape == (len(candidates),)
+
+    def test_global_manager_lgbm(self, archive_1obj, candidates) -> None:
+        manager = GlobalSurrogateManager(
+            LGBMSurrogate(n_estimators=10, verbose=-1), MeanPrediction()
+        )
+        scores, _ = manager.score_candidates(candidates, archive_1obj)
+        assert scores.shape == (len(candidates),)

--- a/tests/test_torch_surrogate.py
+++ b/tests/test_torch_surrogate.py
@@ -1,0 +1,185 @@
+"""
+Tests for TorchSurrogate.
+
+Covers:
+- fit/predict: single/multi-objective, 1D input
+- std is None
+- fit resets weights to initial state
+- missing torch raises ImportError
+- Integration with GlobalSurrogateManager
+"""
+
+import sys
+
+import numpy as np
+import pytest
+import torch
+import torch.nn as nn
+
+from saealib.acquisition import MeanPrediction
+from saealib.population import Archive, PopulationAttribute
+from saealib.surrogate.manager import GlobalSurrogateManager
+from saealib.surrogate.prediction import SurrogatePrediction
+from saealib.surrogate.torch_surrogate import TorchSurrogate
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+DIM = 2
+N_SAMPLES = 20
+
+
+def _make_model_1obj() -> nn.Module:
+    return nn.Sequential(nn.Linear(DIM, 16), nn.ReLU(), nn.Linear(16, 1))
+
+
+def _make_model_2obj() -> nn.Module:
+    return nn.Sequential(nn.Linear(DIM, 16), nn.ReLU(), nn.Linear(16, 2))
+
+
+@pytest.fixture
+def train_data_1obj():
+    rng = np.random.default_rng(0)
+    X = rng.uniform(-2.0, 2.0, size=(N_SAMPLES, DIM))
+    y = np.sum(X**2, axis=1)
+    return X, y
+
+
+@pytest.fixture
+def train_data_2obj():
+    rng = np.random.default_rng(1)
+    X = rng.uniform(0.0, 2.0, size=(N_SAMPLES, DIM))
+    y = np.column_stack([np.sum(X**2, axis=1), np.sum((X - 2.0) ** 2, axis=1)])
+    return X, y
+
+
+@pytest.fixture
+def test_x():
+    rng = np.random.default_rng(7)
+    return rng.uniform(-1.0, 1.0, size=(5, DIM))
+
+
+@pytest.fixture
+def archive_1obj():
+    attrs = [
+        PopulationAttribute(name="x", dtype=np.float64, shape=(DIM,)),
+        PopulationAttribute(name="f", dtype=np.float64, shape=(1,)),
+    ]
+    arc = Archive(attrs, init_capacity=30)
+    rng = np.random.default_rng(42)
+    for _ in range(N_SAMPLES):
+        x = rng.uniform(-2.0, 2.0, size=DIM)
+        f = np.array([np.sum(x**2)])
+        arc.add(x=x, f=f)
+    return arc
+
+
+@pytest.fixture
+def candidates():
+    rng = np.random.default_rng(7)
+    return rng.uniform(-1.0, 1.0, size=(5, DIM))
+
+
+# ===========================================================================
+# TorchSurrogate Tests
+# ===========================================================================
+class TestTorchSurrogate:
+    def test_fit_predict_1obj(self, train_data_1obj, test_x) -> None:
+        X, y = train_data_1obj
+        s = TorchSurrogate(_make_model_1obj(), epochs=10)
+        s.fit(X, y)
+        pred = s.predict(test_x)
+        assert isinstance(pred, SurrogatePrediction)
+        assert pred.value.shape == (5, 1)
+
+    def test_fit_predict_2obj(self, train_data_2obj, test_x) -> None:
+        X, y = train_data_2obj
+        s = TorchSurrogate(_make_model_2obj(), epochs=10)
+        s.fit(X, y)
+        pred = s.predict(test_x)
+        assert pred.value.shape == (5, 2)
+
+    def test_predict_1d_input(self, train_data_1obj) -> None:
+        X, y = train_data_1obj
+        s = TorchSurrogate(_make_model_1obj(), epochs=10)
+        s.fit(X, y)
+        pred = s.predict(X[0])  # 1D input
+        assert pred.value.shape == (1, 1)
+
+    def test_std_is_none(self, train_data_1obj, test_x) -> None:
+        X, y = train_data_1obj
+        s = TorchSurrogate(_make_model_1obj(), epochs=10)
+        s.fit(X, y)
+        assert s.predict(test_x).std is None
+
+    def test_1d_train_y_accepted(self, train_data_1obj, test_x) -> None:
+        X, y = train_data_1obj
+        assert y.ndim == 1
+        s = TorchSurrogate(_make_model_1obj(), epochs=10)
+        s.fit(X, y)
+        assert s.predict(test_x).value.shape == (5, 1)
+
+    def test_fit_resets_weights(self, train_data_1obj, test_x) -> None:
+        X, y = train_data_1obj
+        model = _make_model_1obj()
+        s = TorchSurrogate(model, epochs=50)
+
+        s.fit(X, y)
+        pred_after_fit = s.predict(test_x).value.copy()
+
+        # Second fit should start from the same initial weights
+        s.fit(X, y)
+        pred_after_refit = s.predict(test_x).value.copy()
+
+        np.testing.assert_array_almost_equal(pred_after_fit, pred_after_refit)
+
+    def test_initial_weights_not_modified(self, train_data_1obj) -> None:
+        X, y = train_data_1obj
+        model = _make_model_1obj()
+        s = TorchSurrogate(model, epochs=50)
+        initial_state = {k: v.clone() for k, v in s._initial_state.items()}
+
+        s.fit(X, y)
+
+        for key in initial_state:
+            torch.testing.assert_close(s._initial_state[key], initial_state[key])
+
+    def test_custom_optimizer(self, train_data_1obj, test_x) -> None:
+        X, y = train_data_1obj
+        s = TorchSurrogate(
+            _make_model_1obj(),
+            optimizer_cls=torch.optim.SGD,
+            optimizer_kwargs={"lr": 1e-3},
+            epochs=10,
+        )
+        s.fit(X, y)
+        assert s.predict(test_x).value.shape == (5, 1)
+
+    def test_custom_loss_fn(self, train_data_1obj, test_x) -> None:
+        X, y = train_data_1obj
+        s = TorchSurrogate(
+            _make_model_1obj(),
+            loss_fn=nn.L1Loss(),
+            epochs=10,
+        )
+        s.fit(X, y)
+        assert s.predict(test_x).value.shape == (5, 1)
+
+    def test_missing_torch_raises(self, monkeypatch) -> None:
+        monkeypatch.setitem(sys.modules, "torch", None)
+        with pytest.raises(ImportError, match="PyTorch"):
+            TorchSurrogate(_make_model_1obj())
+
+
+# ===========================================================================
+# Integration: GlobalSurrogateManager
+# ===========================================================================
+class TestTorchSurrogateIntegration:
+    def test_global_manager_1obj(self, archive_1obj, candidates) -> None:
+        s = TorchSurrogate(_make_model_1obj(), epochs=10)
+        manager = GlobalSurrogateManager(s, MeanPrediction())
+        scores, preds = manager.score_candidates(candidates, archive_1obj)
+        assert scores.shape == (len(candidates),)
+        assert len(preds) == len(candidates)
+        for p in preds:
+            assert p.value.shape == (1, 1)

--- a/uv.lock
+++ b/uv.lock
@@ -326,6 +326,76 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/fe/7351d7e586a8b4c9f89731bfe4cf0148223e8f9903ff09571f78b3fb0682/cuda_bindings-13.2.0-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08b395f79cb89ce0cd8effff07c4a1e20101b873c256a1aeb286e8fd7bd0f556", size = 5744254, upload-time = "2026-03-11T00:12:29.798Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ef/184aa775e970fc089942cd9ec6302e6e44679d4c14549c6a7ea45bf7f798/cuda_bindings-13.2.0-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6f3682ec3c4769326aafc67c2ba669d97d688d0b7e63e659d36d2f8b72f32d6", size = 6329075, upload-time = "2026-03-11T00:12:32.319Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273, upload-time = "2026-03-11T00:12:37.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/94/2748597f47bb1600cd466b20cab4159f1530a3a33fe7f70fee199b3abb9e/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1eba9504ac70667dd48313395fe05157518fd6371b532790e96fbb31bbb5a5e1", size = 6313924, upload-time = "2026-03-11T00:12:39.462Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c8/b2589d68acf7e3d63e2be330b84bc25712e97ed799affbca7edd7eae25d6/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788", size = 5722404, upload-time = "2026-03-11T00:12:44.041Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/92/f899f7bbb5617bb65ec52a6eac1e9a1447a86b916c4194f8a5001b8cde0c/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46d8776a55d6d5da9dd6e9858fba2efcda2abe6743871dee47dd06eb8cb6d955", size = 6320619, upload-time = "2026-03-11T00:12:45.939Z" },
+    { url = "https://files.pythonhosted.org/packages/df/93/eef988860a3ca985f82c4f3174fc0cdd94e07331ba9a92e8e064c260337f/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6629ca2df6f795b784752409bcaedbd22a7a651b74b56a165ebc0c9dcbd504d0", size = 5614610, upload-time = "2026-03-11T00:12:50.337Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/6db3aba46864aee357ab2415135b3fe3da7e9f1fa0221fa2a86a5968099c/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7dca0da053d3b4cc4869eff49c61c03f3c5dbaa0bcd712317a358d5b8f3f385d", size = 6149914, upload-time = "2026-03-11T00:12:52.374Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/87/87a014f045b77c6de5c8527b0757fe644417b184e5367db977236a141602/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6464b30f46692d6c7f65d4a0e0450d81dd29de3afc1bb515653973d01c2cd6e", size = 5685673, upload-time = "2026-03-11T00:12:56.371Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/5e/c0fe77a73aaefd3fff25ffaccaac69c5a63eafdf8b9a4c476626ef0ac703/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4af9f3e1be603fa12d5ad6cfca7844c9d230befa9792b5abdf7dd79979c3626", size = 6191386, upload-time = "2026-03-11T00:12:58.965Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/58/ed2c3b39c8dd5f96aa7a4abef0d47a73932c7a988e30f5fa428f00ed0da1/cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df850a1ff8ce1b3385257b08e47b70e959932f5f432d0a4e46a355962b4e4771", size = 5507469, upload-time = "2026-03-11T00:13:04.063Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/0c941b112ceeb21439b05895eace78ca1aa2eaaf695c8521a068fd9b4c00/cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8a16384c6494e5485f39314b0b4afb04bee48d49edb16d5d8593fd35bbd231b", size = 6059693, upload-time = "2026-03-11T00:13:06.003Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/d0/c177e29701cf1d3008d7d2b16b5fc626592ce13bd535f8795c5f57187e0e/cuda_pathfinder-1.5.4-py3-none-any.whl", hash = "sha256:9563d3175ce1828531acf4b94e1c1c7d67208c347ca002493e2654878b26f4b7", size = 51657, upload-time = "2026-04-27T22:42:07.712Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364, upload-time = "2025-12-19T23:24:07.328Z" },
+]
+
+[package.optional-dependencies]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusolver = [
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -353,6 +423,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
@@ -413,6 +492,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fsspec"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
 name = "furo"
 version = "2025.12.19"
 source = { registry = "https://pypi.org/simple" }
@@ -465,6 +553,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
 ]
 
 [[package]]
@@ -573,6 +670,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/33/01/a8ea7c5ea32a9b45ceeaee051a04c8ed4320f5add3c51bfa20879b765b70/kiwisolver-1.4.9-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:85b5352f94e490c028926ea567fc569c52ec79ce131dadb968d3853e809518c2", size = 80281, upload-time = "2025-08-10T21:27:45.369Z" },
     { url = "https://files.pythonhosted.org/packages/da/e3/dbd2ecdce306f1d07a1aaf324817ee993aab7aee9db47ceac757deabafbe/kiwisolver-1.4.9-pp311-pypy311_pp73-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:464415881e4801295659462c49461a24fb107c140de781d55518c4b80cb6790f", size = 78009, upload-time = "2025-08-10T21:27:46.376Z" },
     { url = "https://files.pythonhosted.org/packages/da/e9/0d4add7873a73e462aeb45c036a2dead2562b825aa46ba326727b3f31016/kiwisolver-1.4.9-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:fb940820c63a9590d31d88b815e7a3aa5915cad3ce735ab45f0c730b39547de1", size = 73929, upload-time = "2025-08-10T21:27:48.236Z" },
+]
+
+[[package]]
+name = "lightgbm"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/0b/a2e9f5c5da7ef047cc60cef37f86185088845e8433e54d2e7ed439cce8a3/lightgbm-4.6.0.tar.gz", hash = "sha256:cb1c59720eb569389c0ba74d14f52351b573af489f230032a1c9f314f8bab7fe", size = 1703705, upload-time = "2025-02-15T04:03:03.111Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/75/cffc9962cca296bc5536896b7e65b4a7cdeb8db208e71b9c0133c08f8f7e/lightgbm-4.6.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:b7a393de8a334d5c8e490df91270f0763f83f959574d504c7ccb9eee4aef70ed", size = 2010151, upload-time = "2025-02-15T04:02:50.961Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/550ee378512b78847930f5d74228ca1fdba2a7fbdeaac9aeccc085b0e257/lightgbm-4.6.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:2dafd98d4e02b844ceb0b61450a660681076b1ea6c7adb8c566dfd66832aafad", size = 1592172, upload-time = "2025-02-15T04:02:53.937Z" },
+    { url = "https://files.pythonhosted.org/packages/64/41/4fbde2c3d29e25ee7c41d87df2f2e5eda65b431ee154d4d462c31041846c/lightgbm-4.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4d68712bbd2b57a0b14390cbf9376c1d5ed773fa2e71e099cac588703b590336", size = 3454567, upload-time = "2025-02-15T04:02:56.443Z" },
+    { url = "https://files.pythonhosted.org/packages/42/86/dabda8fbcb1b00bcfb0003c3776e8ade1aa7b413dff0a2c08f457dace22f/lightgbm-4.6.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cb19b5afea55b5b61cbb2131095f50538bd608a00655f23ad5d25ae3e3bf1c8d", size = 3569831, upload-time = "2025-02-15T04:02:58.925Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/23/f8b28ca248bb629b9e08f877dd2965d1994e1674a03d67cd10c5246da248/lightgbm-4.6.0-py3-none-win_amd64.whl", hash = "sha256:37089ee95664b6550a7189d887dbf098e3eadab03537e411f52c63c121e3ba4b", size = 1451509, upload-time = "2025-02-15T04:03:01.515Z" },
 ]
 
 [[package]]
@@ -789,6 +905,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "myst-parser"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -827,6 +952,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/33/fa/7b45eef11b7971f0beb29d27b7bfe0d747d063aa29e170d9edd004733c8a/myst_parser-5.0.0.tar.gz", hash = "sha256:f6f231452c56e8baa662cc352c548158f6a16fcbd6e3800fc594978002b94f3a", size = 98535, upload-time = "2026-01-15T09:08:18.036Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/ac/686789b9145413f1a61878c407210e41bfdb097976864e0913078b24098c/myst_parser-5.0.0-py3-none-any.whl", hash = "sha256:ab31e516024918296e169139072b81592336f2fef55b8986aa31c9f04b5f7211", size = 84533, upload-time = "2026-01-15T09:08:16.788Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263, upload-time = "2024-10-21T12:39:36.247Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -975,6 +1125,167 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/91/da/643aad274e29ccbdf42ecd94dafe524b81c87bcb56b83872d54827f10543/numpy-2.4.2-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e04ae107ac591763a47398bb45b568fc38f02dbc4aa44c063f67a131f99346cb", size = 15797142, upload-time = "2026-01-31T23:13:02.219Z" },
     { url = "https://files.pythonhosted.org/packages/66/27/965b8525e9cb5dc16481b30a1b3c21e50c7ebf6e9dbd48d0c4d0d5089c7e/numpy-2.4.2-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:602f65afdef699cda27ec0b9224ae5dc43e328f4c24c689deaf77133dbee74d0", size = 16727979, upload-time = "2026-01-31T23:13:04.62Z" },
     { url = "https://files.pythonhosted.org/packages/de/e5/b7d20451657664b07986c2f6e3be564433f5dcaf3482d68eaecd79afaf03/numpy-2.4.2-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be71bf1edb48ebbbf7f6337b5bfd2f895d1902f6335a5830b20141fc126ffba0", size = 12502577, upload-time = "2026-01-31T23:13:07.08Z" },
+]
+
+[[package]]
+name = "nvidia-cublas"
+version = "13.1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.20.0.48"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.30.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/2b/1757b6b74ee241de5efee3f35487dcb33e09c07605254809c6ce36aeb783/nvidia_nccl_cu12-2.30.4-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:606fa9aa9215c00367d060188eb1a5bbd28396aff5e11b9200d99d1a6ab79a71", size = 300091935, upload-time = "2026-04-23T03:22:58.024Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/c3/0e45ff4dce8401f6ea7c25d80d75738813a47f5ae2691e2478f2fd1e5e93/nvidia_nccl_cu12-2.30.4-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:040974b261edec4b8b793e59e92ab7176fe4ab4bc61b800f9f3bfaeec2d436f3", size = 300164158, upload-time = "2026-04-23T03:23:19.589Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.29.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
 
 [[package]]
@@ -1274,12 +1585,32 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 
+[package.optional-dependencies]
+lightgbm = [
+    { name = "lightgbm" },
+]
+sklearn = [
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+torch = [
+    { name = "torch" },
+]
+xgboost = [
+    { name = "xgboost" },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "lightgbm" },
     { name = "opfunu" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "setuptools" },
+    { name = "torch" },
+    { name = "xgboost" },
 ]
 docs = [
     { name = "furo" },
@@ -1297,17 +1628,26 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "lightgbm", marker = "extra == 'lightgbm'", specifier = ">=3.0.0" },
     { name = "numpy", specifier = ">=1.22.1" },
+    { name = "scikit-learn", marker = "extra == 'sklearn'", specifier = ">=1.0.0" },
     { name = "scipy", specifier = ">=1.0.0" },
+    { name = "torch", marker = "extra == 'torch'", specifier = ">=2.0.0" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
+    { name = "xgboost", marker = "extra == 'xgboost'", specifier = ">=1.7.0" },
 ]
+provides-extras = ["sklearn", "xgboost", "lightgbm", "torch"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "lightgbm", specifier = ">=3.0.0" },
     { name = "opfunu", specifier = ">=1.0.4" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "ruff" },
+    { name = "scikit-learn", specifier = ">=1.0.0" },
     { name = "setuptools", specifier = ">=80.9.0" },
+    { name = "torch", specifier = ">=2.0.0" },
+    { name = "xgboost", specifier = ">=1.7.0" },
 ]
 docs = [
     { name = "furo", specifier = ">=2025.12.19" },
@@ -1319,6 +1659,107 @@ docs = [
     { name = "sphinx-multiversion", specifier = ">=0.2.4" },
     { name = "sphinx-sitemap", specifier = ">=2.6.0" },
     { name = "sphinxcontrib-mermaid", specifier = ">=1.0.0" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "joblib", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/3e/daed796fd69cce768b8788401cc464ea90b306fb196ae1ffed0b98182859/scikit_learn-1.7.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b33579c10a3081d076ab403df4a4190da4f4432d443521674637677dc91e61f", size = 9336221, upload-time = "2025-09-09T08:20:19.328Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ce/af9d99533b24c55ff4e18d9b7b4d9919bbc6cd8f22fe7a7be01519a347d5/scikit_learn-1.7.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:36749fb62b3d961b1ce4fedf08fa57a1986cd409eff2d783bca5d4b9b5fce51c", size = 8653834, upload-time = "2025-09-09T08:20:22.073Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0e/8c2a03d518fb6bd0b6b0d4b114c63d5f1db01ff0f9925d8eb10960d01c01/scikit_learn-1.7.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7a58814265dfc52b3295b1900cfb5701589d30a8bb026c7540f1e9d3499d5ec8", size = 9660938, upload-time = "2025-09-09T08:20:24.327Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/75/4311605069b5d220e7cf5adabb38535bd96f0079313cdbb04b291479b22a/scikit_learn-1.7.2-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a847fea807e278f821a0406ca01e387f97653e284ecbd9750e3ee7c90347f18", size = 9477818, upload-time = "2025-09-09T08:20:26.845Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/9b/87961813c34adbca21a6b3f6b2bea344c43b30217a6d24cc437c6147f3e8/scikit_learn-1.7.2-cp310-cp310-win_amd64.whl", hash = "sha256:ca250e6836d10e6f402436d6463d6c0e4d8e0234cfb6a9a47835bd392b852ce5", size = 8886969, upload-time = "2025-09-09T08:20:29.329Z" },
+    { url = "https://files.pythonhosted.org/packages/43/83/564e141eef908a5863a54da8ca342a137f45a0bfb71d1d79704c9894c9d1/scikit_learn-1.7.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c7509693451651cd7361d30ce4e86a1347493554f172b1c72a39300fa2aea79e", size = 9331967, upload-time = "2025-09-09T08:20:32.421Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d6/ba863a4171ac9d7314c4d3fc251f015704a2caeee41ced89f321c049ed83/scikit_learn-1.7.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:0486c8f827c2e7b64837c731c8feff72c0bd2b998067a8a9cbc10643c31f0fe1", size = 8648645, upload-time = "2025-09-09T08:20:34.436Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/0e/97dbca66347b8cf0ea8b529e6bb9367e337ba2e8be0ef5c1a545232abfde/scikit_learn-1.7.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:89877e19a80c7b11a2891a27c21c4894fb18e2c2e077815bcade10d34287b20d", size = 9715424, upload-time = "2025-09-09T08:20:36.776Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/32/1f3b22e3207e1d2c883a7e09abb956362e7d1bd2f14458c7de258a26ac15/scikit_learn-1.7.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8da8bf89d4d79aaec192d2bda62f9b56ae4e5b4ef93b6a56b5de4977e375c1f1", size = 9509234, upload-time = "2025-09-09T08:20:38.957Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/71/34ddbd21f1da67c7a768146968b4d0220ee6831e4bcbad3e03dd3eae88b6/scikit_learn-1.7.2-cp311-cp311-win_amd64.whl", hash = "sha256:9b7ed8d58725030568523e937c43e56bc01cadb478fc43c042a9aca1dacb3ba1", size = 8894244, upload-time = "2025-09-09T08:20:41.166Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/aa/3996e2196075689afb9fce0410ebdb4a09099d7964d061d7213700204409/scikit_learn-1.7.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8d91a97fa2b706943822398ab943cde71858a50245e31bc71dba62aab1d60a96", size = 9259818, upload-time = "2025-09-09T08:20:43.19Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5d/779320063e88af9c4a7c2cf463ff11c21ac9c8bd730c4a294b0000b666c9/scikit_learn-1.7.2-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:acbc0f5fd2edd3432a22c69bed78e837c70cf896cd7993d71d51ba6708507476", size = 8636997, upload-time = "2025-09-09T08:20:45.468Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/d0/0c577d9325b05594fdd33aa970bf53fb673f051a45496842caee13cfd7fe/scikit_learn-1.7.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e5bf3d930aee75a65478df91ac1225ff89cd28e9ac7bd1196853a9229b6adb0b", size = 9478381, upload-time = "2025-09-09T08:20:47.982Z" },
+    { url = "https://files.pythonhosted.org/packages/82/70/8bf44b933837ba8494ca0fc9a9ab60f1c13b062ad0197f60a56e2fc4c43e/scikit_learn-1.7.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4d6e9deed1a47aca9fe2f267ab8e8fe82ee20b4526b2c0cd9e135cea10feb44", size = 9300296, upload-time = "2025-09-09T08:20:50.366Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/99/ed35197a158f1fdc2fe7c3680e9c70d0128f662e1fee4ed495f4b5e13db0/scikit_learn-1.7.2-cp312-cp312-win_amd64.whl", hash = "sha256:6088aa475f0785e01bcf8529f55280a3d7d298679f50c0bb70a2364a82d0b290", size = 8731256, upload-time = "2025-09-09T08:20:52.627Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/93/a3038cb0293037fd335f77f31fe053b89c72f17b1c8908c576c29d953e84/scikit_learn-1.7.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0b7dacaa05e5d76759fb071558a8b5130f4845166d88654a0f9bdf3eb57851b7", size = 9212382, upload-time = "2025-09-09T08:20:54.731Z" },
+    { url = "https://files.pythonhosted.org/packages/40/dd/9a88879b0c1104259136146e4742026b52df8540c39fec21a6383f8292c7/scikit_learn-1.7.2-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:abebbd61ad9e1deed54cca45caea8ad5f79e1b93173dece40bb8e0c658dbe6fe", size = 8592042, upload-time = "2025-09-09T08:20:57.313Z" },
+    { url = "https://files.pythonhosted.org/packages/46/af/c5e286471b7d10871b811b72ae794ac5fe2989c0a2df07f0ec723030f5f5/scikit_learn-1.7.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:502c18e39849c0ea1a5d681af1dbcf15f6cce601aebb657aabbfe84133c1907f", size = 9434180, upload-time = "2025-09-09T08:20:59.671Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fd/df59faa53312d585023b2da27e866524ffb8faf87a68516c23896c718320/scikit_learn-1.7.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a4c328a71785382fe3fe676a9ecf2c86189249beff90bf85e22bdb7efaf9ae0", size = 9283660, upload-time = "2025-09-09T08:21:01.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c7/03000262759d7b6f38c836ff9d512f438a70d8a8ddae68ee80de72dcfb63/scikit_learn-1.7.2-cp313-cp313-win_amd64.whl", hash = "sha256:63a9afd6f7b229aad94618c01c252ce9e6fa97918c5ca19c9a17a087d819440c", size = 8702057, upload-time = "2025-09-09T08:21:04.234Z" },
+    { url = "https://files.pythonhosted.org/packages/55/87/ef5eb1f267084532c8e4aef98a28b6ffe7425acbfd64b5e2f2e066bc29b3/scikit_learn-1.7.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9acb6c5e867447b4e1390930e3944a005e2cb115922e693c08a323421a6966e8", size = 9558731, upload-time = "2025-09-09T08:21:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f8/6c1e3fc14b10118068d7938878a9f3f4e6d7b74a8ddb1e5bed65159ccda8/scikit_learn-1.7.2-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:2a41e2a0ef45063e654152ec9d8bcfc39f7afce35b08902bfe290c2498a67a6a", size = 9038852, upload-time = "2025-09-09T08:21:08.628Z" },
+    { url = "https://files.pythonhosted.org/packages/83/87/066cafc896ee540c34becf95d30375fe5cbe93c3b75a0ee9aa852cd60021/scikit_learn-1.7.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:98335fb98509b73385b3ab2bd0639b1f610541d3988ee675c670371d6a87aa7c", size = 9527094, upload-time = "2025-09-09T08:21:11.486Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/2b/4903e1ccafa1f6453b1ab78413938c8800633988c838aa0be386cbb33072/scikit_learn-1.7.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:191e5550980d45449126e23ed1d5e9e24b2c68329ee1f691a3987476e115e09c", size = 9367436, upload-time = "2025-09-09T08:21:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/aa/8444be3cfb10451617ff9d177b3c190288f4563e6c50ff02728be67ad094/scikit_learn-1.7.2-cp313-cp313t-win_amd64.whl", hash = "sha256:57dc4deb1d3762c75d685507fbd0bc17160144b2f2ba4ccea5dc285ab0d0e973", size = 9275749, upload-time = "2025-09-09T08:21:15.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/dee5acf66837852e8e68df6d8d3a6cb22d3df997b733b032f513d95205b7/scikit_learn-1.7.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fa8f63940e29c82d1e67a45d5297bdebbcb585f5a5a50c4914cc2e852ab77f33", size = 9208906, upload-time = "2025-09-09T08:21:18.557Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/30/9029e54e17b87cb7d50d51a5926429c683d5b4c1732f0507a6c3bed9bf65/scikit_learn-1.7.2-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:f95dc55b7902b91331fa4e5845dd5bde0580c9cd9612b1b2791b7e80c3d32615", size = 8627836, upload-time = "2025-09-09T08:21:20.695Z" },
+    { url = "https://files.pythonhosted.org/packages/60/18/4a52c635c71b536879f4b971c2cedf32c35ee78f48367885ed8025d1f7ee/scikit_learn-1.7.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9656e4a53e54578ad10a434dc1f993330568cfee176dff07112b8785fb413106", size = 9426236, upload-time = "2025-09-09T08:21:22.645Z" },
+    { url = "https://files.pythonhosted.org/packages/99/7e/290362f6ab582128c53445458a5befd471ed1ea37953d5bcf80604619250/scikit_learn-1.7.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96dc05a854add0e50d3f47a1ef21a10a595016da5b007c7d9cd9d0bffd1fcc61", size = 9312593, upload-time = "2025-09-09T08:21:24.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/87/24f541b6d62b1794939ae6422f8023703bbf6900378b2b34e0b4384dfefd/scikit_learn-1.7.2-cp314-cp314-win_amd64.whl", hash = "sha256:bb24510ed3f9f61476181e4db51ce801e2ba37541def12dc9333b946fc7a9cf8", size = 8820007, upload-time = "2025-09-09T08:21:26.713Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "joblib", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/92/53ea2181da8ac6bf27170191028aee7251f8f841f8d3edbfdcaf2008fde9/scikit_learn-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:146b4d36f800c013d267b29168813f7a03a43ecd2895d04861f1240b564421da", size = 8595835, upload-time = "2025-12-10T07:07:39.385Z" },
+    { url = "https://files.pythonhosted.org/packages/01/18/d154dc1638803adf987910cdd07097d9c526663a55666a97c124d09fb96a/scikit_learn-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f984ca4b14914e6b4094c5d52a32ea16b49832c03bd17a110f004db3c223e8e1", size = 8080381, upload-time = "2025-12-10T07:07:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/44/226142fcb7b7101e64fdee5f49dbe6288d4c7af8abf593237b70fca080a4/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e30adb87f0cc81c7690a84f7932dd66be5bac57cfe16b91cb9151683a4a2d3b", size = 8799632, upload-time = "2025-12-10T07:07:43.899Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4d/4a67f30778a45d542bbea5db2dbfa1e9e100bf9ba64aefe34215ba9f11f6/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ada8121bcb4dac28d930febc791a69f7cb1673c8495e5eee274190b73a4559c1", size = 9103788, upload-time = "2025-12-10T07:07:45.982Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3c/45c352094cfa60050bcbb967b1faf246b22e93cb459f2f907b600f2ceda5/scikit_learn-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:c57b1b610bd1f40ba43970e11ce62821c2e6569e4d74023db19c6b26f246cb3b", size = 8081706, upload-time = "2025-12-10T07:07:48.111Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/46/5416595bb395757f754feb20c3d776553a386b661658fb21b7c814e89efe/scikit_learn-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:2838551e011a64e3053ad7618dda9310175f7515f1742fa2d756f7c874c05961", size = 7688451, upload-time = "2025-12-10T07:07:49.873Z" },
+    { url = "https://files.pythonhosted.org/packages/90/74/e6a7cc4b820e95cc38cf36cd74d5aa2b42e8ffc2d21fe5a9a9c45c1c7630/scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e", size = 8548242, upload-time = "2025-12-10T07:07:51.568Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d8/9be608c6024d021041c7f0b3928d4749a706f4e2c3832bbede4fb4f58c95/scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76", size = 8079075, upload-time = "2025-12-10T07:07:53.697Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/47/f187b4636ff80cc63f21cd40b7b2d177134acaa10f6bb73746130ee8c2e5/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4", size = 8660492, upload-time = "2025-12-10T07:07:55.574Z" },
+    { url = "https://files.pythonhosted.org/packages/97/74/b7a304feb2b49df9fafa9382d4d09061a96ee9a9449a7cbea7988dda0828/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a", size = 8931904, upload-time = "2025-12-10T07:07:57.666Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c4/0ab22726a04ede56f689476b760f98f8f46607caecff993017ac1b64aa5d/scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809", size = 8019359, upload-time = "2025-12-10T07:07:59.838Z" },
+    { url = "https://files.pythonhosted.org/packages/24/90/344a67811cfd561d7335c1b96ca21455e7e472d281c3c279c4d3f2300236/scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb", size = 7641898, upload-time = "2025-12-10T07:08:01.36Z" },
+    { url = "https://files.pythonhosted.org/packages/03/aa/e22e0768512ce9255eba34775be2e85c2048da73da1193e841707f8f039c/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a", size = 8513770, upload-time = "2025-12-10T07:08:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/58/37/31b83b2594105f61a381fc74ca19e8780ee923be2d496fcd8d2e1147bd99/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e", size = 8044458, upload-time = "2025-12-10T07:08:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5a/3f1caed8765f33eabb723596666da4ebbf43d11e96550fb18bdec42b467b/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57", size = 8610341, upload-time = "2025-12-10T07:08:07.732Z" },
+    { url = "https://files.pythonhosted.org/packages/38/cf/06896db3f71c75902a8e9943b444a56e727418f6b4b4a90c98c934f51ed4/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e", size = 8900022, upload-time = "2025-12-10T07:08:09.862Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f9/9b7563caf3ec8873e17a31401858efab6b39a882daf6c1bfa88879c0aa11/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271", size = 7989409, upload-time = "2025-12-10T07:08:12.028Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/1f4001503650e72c4f6009ac0c4413cb17d2d601cef6f71c0453da2732fc/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3", size = 7619760, upload-time = "2025-12-10T07:08:13.688Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/7d/a630359fc9dcc95496588c8d8e3245cc8fd81980251079bc09c70d41d951/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735", size = 8826045, upload-time = "2025-12-10T07:08:15.215Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/56/a0c86f6930cfcd1c7054a2bc417e26960bb88d32444fe7f71d5c2cfae891/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd", size = 8420324, upload-time = "2025-12-10T07:08:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/46/1e/05962ea1cebc1cf3876667ecb14c283ef755bf409993c5946ade3b77e303/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e", size = 8680651, upload-time = "2025-12-10T07:08:19.952Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/56/a85473cd75f200c9759e3a5f0bcab2d116c92a8a02ee08ccd73b870f8bb4/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb", size = 8925045, upload-time = "2025-12-10T07:08:22.11Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b7/64d8cfa896c64435ae57f4917a548d7ac7a44762ff9802f75a79b77cb633/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702", size = 8507994, upload-time = "2025-12-10T07:08:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/37/e192ea709551799379958b4c4771ec507347027bb7c942662c7fbeba31cb/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde", size = 7869518, upload-time = "2025-12-10T07:08:25.71Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
+    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
 ]
 
 [[package]]
@@ -1694,6 +2135,27 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1748,6 +2210,80 @@ wheels = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/b7/53fe0436586716ab7aecff41e26b9302d57c85ded481fd83a2cd741e6b4e/torch-2.12.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:1834bd984f8a2f4f16bdfbeecca9146184b220aa46276bf5756735b5dae12812", size = 87981887, upload-time = "2026-05-13T14:55:53.234Z" },
+    { url = "https://files.pythonhosted.org/packages/34/60/d930eac44c30de06ed16f6d1ba4e785e1632532b50d8f0bf9bf699a4d0c7/torch-2.12.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d4d029801cb7b6df858804a2a21b00cc2aa0bf0ee5d2ab18d343c9e9e5681f35", size = 426355000, upload-time = "2026-05-13T14:54:31.944Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0c/c76b6a087820bab55705b94dfc074e520de9ae91f5ef90da2ecbf2a3ef12/torch-2.12.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:d47e7dee68ac4cd7a068b26bcd6b989935427709fae1c8f7bd0019978f829e15", size = 532144998, upload-time = "2026-05-13T14:56:05.523Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/64/8a0d036e166a6aa85ee09bef072f3655d1ba5d5486a68d1b03b6813c01b3/torch-2.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:cf9839790285dd472e7a16aafcb4a4e6bf58ec1b494045044b0eefb0eb4bd1f2", size = 122949877, upload-time = "2026-05-13T14:55:46.841Z" },
+    { url = "https://files.pythonhosted.org/packages/18/62/131124fb95df03811b8260d1d43dcc5ee85ea1a344b964613d7efe77fb08/torch-2.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:10802fd383bbfed646212e765a72c37d2185205d4f26eb197a254e8ac7ddcb25", size = 87990344, upload-time = "2026-05-13T14:55:42.154Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9c/dda0dbd547dc549839824135f223792fd0e725f28ed0715dda366b7acaa2/torch-2.12.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:c12592630aef72feaf18bd3f197ef587bbfa21131b31c38b23ab2e55fce92e36", size = 426362932, upload-time = "2026-05-13T14:54:15.295Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d2/a7dd5a3f9bdaa7842124e8e2359202b317c48d47d2fc5816fafdf2049adb/torch-2.12.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:415c1b8d0412f67551c8e89a2daca0fb3e56694af0281ba155eaa9da481f58b4", size = 532170085, upload-time = "2026-05-13T14:55:20.788Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1b/a61ce2004f9ab0ea8964a6e6168133a127795667639e2ff4f8f2bdb16a65/torch-2.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:dd37188ea325042cb1f6cafa56822b11ada2520c04791a52629b0af25bdfbfd9", size = 122953128, upload-time = "2026-05-13T14:54:52.744Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/285d643f254731294c9b595a007eac39db4600a98682d7bca688f42ca164/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b41339df93d491435e790ff8bcbae1c0ce777175889bfd1281d119862793e6a2", size = 88010197, upload-time = "2026-05-13T14:55:35.414Z" },
+    { url = "https://files.pythonhosted.org/packages/79/81/76debf1db1343bd929bbb5d74c89fb437c2ed88eb144712557e7bd3eea45/torch-2.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8fbef9f108a863e7722a73740998967e3b074742a834fc5be3a535a2befa7057", size = 426376751, upload-time = "2026-05-13T14:55:03.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f0/80026028b603c4650ff270fc3785bdef4bd6738765a9cc5a0f5a637d65a2/torch-2.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4b4f64c2c2b11f7510d93dd6412b87025ff6eddd6bb61c3b5a3d892ea20c4756", size = 532261691, upload-time = "2026-05-13T14:52:54.453Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c2/64b06cbb7830fb3cd9be13e1158b31a3f36b68e6a209105ee3c9d9480be0/torch-2.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b958caff4a14d3a3b0b2dfc6a378f64dda9728a9dad28c08a0db9ce4dafb549", size = 122988114, upload-time = "2026-05-13T14:54:42.153Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ca/01896c80ba921676aa45886b2c5b8d774912de2a1f719de48169c6f755cd/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", size = 88009511, upload-time = "2026-05-13T14:54:47.411Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/04/52bdaf4787eab6ac7d7f5851dff934e4def0bc8ead9c8fd2b69b3e529699/torch-2.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:864392c73b7654f4d2b3ae712f607937d0dbb1101c4555fbb41848106b297f39", size = 426383231, upload-time = "2026-05-13T14:53:32.129Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8a/94bdecd13f5aaa90d45920b89789d9fe7c6f4af8c3cdd7ce01fcb59908fc/torch-2.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5d6b560dfa7d56291c07d615c3bb73e8d9943d9b6d87f76cd0d9d570c4797fa6", size = 532269288, upload-time = "2026-05-13T14:53:49.423Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2f/bdbaaa267de519ef1b73054bf590d8c93c37a266c9a4e24a01bd38b6918f/torch-2.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:3fee918902090ade827643e758e98363278815de583c75d111fdd665ebffde9f", size = 122987706, upload-time = "2026-05-13T14:54:00.335Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ad/e95e822f3538171e22640a7fbe839a1fdb666600bf6487025de2ff03b11a/torch-2.12.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:10ee1448a9f304d3b987eb4656f664ba6e4d7b410ca7a5a7c642199777a2cf88", size = 88319556, upload-time = "2026-05-13T14:54:05.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/07/055d06d985b445d67422d25b033c11cf55bbb81785d4c4e68e28bca5820e/torch-2.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af68dbf403439cae9ceaeaaf92f8352b460787dcd27b92aa05c40dd4a19c0f1e", size = 426397656, upload-time = "2026-05-13T14:52:38.84Z" },
+    { url = "https://files.pythonhosted.org/packages/43/94/b0b4fdc3014122e0a7302fb90086d352aa48f2576f0b252561ebb38c01a8/torch-2.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a6a2eebb237d3b1d9ad3b378e86d9b9e0782afdea8b1e0eba6a13646b9b49c07", size = 532183124, upload-time = "2026-05-13T14:53:16.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/c8/052405e6ad05d3237bfe5a4df78f917773956f8e17813a2d44c059068b74/torch-2.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2140e373e9a51a3e22ef62e8d14366d0b470d18f0adf19fdc757368077133a34", size = 123232462, upload-time = "2026-05-13T14:52:27.26Z" },
+    { url = "https://files.pythonhosted.org/packages/67/dc/ac069f8d6e8be701535921141055293b0d4819d3d7f224a4612cf157c7f9/torch-2.12.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f7dfae4a519197dfa050e98d8e36378a0fb5899625a875c2b54445005a2e404e", size = 88027282, upload-time = "2026-05-13T14:53:05.258Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c3/1c1eb00e34555b536dddf792676026a988d710ed36981aa00499b36b0620/torch-2.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:891c769072637c74e9a5a77a3bc782894696d8ffec83b938df8536dee7f0ba78", size = 426386961, upload-time = "2026-05-13T14:51:28.406Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d4/7e730dba0c7032a4154dc9056b76cf9625515e030e269cfbf8098fcfee7d/torch-2.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e2ad3eb85d39c3cab62dfa93ed5a73516e6a53c6713cb97d004004fe089f0f1f", size = 532272265, upload-time = "2026-05-13T14:51:59.308Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b4/92c80d1bbfee1c0036c06d1d2155a3065bd2423134c83bf8a47e65cd6b9b/torch-2.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:c66696857e987efb8bc1777a37357ec4f60ab5e8af6250b83d6034437fa2d8f3", size = 122987138, upload-time = "2026-05-13T14:51:45.942Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/78/2e12b37ce50a19a037d7bc62d652a5a8f27385a7b05859d6bc9204f20cfe/torch-2.12.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:b4556715c8572758625d62b6e0ae3b1f76c440221913a6fb5e100f321fb4fb02", size = 88320100, upload-time = "2026-05-13T14:51:39.955Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5e/83c450ec7b0bb40a7b74611c1b5440f9260e33c54c90d556fd4a1f0fd955/torch-2.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a43ac605a5e13116c72b64c359644cce0229f213dde48d2ae0ae5eb5becf7feb", size = 426391871, upload-time = "2026-05-13T14:52:14.989Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e9/1a0b575d98d0afedd8f157d23fa3d2759421483660448e60d0a4b10b6daa/torch-2.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6a7512adfdd7f6732e40de1c620831e3c75b39b98cef60b11d0c5f0a76473ec5", size = 532192241, upload-time = "2026-05-13T14:51:07.795Z" },
+    { url = "https://files.pythonhosted.org/packages/88/21/afadd25ecd81b3cea1e11c73cf1ab41a983a50271548c3ec7ec3b9efc3e9/torch-2.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f96b63f8287f66a005dd1b5a6abba2920f11156c5e5c4d815f3e2050fd1aa16", size = 123231092, upload-time = "2026-05-13T14:51:18.854Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/97/dcd1f2a0f8336691bff74abc59b2ed9c69a0c0f8f65cd77109c49e05f068/triton-3.7.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223ac302091491436c248a34ee1e6c47a1026486579103c906ffd805be50cb89", size = 188367104, upload-time = "2026-05-07T19:04:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c0/c2ac4fd2d8809b7579d4a820a0f9e5de62a9bc8a757ed4b3abf4f7ee964a/triton-3.7.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c631b65668d4951213b948a413c0564184305b77bb45cc9d686d3e1ecc4701a3", size = 201313191, upload-time = "2026-05-07T18:45:58.444Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/5d842314bb6c78442cc60437928781701c6050b8d479bc2a1aed691d37ca/triton-3.7.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9e71fc392675fac364e0ecf4ef3f76f85b7f5433a16f4c3c5fe5f05a52c85fe", size = 188480277, upload-time = "2026-05-07T19:05:03.231Z" },
+    { url = "https://files.pythonhosted.org/packages/13/31/8315ea5f8dd18e60970b3022e3a8b93fd37e0b784fbbef86e10c8e6e5ca1/triton-3.7.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22bacffce443f54593dd20f05294d5a40622e0ea9ab632816f87154504356221", size = 201415942, upload-time = "2026-05-07T18:46:06.479Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/13/ec05adfcd87311d532ba61e3af143e8be59fcd26675884c4682841406a20/triton-3.7.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4bf49b00a7a377a68a6da603a876e797614e6455a80e9021669c476a953ad9a", size = 188505104, upload-time = "2026-05-07T19:05:09.843Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7b/468a576e35beef1426e0828e28e9ba9e65f5474d496f16ee126c15646324/triton-3.7.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f111161d49bf903c0eaedde3962353a3d841c08a836839b7cc1025b8426efcf", size = 201457567, upload-time = "2026-05-07T18:46:13.505Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e1/a59a583de59b8f62c495d67c80ee3ea97d09e91ac80c4c6e76456ed8d8ac/triton-3.7.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abdf6beaa89b1bcfb9a43cd990536ce66091a997841a4814b260b7bee4c88c3c", size = 188503209, upload-time = "2026-05-07T19:05:17.935Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b1/b7507bb9815d403927c8dd51d4158ed2e11751a92dbc118a044f247b6848/triton-3.7.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a35d7afe3f3f058e7ec49fcce09794049e0ffc5c59019ac25ec3413741b8c4e7", size = 201453566, upload-time = "2026-05-07T18:46:20.427Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/8f/0bea7a6a0c989315c9135a1d7fb37e41905cfb3a17cbc1f10044ebd4cc3a/triton-3.7.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc1d61c172d257db80ddf42595131fb196ad2e9bdd751e90fe2ef13531734e8b", size = 188612899, upload-time = "2026-05-07T19:05:24.955Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/02/d96f57828d0912aec733b9bc7e0e7dbfd2c6f079a8fa433ac25cb93d1a30/triton-3.7.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70fb9bbdc9f400afc54bbf6eb2670af28829a6ae3996863317964783141daf56", size = 201553816, upload-time = "2026-05-07T18:46:27.49Z" },
+    { url = "https://files.pythonhosted.org/packages/40/fb/82a802dac4689f2a2fb2e69302e6a138eecc3e175bbe976ba3cfc717683a/triton-3.7.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4a44a8476d0d3571eac4e4d1048e1ff75aad81a09ff4602ccfc56c6dea1672e", size = 188507879, upload-time = "2026-05-07T19:05:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/af/9904ec6d3c93d9b24e5ec360445bbdf758b7f00bfbeedb89cb0eb64eb8bb/triton-3.7.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9b85e72968a9d8bba5ddb24e9b64aaabaf48affb042f2755cb7cfa92b7531ce", size = 201460637, upload-time = "2026-05-07T18:46:34.749Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/f9/4835a8ea746b88727d8899f4e3ccce4f9cacb38abfc3bb0a638266c53111/triton-3.7.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18a160de426fd99f92b0baf509045360afbd3bfaa0b4a5171dde800ec9f09684", size = 188608706, upload-time = "2026-05-07T19:05:39.218Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/68/fa86e5a39608000f645535b2c124920126327ab731f8c4fafd5b07ff8d4b/triton-3.7.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce061073102714b725f3660ec6939d94a1da7984b3aa99c921417cae273672f5", size = 201546766, upload-time = "2026-05-07T18:46:42.088Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1763,4 +2299,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "xgboost"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/bb/1eb0242409d22db725d7a88088e6cfd6556829fb0736f9ff69aa9f1e9455/xgboost-3.2.0.tar.gz", hash = "sha256:99b0e9a2a64896cdaf509c5e46372d336c692406646d20f2af505003c0c5d70d", size = 1263936, upload-time = "2026-02-10T11:03:05.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/49/6e4cdd877c24adf56cb3586bc96d93d4dcd780b5ea1efb32e1ee0de08bae/xgboost-3.2.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:2f661966d3e322536d9c448090a870fcba1e32ee5760c10b7c46bac7a342079a", size = 2507014, upload-time = "2026-02-10T10:50:57.44Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f1/c09ef1add609453aa3ba5bafcd0d1c1a805c1263c0b60138ec968f8ec296/xgboost-3.2.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:eabbd40d474b8dbf6cb3536325f9150b9e6f0db32d18de9914fb3227d0bef5b7", size = 2328527, upload-time = "2026-02-10T10:51:17.502Z" },
+    { url = "https://files.pythonhosted.org/packages/96/9f/d9914a7b8df842832850b1a18e5f47aaa071c217cdd1da2ae9deb291018b/xgboost-3.2.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:852eabc6d3b3702a59bf78dbfdcd1cb9c4d3a3b6e5ed1f8781d8b9512354fdd2", size = 131100954, upload-time = "2026-02-10T11:02:42.704Z" },
+    { url = "https://files.pythonhosted.org/packages/79/98/679de17c2caa4fd3b0b4386ecf7377301702cb0afb22930a07c142fcb1d8/xgboost-3.2.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:99b4a6bbcb47212fec5cf5fbe12347215f073c08967431b0122cfbd1ee70312c", size = 131748579, upload-time = "2026-02-10T10:54:40.424Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1661dd114a914a67e3f7ab66fa1382e7599c2a8c340f314ad30a3e2b4d08/xgboost-3.2.0-py3-none-win_amd64.whl", hash = "sha256:0d169736fd836fc13646c7ab787167b3a8110351c2c6bc770c755ee1618f0442", size = 101681668, upload-time = "2026-02-10T10:59:31.202Z" },
 ]


### PR DESCRIPTION
## Related Issue
Closes #72 

## Overview
To expand the capabilities of the surrogate model, we will add an adapter that allows the use of models from other libraries.
In addition, we will add a subclass of `Surrogate` to manage different surrogate models for each objective function.

## Changes
- Add `SklearnSurrogate` class: adapter for any scikit-learn-compatible estimator
- Add `SVMSurrogate`, `DTSurrogate`, `NNSurrogate`, `XGBSurrogate`, `LGBMSurrogate`
- Add `TorchSurrogate` class: adapter for `torch.nn.Module`
- Add `PerObjectiveSurrogate` class a compositor that dispatches a dedicated surrogate to each objective column

## Verification Steps
- [ ] `tests/test_sklearn_surrogate.py`
- [ ] `tests/test_torch_surrogate.py`
- [ ] `tests/test_per_objective.py` 
