### PR TITLE
refactor: [#92] Separate Problem.eps into eps_cv and eps_obj

### DIFF
--- a/src/saealib/api.py
+++ b/src/saealib/api.py
@@ -161,7 +161,7 @@ def _build_result(ctx: OptimizationContext) -> Result:
     archive_f = ctx.archive.get_array("f")
     archive_cv = ctx.archive.get_array("cv")
     weight = ctx.problem.weight
-    eps = ctx.problem.eps
+    eps = ctx.problem.eps_cv
 
     feasible = np.where(archive_cv <= eps)[0]
     pool = feasible if len(feasible) else np.array([int(np.argmin(archive_cv))])

--- a/src/saealib/comparators.py
+++ b/src/saealib/comparators.py
@@ -7,6 +7,7 @@ for ranking and comparing solutions in single- and multi-objective optimization.
 
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
@@ -24,14 +25,28 @@ class Comparator(ABC):
     ----------
     weights : np.ndarray
         Weights for objectives. shape = (n_obj, )
-    eps : float
-        Epsilon value for comparison tolerance.
+    eps_cv : float
+        Epsilon for constraint violation feasibility threshold.
+    eps_obj : float
+        Epsilon for objective value equality comparison.
     """
 
     @abstractmethod
-    def __init__(self, weights: np.ndarray, eps: float):
+    def __init__(self, weights: np.ndarray, eps_cv: float, eps_obj: float):
         self.weights = weights
-        self.eps = eps
+        self.eps_cv = eps_cv
+        self.eps_obj = eps_obj
+
+    @property
+    def eps(self) -> float:
+        """Deprecated. Use eps_cv or eps_obj."""
+        warnings.warn(
+            "Comparator.eps is deprecated and will be removed in 0.1.0. "
+            "Use eps_cv or eps_obj.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.eps_cv
 
     @abstractmethod
     def sort_population(self, population: Population) -> np.ndarray:
@@ -104,8 +119,23 @@ class Comparator(ABC):
 class SingleObjectiveComparator(Comparator):
     """Comparator for single-objective optimization."""
 
-    def __init__(self, weight: float = 1.0, eps: float = 1e-6):
-        super().__init__(np.array([weight]), eps)
+    def __init__(
+        self,
+        weight: float = 1.0,
+        eps: float | None = None,
+        *,
+        eps_cv: float = 1e-6,
+        eps_obj: float = 1e-6,
+    ):
+        if eps is not None:
+            warnings.warn(
+                "SingleObjectiveComparator(eps=...) is deprecated and will be removed in 0.1.0. "
+                "Use eps_cv and eps_obj.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            eps_cv = eps_obj = eps
+        super().__init__(np.array([weight]), eps_cv, eps_obj)
 
     def sort_population(self, population: Population) -> np.ndarray:
         """
@@ -139,21 +169,21 @@ class SingleObjectiveComparator(Comparator):
         self, fitness_a: np.ndarray, cv_a: float, fitness_b: np.ndarray, cv_b: float
     ) -> int:
         """Constraint-domination comparison; -1=a better, 1=b better, 0=equal."""
-        if cv_a > self.eps and cv_b > self.eps:
+        if cv_a > self.eps_cv and cv_b > self.eps_cv:
             if cv_a < cv_b:
                 return -1
             elif cv_a > cv_b:
                 return 1
             else:
                 return 0
-        elif cv_a > self.eps and cv_b <= self.eps:
+        elif cv_a > self.eps_cv and cv_b <= self.eps_cv:
             return 1
-        elif cv_a <= self.eps and cv_b > self.eps:
+        elif cv_a <= self.eps_cv and cv_b > self.eps_cv:
             return -1
         else:
-            if fitness_a[0] < fitness_b[0] - self.eps:
+            if fitness_a[0] < fitness_b[0] - self.eps_obj:
                 return -1
