### PR TITLE
feat: [#78] Implement Gaussian Process surrogate (uncertainty estimation)

### DIFF
--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -102,6 +102,7 @@ from saealib.surrogate.prediction import SurrogatePrediction
 from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
 from saealib.surrogate.sklearn_surrogate import (
     DTSurrogate,
+    GPSurrogate,
     LGBMSurrogate,
     NNSurrogate,
     SklearnSurrogate,
@@ -136,6 +137,7 @@ __all__ = [
     "EnsembleSurrogateManager",
     "Event",
     "ExpectedImprovement",
+    "GPSurrogate",
     "GenerationBasedStrategy",
     "GenerationEndEvent",
     "GenerationStartEvent",

--- a/src/saealib/surrogate/sklearn_surrogate.py
+++ b/src/saealib/surrogate/sklearn_surrogate.py
@@ -146,6 +146,59 @@ class DTSurrogate(SklearnSurrogate):
         super().__init__(RandomForestRegressor(**kwargs))
 
 
+class GPSurrogate(SklearnSurrogate):
+    """
+    Gaussian Process Regressor surrogate.
+
+    Convenience wrapper around ``SklearnSurrogate`` using
+    ``sklearn.gaussian_process.GaussianProcessRegressor``.
+    Provides uncertainty estimates via ``SurrogatePrediction.std``,
+    enabling compatibility with acquisition functions such as EI, LCB,
+    PoF, and MaxUncertainty.
+
+    Parameters
+    ----------
+    **kwargs
+        Keyword arguments forwarded to
+        ``sklearn.gaussian_process.GaussianProcessRegressor``
+        (e.g. ``kernel``, ``alpha``, ``n_restarts_optimizer``).
+    """
+
+    provides_uncertainty: bool = True
+
+    def __init__(self, **kwargs: object) -> None:
+        from sklearn.gaussian_process import GaussianProcessRegressor
+
+        super().__init__(GaussianProcessRegressor(**kwargs))
+
+    def predict(self, test_x: np.ndarray) -> SurrogatePrediction:
+        """
+        Predict mean and standard deviation using the GP models.
+
+        Parameters
+        ----------
+        test_x : np.ndarray
+            Input data. shape: (n_samples, n_features) or (n_features,)
+
+        Returns
+        -------
+        SurrogatePrediction
+            prediction.value shape: (n_samples, n_obj)
+            prediction.std  shape: (n_samples, n_obj)
+        """
+        test = np.asarray(test_x)
+        if test.ndim == 1:
+            test = test.reshape(1, -1)
+        means, stds = [], []
+        for m in self._models:
+            mu, sigma = m.predict(test, return_std=True)
+            means.append(mu)
+            stds.append(sigma)
+        value = np.column_stack(means)
+        std = np.column_stack(stds)
+        return SurrogatePrediction(value=value, std=std)
+
+
 class XGBSurrogate(SklearnSurrogate):
     """
     XGBoost surrogate.

--- a/tests/test_gp_surrogate.py
+++ b/tests/test_gp_surrogate.py
@@ -1,0 +1,208 @@
+"""
+Tests for GPSurrogate.
+
+Covers:
+- GPSurrogate: fit/predict, single/multi-objective, std population
+- provides_uncertainty flag
+- Custom kernel
+- Integration with EI, LCB, MaxUncertainty, PoF acquisition functions
+- Integration with GlobalSurrogateManager
+"""
+
+import numpy as np
+import pytest
+
+from saealib.acquisition import (
+    ExpectedImprovement,
+    LowerConfidenceBound,
+    MaxUncertainty,
+    ProbabilityOfFeasibility,
+)
+from saealib.population import Archive, PopulationAttribute
+from saealib.surrogate.manager import GlobalSurrogateManager
+from saealib.surrogate.prediction import SurrogatePrediction
+from saealib.surrogate.sklearn_surrogate import GPSurrogate
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+DIM = 2
+N_SAMPLES = 20
+
+
+@pytest.fixture
+def train_data_1obj():
+    rng = np.random.default_rng(0)
+    X = rng.uniform(-2.0, 2.0, size=(N_SAMPLES, DIM))
+    y = np.sum(X**2, axis=1)
+    return X, y
+
+
+@pytest.fixture
+def train_data_2obj():
+    rng = np.random.default_rng(1)
+    X = rng.uniform(0.0, 2.0, size=(N_SAMPLES, DIM))
+    y = np.column_stack([np.sum(X**2, axis=1), np.sum((X - 2.0) ** 2, axis=1)])
+    return X, y
+
+
+@pytest.fixture
+def test_x():
+    rng = np.random.default_rng(7)
+    return rng.uniform(-1.0, 1.0, size=(5, DIM))
+
+
+@pytest.fixture
+def fitted_gp(train_data_1obj):
+    X, y = train_data_1obj
+    gp = GPSurrogate()
+    gp.fit(X, y)
+    return gp
+
+
+@pytest.fixture
+def archive_1obj():
+    attrs = [
+        PopulationAttribute(name="x", dtype=np.float64, shape=(DIM,)),
+        PopulationAttribute(name="f", dtype=np.float64, shape=(1,)),
+    ]
+    arc = Archive(attrs, init_capacity=30)
+    rng = np.random.default_rng(42)
+    for _ in range(N_SAMPLES):
+        x = rng.uniform(-2.0, 2.0, size=DIM)
+        f = np.array([np.sum(x**2)])
+        arc.add(x=x, f=f)
+    return arc
+
+
+@pytest.fixture
+def candidates():
+    rng = np.random.default_rng(7)
+    return rng.uniform(-1.0, 1.0, size=(5, DIM))
+
+
+# ===========================================================================
+# GPSurrogate Tests
+# ===========================================================================
+class TestGPSurrogate:
+    def test_fit_predict_1obj(self, train_data_1obj, test_x) -> None:
+        X, y = train_data_1obj
+        gp = GPSurrogate()
+        gp.fit(X, y)
+        pred = gp.predict(test_x)
+        assert isinstance(pred, SurrogatePrediction)
+        assert pred.value.shape == (5, 1)
+
+    def test_fit_predict_2obj(self, train_data_2obj, test_x) -> None:
+        X, y = train_data_2obj
+        gp = GPSurrogate()
+        gp.fit(X, y)
+        pred = gp.predict(test_x)
+        assert pred.value.shape == (5, 2)
+
+    def test_predict_1d_input(self, fitted_gp, train_data_1obj) -> None:
+        X, _ = train_data_1obj
+        pred = fitted_gp.predict(X[0])
+        assert pred.value.shape == (1, 1)
+
+    def test_std_populated(self, fitted_gp, test_x) -> None:
+        pred = fitted_gp.predict(test_x)
+        assert pred.std is not None
+
+    def test_std_shape_matches_value(self, fitted_gp, test_x) -> None:
+        pred = fitted_gp.predict(test_x)
+        assert pred.std.shape == pred.value.shape
+
+    def test_std_shape_2obj(self, train_data_2obj, test_x) -> None:
+        X, y = train_data_2obj
+        gp = GPSurrogate()
+        gp.fit(X, y)
+        pred = gp.predict(test_x)
+        assert pred.std.shape == (5, 2)
+
+    def test_std_nonnegative(self, fitted_gp, test_x) -> None:
+        pred = fitted_gp.predict(test_x)
+        assert np.all(pred.std >= 0.0)
+
+    def test_provides_uncertainty_class_attribute(self) -> None:
+        assert GPSurrogate.provides_uncertainty is True
+
+    def test_has_uncertainty_true(self, fitted_gp, test_x) -> None:
+        pred = fitted_gp.predict(test_x)
+        assert pred.has_uncertainty is True
+
+    def test_custom_kernel(self, train_data_1obj, test_x) -> None:
+        from sklearn.gaussian_process.kernels import Matern
+
+        X, y = train_data_1obj
+        gp = GPSurrogate(kernel=Matern(nu=2.5))
+        gp.fit(X, y)
+        pred = gp.predict(test_x)
+        assert pred.value.shape == (5, 1)
+        assert pred.std is not None
+
+    def test_refit_different_nobj(self, train_data_1obj, train_data_2obj, test_x) -> None:
+        X1, y1 = train_data_1obj
+        X2, y2 = train_data_2obj
+        gp = GPSurrogate()
+        gp.fit(X1, y1)
+        gp.fit(X2, y2)
+        pred = gp.predict(test_x)
+        assert pred.value.shape == (5, 2)
+        assert pred.std.shape == (5, 2)
+
+    def test_models_are_cloned_per_objective(self, train_data_2obj) -> None:
+        X, y = train_data_2obj
+        gp = GPSurrogate()
+        gp.fit(X, y)
+        assert gp._models[0] is not gp._models[1]
+
+
+# ===========================================================================
+# GPSurrogate + Acquisition Function Integration Tests
+# ===========================================================================
+class TestGPSurrogateWithAcquisition:
+    def test_ei_integration(self, fitted_gp, test_x) -> None:
+        pred = fitted_gp.predict(test_x)
+        scores = ExpectedImprovement().score(pred, reference=1.0)
+        assert scores.shape == (5,)
+        assert np.all(scores >= 0.0)
+
+    def test_lcb_integration(self, fitted_gp, test_x) -> None:
+        pred = fitted_gp.predict(test_x)
+        scores = LowerConfidenceBound().score(pred, reference=None)
+        assert scores.shape == (5,)
+
+    def test_max_uncertainty_integration(self, fitted_gp, test_x) -> None:
+        pred = fitted_gp.predict(test_x)
+        scores = MaxUncertainty().score(pred, reference=None)
+        assert scores.shape == (5,)
+        assert np.all(scores >= 0.0)
+
+    def test_pof_integration(self, fitted_gp, test_x) -> None:
+        pred = fitted_gp.predict(test_x)
+        scores = ProbabilityOfFeasibility().score(pred, reference=None)
+        assert scores.shape == (5,)
+        assert np.all(scores >= 0.0)
+        assert np.all(scores <= 1.0)
+
+
+# ===========================================================================
+# Integration: GlobalSurrogateManager
+# ===========================================================================
+class TestGPSurrogateManager:
+    def test_global_manager_ei(self, archive_1obj, candidates) -> None:
+        manager = GlobalSurrogateManager(GPSurrogate(), ExpectedImprovement())
+        scores, preds = manager.score_candidates(candidates, archive_1obj)
+        assert scores.shape == (len(candidates),)
+        assert np.all(scores >= 0.0)
+
+    def test_global_manager_lcb(self, archive_1obj, candidates) -> None:
+        manager = GlobalSurrogateManager(GPSurrogate(), LowerConfidenceBound())
+        scores, _ = manager.score_candidates(candidates, archive_1obj)
+        assert scores.shape == (len(candidates),)
+
+    def test_global_manager_max_uncertainty(self, archive_1obj, candidates) -> None:
+        manager = GlobalSurrogateManager(GPSurrogate(), MaxUncertainty())
+        scores, _ = manager.score_candidates(candidates, archive_1obj)
+        assert scores.shape == (len(candidates),)

--- a/tests/test_gp_surrogate.py
+++ b/tests/test_gp_surrogate.py
@@ -141,7 +141,9 @@ class TestGPSurrogate:
         assert pred.value.shape == (5, 1)
         assert pred.std is not None
 
-    def test_refit_different_nobj(self, train_data_1obj, train_data_2obj, test_x) -> None:
+    def test_refit_different_nobj(
+        self, train_data_1obj, train_data_2obj, test_x
+    ) -> None:
         X1, y1 = train_data_1obj
         X2, y2 = train_data_2obj
         gp = GPSurrogate()
@@ -196,6 +198,9 @@ class TestGPSurrogateManager:
         scores, preds = manager.score_candidates(candidates, archive_1obj)
         assert scores.shape == (len(candidates),)
         assert np.all(scores >= 0.0)
+        assert len(preds) == len(candidates)
+        for p in preds:
+            assert p.std is not None
 
     def test_global_manager_lcb(self, archive_1obj, candidates) -> None:
         manager = GlobalSurrogateManager(GPSurrogate(), LowerConfidenceBound())


### PR DESCRIPTION
## Related Issue
Closes #78

## Overview
To expand the Surrogate model, we have implemented a GPR that returns uncertainty.
The implementation inherits from the `SklearnSurrogate` adapter in scikit-learn.

## Changes
- Add `GPSurrogate` class and tests

## Verification Steps
`pytest tests/test_gp_surrogate.py`
