### PR TITLE
perf: [#91] Eliminate np.vstack loop in GA.ask (O(N^2) reallocation)

### DIFF
--- a/src/saealib/algorithms/ga.py
+++ b/src/saealib/algorithms/ga.py
@@ -108,13 +108,13 @@ class GA(Algorithm):
         -------
         Population
         """
-        cand = np.empty((0, ctx.dim))
         pop = ctx.population.get_array("x")
         popsize = len(pop)
         target = n_offspring if n_offspring is not None else popsize
         lb = ctx.problem.lb
         ub = ctx.problem.ub
-        n_pair = math.ceil(target / 2)
+        n_children = self.crossover.n_children
+        n_pair = math.ceil(target / n_children)
         parent_idx_m = (
             self.parent_selection.select(
                 ctx,
@@ -125,13 +125,14 @@ class GA(Algorithm):
             )
             % popsize
         )
+        cand = np.empty((n_pair * n_children, ctx.dim))
         for i in range(n_pair):
             parent = pop[parent_idx_m[i]]
             if ctx.rng.random() < self.crossover.crossover_rate:
                 c = self.crossover.crossover(parent, rng=ctx.rng)
             else:
-                c = parent.copy()
-            cand = np.vstack((cand, c))
+                c = parent[:n_children].copy()
+            cand[i * n_children : (i + 1) * n_children] = c
         if self.repair is not None:
             cand = self.repair(cand, (lb, ub))
         post_co = PostCrossoverEvent(ctx=ctx, provider=provider, candidates=cand)

--- a/src/saealib/operators/crossover.py
+++ b/src/saealib/operators/crossover.py
@@ -14,9 +14,14 @@ class Crossover(ABC):
         Number of parents required per crossover call. Default is 2.
         Subclasses may override this class attribute if they require a
         different number of parents.
+    n_children : int
+        Number of offspring produced per crossover call. Default is 2.
+        Subclasses may override this class attribute if they produce a
+        different number of offspring.
     """
 
     n_parents: int = 2
+    n_children: int = 2
 
     @abstractmethod
     def crossover(

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -7,6 +7,7 @@ Tests cover:
 - CrossoverUniform: output shape, swap_rate=0/1 boundary cases
 - CrossoverOnePoint: output shape, segment integrity
 - CrossoverTwoPoint: output shape, segment integrity
+- Crossover (base): n_children default and consistency with output shape
 - MutationPolynomial: output shape, within-bounds, zero-rate
 - MutationGaussian: output shape, zero-rate, zero-sigma
 - RouletteWheelSelection: output shape, probability bias
@@ -220,6 +221,31 @@ class TestCrossoverTwoPoint:
         np.testing.assert_array_equal(c[0, :pt1], p[0, :pt1])
         np.testing.assert_array_equal(c[0, pt1:pt2], p[1, pt1:pt2])
         np.testing.assert_array_equal(c[0, pt2:], p[0, pt2:])
+
+
+# ---------------------------------------------------------------------------
+# Crossover base: n_children
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4),
+        CrossoverSBX(crossover_rate=0.9, eta=2.0),
+        CrossoverUniform(crossover_rate=0.9),
+        CrossoverOnePoint(crossover_rate=0.9),
+        CrossoverTwoPoint(crossover_rate=0.9),
+    ],
+)
+class TestCrossoverNChildren:
+    def test_n_children_default(self, op):
+        assert op.n_children == 2
+
+    def test_output_rows_match_n_children(self, op):
+        rng = np.random.default_rng(0)
+        c = op.crossover(_make_parents(rng), rng=rng)
+        assert c.shape[0] == op.n_children
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related Issue
Closes #91 

## Overview
np.vstack is being called within a loop in GA.ask(). We have modified the code to pre-allocate this.
Also took this opportunity to fix the hard-coded values. Specifically, added Crossover.n_children and replaced the hard-coded "*2" in n_pair.

## Changes- 
- Remove np.vstack in GA.ask()
- Add Crossover.n_children attribute

## Verification Steps
run pytest