-            elif fitness_a[0] > fitness_b[0] + self.eps:
+            elif fitness_a[0] > fitness_b[0] + self.eps_obj:
                 return 1
             else:
                 return 0
@@ -174,7 +204,7 @@ class SingleObjectiveComparator(Comparator):
         np.ndarray
             Sorted indices of the solutions.
         """
-        cv_key = np.where(cv > self.eps, cv, 0)
+        cv_key = np.where(cv > self.eps_cv, cv, 0)
         obj_key = fitness.flatten() * self.weights[0]
         return np.lexsort((-obj_key, cv_key))
 
@@ -198,15 +228,30 @@ class WeightedSumComparator(Comparator):
         Epsilon tolerance for constraint violation and fitness comparison.
     """
 
-    def __init__(self, weights: np.ndarray, eps: float = 1e-6):
-        super().__init__(np.asarray(weights, dtype=float), eps)
+    def __init__(
+        self,
+        weights: np.ndarray,
+        eps: float | None = None,
+        *,
+        eps_cv: float = 1e-6,
+        eps_obj: float = 1e-6,
+    ):
+        if eps is not None:
+            warnings.warn(
+                "WeightedSumComparator(eps=...) is deprecated and will be removed in 0.1.0. "
+                "Use eps_cv and eps_obj.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            eps_cv = eps_obj = eps
+        super().__init__(np.asarray(weights, dtype=float), eps_cv, eps_obj)
 
     def sort_population(self, population: Population) -> np.ndarray:
         """Sort population by weighted sum of objectives, with feasibility first."""
         f = population.get("f")  # (n_ind, n_obj)
         cv = population.get("cv")  # (n_ind,)
         scalar = f @ self.weights  # (n_ind,) weighted sum per individual
-        cv_key = np.where(cv > self.eps, cv, 0)
+        cv_key = np.where(cv > self.eps_cv, cv, 0)
         return np.lexsort((-scalar, cv_key))
 
     def compare_population(self, population: Population, idx_a: int, idx_b: int) -> int:
@@ -220,22 +265,22 @@ class WeightedSumComparator(Comparator):
         return self._compare(fa, cv_a, fb, cv_b)
 
     def _compare(self, fa: np.ndarray, cv_a: float, fb: np.ndarray, cv_b: float) -> int:
-        if cv_a > self.eps and cv_b > self.eps:
+        if cv_a > self.eps_cv and cv_b > self.eps_cv:
             if cv_a < cv_b:
                 return -1
             elif cv_a > cv_b:
                 return 1
             else:
                 return 0
-        elif cv_a > self.eps:
+        elif cv_a > self.eps_cv:
             return 1
-        elif cv_b > self.eps:
+        elif cv_b > self.eps_cv:
             return -1
         sa = float(np.dot(fa, self.weights))
         sb = float(np.dot(fb, self.weights))
-        if sa > sb + self.eps:
+        if sa > sb + self.eps_obj:
             return -1
-        elif sa < sb - self.eps:
+        elif sa < sb - self.eps_obj:
             return 1
         return 0
 
@@ -418,16 +463,31 @@ class ParetoComparator(Comparator):
         Epsilon tolerance for constraint violation.
     """
 
-    def __init__(self, weights: np.ndarray | None = None, eps: float = 1e-6):
+    def __init__(
+        self,
+        weights: np.ndarray | None = None,
+        eps: float | None = None,
+        *,
+        eps_cv: float = 1e-6,
+        eps_obj: float = 1e-6,
+    ):
+        if eps is not None:
+            warnings.warn(
+                "ParetoComparator(eps=...) is deprecated and will be removed in 0.1.0. "
+                "Use eps_cv.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            eps_cv = eps
         w = np.asarray(weights, dtype=float) if weights is not None else np.empty(0)
-        super().__init__(w, eps)
+        super().__init__(w, eps_cv, eps_obj)
 
     def sort_population(self, population: Population) -> np.ndarray:
         """Sort by Pareto front rank; infeasible individuals come last."""
         f = population.get("f")
         cv = population.get("cv")
-        feasible = np.where(cv <= self.eps)[0]
-        infeasible = np.where(cv > self.eps)[0]
+        feasible = np.where(cv <= self.eps_cv)[0]
+        infeasible = np.where(cv > self.eps_cv)[0]
 
         sorted_feasible = np.empty(0, int)
         if len(feasible):
@@ -449,15 +509,15 @@ class ParetoComparator(Comparator):
 
     def compare(self, fa: np.ndarray, cv_a: float, fb: np.ndarray, cv_b: float) -> int:
         """Compare two solutions directly without a Population object."""
-        if cv_a > self.eps and cv_b > self.eps:
+        if cv_a > self.eps_cv and cv_b > self.eps_cv:
             if cv_a < cv_b:
                 return -1
             elif cv_a > cv_b:
                 return 1
             return 0
-        elif cv_a > self.eps:
+        elif cv_a > self.eps_cv:
             return 1
-        elif cv_b > self.eps:
+        elif cv_b > self.eps_cv:
             return -1
 
         if _pareto_dominates(fa, fb):
@@ -489,8 +549,23 @@ class NSGA2Comparator(ParetoComparator):
         Epsilon tolerance for constraint violation.
     """
 
-    def __init__(self, weights: np.ndarray | None = None, eps: float = 1e-6):
-        super().__init__(weights, eps)
+    def __init__(
+        self,
+        weights: np.ndarray | None = None,
+        eps: float | None = None,
+        *,
+        eps_cv: float = 1e-6,
+        eps_obj: float = 1e-6,
+    ):
+        if eps is not None:
+            warnings.warn(
+                "NSGA2Comparator(eps=...) is deprecated and will be removed in 0.1.0. "
+                "Use eps_cv.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            eps_cv = eps
+        super().__init__(weights, eps_cv=eps_cv, eps_obj=eps_obj)
 
     def sort_population(self, population: Population) -> np.ndarray:
         """Sort by Pareto front rank then crowding distance (NSGA-II style)."""
@@ -500,8 +575,8 @@ class NSGA2Comparator(ParetoComparator):
 
         f = population.get("f")  # (n, n_obj)
         cv = population.get("cv")  # (n,)
-        feasible = np.where(cv <= self.eps)[0]
-        infeasible = np.where(cv > self.eps)[0]
+        feasible = np.where(cv <= self.eps_cv)[0]
+        infeasible = np.where(cv > self.eps_cv)[0]
 
         sorted_feasible = np.empty(0, int)
         if len(feasible):

--- a/src/saealib/comparators.py
+++ b/src/saealib/comparators.py
@@ -129,8 +129,8 @@ class SingleObjectiveComparator(Comparator):
     ):
         if eps is not None:
             warnings.warn(
-                "SingleObjectiveComparator(eps=...) is deprecated and will be removed in 0.1.0. "
-                "Use eps_cv and eps_obj.",
+                "SingleObjectiveComparator(eps=...) is deprecated"
+                " and will be removed in 0.1.0. Use eps_cv and eps_obj.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -238,8 +238,8 @@ class WeightedSumComparator(Comparator):
     ):
         if eps is not None:
             warnings.warn(
-                "WeightedSumComparator(eps=...) is deprecated and will be removed in 0.1.0. "
-                "Use eps_cv and eps_obj.",
+                "WeightedSumComparator(eps=...) is deprecated"
+                " and will be removed in 0.1.0. Use eps_cv and eps_obj.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/saealib/problem.py
+++ b/src/saealib/problem.py
@@ -139,9 +139,13 @@ class Problem:
         if comparator is not None:
             self.comparator = comparator
         elif n_obj == 1:
-            self.comparator = SingleObjectiveComparator(weight=weight, eps_cv=eps_cv, eps_obj=eps_obj)
+            self.comparator = SingleObjectiveComparator(
+                weight=weight, eps_cv=eps_cv, eps_obj=eps_obj
+            )
         else:
-            self.comparator = NSGA2Comparator(weights=weight, eps_cv=eps_cv, eps_obj=eps_obj)
+            self.comparator = NSGA2Comparator(
+                weights=weight, eps_cv=eps_cv, eps_obj=eps_obj
+            )
 
     @property
     def eps(self) -> float:

--- a/src/saealib/problem.py
+++ b/src/saealib/problem.py
@@ -7,6 +7,8 @@ Comparator classes and Pareto-related utilities are in saealib.comparators.
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 
 from saealib.comparators import (
@@ -59,8 +61,10 @@ class Problem:
         Upper bounds for design variables. shape = (dim, )
     comparator : Comparator
         Comparator instance to compare solutions.
-    eps : float
-        Epsilon value for comparison (Comparator use).
+    eps_cv : float
+        Epsilon for constraint violation feasibility threshold.
+    eps_obj : float
+        Epsilon for objective value equality comparison.
     func : callable -> float
         Objective function to evaluate solutions.
     constraints : list[Constraint]
@@ -75,9 +79,12 @@ class Problem:
         weight: np.ndarray,
         lb: list[float],
         ub: list[float],
-        eps: float = 1e-6,
+        eps: float | None = None,
         comparator: Comparator | None = None,
         constraints: list[Constraint] | None = None,
+        *,
+        eps_cv: float = 1e-6,
+        eps_obj: float = 1e-6,
     ):
         """
         Initialize Problem instance.
@@ -99,18 +106,31 @@ class Problem:
         ub : list[float]
             Upper bounds for design variables. length = dim
         eps : float, optional
-            Epsilon value for comparison (Comparator use), by default 1e-6
+            Deprecated. Use eps_cv and eps_obj. Will be removed in 0.1.0.
         comparator : Comparator, optional
             Comparator instance to use. If None, auto-selected based on n_obj:
             n_obj == 1 -> SingleObjectiveComparator,
             n_obj >  1 -> NSGA2Comparator.
         constraints : list[Constraint], optional
             List of inequality constraint definitions. Default: empty list.
+        eps_cv : float, optional
+            Epsilon for constraint violation feasibility threshold. Default: 1e-6.
+        eps_obj : float, optional
+            Epsilon for objective value equality comparison. Default: 1e-6.
         """
+        if eps is not None:
+            warnings.warn(
+                "Problem(eps=...) is deprecated and will be removed in 0.1.0. "
+                "Use eps_cv and eps_obj.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            eps_cv = eps_obj = eps
         self.dim = dim
         self.n_obj = n_obj
         self.weight = weight
-        self.eps = eps
+        self.eps_cv = eps_cv
+        self.eps_obj = eps_obj
         self.lb = np.asarray(lb)
         self.ub = np.asarray(ub)
         self.func = func
@@ -119,9 +139,20 @@ class Problem:
         if comparator is not None:
             self.comparator = comparator
         elif n_obj == 1:
-            self.comparator = SingleObjectiveComparator(weight=weight, eps=eps)
+            self.comparator = SingleObjectiveComparator(weight=weight, eps_cv=eps_cv, eps_obj=eps_obj)
         else:
-            self.comparator = NSGA2Comparator(weights=weight, eps=eps)
+            self.comparator = NSGA2Comparator(weights=weight, eps_cv=eps_cv, eps_obj=eps_obj)
+
+    @property
+    def eps(self) -> float:
+        """Deprecated. Use eps_cv or eps_obj."""
+        warnings.warn(
+            "Problem.eps is deprecated and will be removed in 0.1.0. "
+            "Use eps_cv or eps_obj.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.eps_cv
 
     @property
     def n_constraints(self) -> int:

--- a/src/saealib/surrogate/training_set.py
+++ b/src/saealib/surrogate/training_set.py
@@ -81,7 +81,7 @@ class TrainingSet(ABC):
         population:
             Current population. Not used by all implementations.
         ctx:
-            Optimization context. Provides ``comparator``, ``problem.eps``,
+            Optimization context. Provides ``comparator``, ``problem.eps_cv``,
             etc. Required by ranking- and comparison-based implementations.
         candidate_x:
             Centre point for k-NN queries (shape ``(dim,)``). Passed by
@@ -155,8 +155,8 @@ class KNNObjectiveSet(TrainingSet):
 class FeasibilityClassificationSet(TrainingSet):
     """Binary labels derived from constraint violation: 1 if feasible, 0 otherwise.
 
-    A sample is feasible when ``cv <= eps``, where ``eps`` is taken from
-    ``ctx.problem.eps`` (defaults to ``1e-6`` when ``ctx`` is ``None``).
+    A sample is feasible when ``cv <= eps_cv``, where ``eps_cv`` is taken from
+    ``ctx.problem.eps_cv`` (defaults to ``1e-6`` when ``ctx`` is ``None``).
 
     This set is algo-agnostic and works with any surrogate that accepts binary
     classification targets (shape ``(n_train,)``).
@@ -193,7 +193,7 @@ class FeasibilityClassificationSet(TrainingSet):
             src = population
         else:
             src = archive
-        eps = ctx.problem.eps if ctx is not None else 1e-6
+        eps = ctx.problem.eps_cv if ctx is not None else 1e-6
         labels = (src.get_array("cv") <= eps).astype(float)
         return TrainingData(train_x=src.get_array("x"), train_y=labels)
 

--- a/tests/test_training_set.py
+++ b/tests/test_training_set.py
@@ -34,7 +34,7 @@ _ATTRS = [
 ]
 
 
-def _make_problem(eps: float = 1e-6) -> Problem:
+def _make_problem(eps_cv: float = 1e-6) -> Problem:
     return Problem(
         func=lambda x: np.array([np.sum(x**2)]),
         dim=DIM,
@@ -42,7 +42,7 @@ def _make_problem(eps: float = 1e-6) -> Problem:
         weight=np.array([-1.0]),
         lb=[-5.0] * DIM,
         ub=[5.0] * DIM,
-        eps=eps,
+        eps_cv=eps_cv,
         comparator=SingleObjectiveComparator(),
     )
 
@@ -82,9 +82,9 @@ def _make_population_with_cv(cvs: list[float]) -> Population:
 def _make_ctx(
     archive: Archive | None = None,
     population: Population | None = None,
-    eps: float = 1e-6,
+    eps_cv: float = 1e-6,
 ) -> OptimizationContext:
-    problem = _make_problem(eps=eps)
+    problem = _make_problem(eps_cv=eps_cv)
     arc = archive if archive is not None else _make_archive()
     pop = population if population is not None else _make_population_with_cv([0.0] * 5)
     return OptimizationContext(
@@ -187,7 +187,7 @@ class TestFeasibilityClassificationSet:
     def test_eps_from_ctx(self) -> None:
         """Boundary value: cv == eps is feasible."""
         arc = _make_archive_with_cv([0.1, 0.2, 0.3])
-        ctx = _make_ctx(archive=arc, eps=0.15)
+        ctx = _make_ctx(archive=arc, eps_cv=0.15)
         ts = FeasibilityClassificationSet(source="archive")
         data = ts.build(arc, None, ctx)
         # cv=0.1 <= 0.15 → 1, cv=0.2 > 0.15 → 0, cv=0.3 > 0.15 → 0


### PR DESCRIPTION
## Related Issue
Closes #92 

## Overview
Problem.eps was used for both feasibility checks and the Comparator.
To allow for separate configuration, we will split it into eps_cv and eps_obj.

## Changes
- Separate Problem.eps into eps_cv and eps_obj
- Modified the Comparator to use eps_cv and eps_obj

## Verification Steps
run pytest

## Concerns
Problem.eps and Comparator.eps are scheduled to be removed in version 0.1.0.