### PR TITLE
refactor: [#93] Unify Pareto comparator sign convention to support maximize

### DIFF
--- a/src/saealib/api.py
+++ b/src/saealib/api.py
@@ -172,7 +172,8 @@ def _build_result(ctx: OptimizationContext) -> Result:
         best_x = archive_x[best_idx]
         best_f = archive_f[best_idx]
     else:
-        _, fronts = non_dominated_sort(archive_f[pool])
+        direction = np.sign(weight)
+        _, fronts = non_dominated_sort(archive_f[pool], direction=direction)
         pareto_idx = pool[fronts[0]]
         best_x = archive_x[pareto_idx]
         best_f = archive_f[pareto_idx]

--- a/src/saealib/comparators.py
+++ b/src/saealib/comparators.py
@@ -290,9 +290,11 @@ class WeightedSumComparator(Comparator):
 # ---------------------------------------------------------------------------
 
 
-def _pareto_dominates(fa: np.ndarray, fb: np.ndarray) -> bool:
+def _pareto_dominates(
+    fa: np.ndarray, fb: np.ndarray, direction: np.ndarray | None = None
+) -> bool:
     """
-    Return True if fa Pareto-dominates fb (minimization).
+    Return True if fa Pareto-dominates fb.
 
     NaN values in fa are treated as non-dominating (returns False).
 
@@ -300,16 +302,23 @@ def _pareto_dominates(fa: np.ndarray, fb: np.ndarray) -> bool:
     ----------
     fa, fb : np.ndarray
         Objective vectors to compare.
+    direction : np.ndarray or None
+        Per-objective optimization direction: +1 = maximize, -1 = minimize.
+        None defaults to minimization for all objectives.
     """
     fa = np.asarray(fa, float)
     fb = np.asarray(fb, float)
     if np.any(np.isnan(fa)):
         return False
+    if direction is not None:
+        fa = fa * (-direction)
+        fb = fb * (-direction)
     return bool(np.all(fa <= fb) and np.any(fa < fb))
 
 
 def non_dominated_sort(
     f: np.ndarray,
+    direction: np.ndarray | None = None,
 ) -> tuple[np.ndarray, list[list[int]]]:
     """
     O(MN^2) non-dominated sorting (Deb et al., 2002).
@@ -320,6 +329,9 @@ def non_dominated_sort(
     ----------
     f : np.ndarray
         Objective matrix. shape: (n, n_obj)
+    direction : np.ndarray or None
+        Per-objective optimization direction: +1 = maximize, -1 = minimize.
+        None defaults to minimization for all objectives.
 
     Returns
     -------
@@ -341,7 +353,7 @@ def non_dominated_sort(
         for j in valid:
             if i == j:
                 continue
-            if _pareto_dominates(f[i], f[j]):
+            if _pareto_dominates(f[i], f[j], direction):
                 dominates_set[i].append(j)
                 dominated_by_count[j] += 1
 
@@ -482,6 +494,12 @@ class ParetoComparator(Comparator):
         w = np.asarray(weights, dtype=float) if weights is not None else np.empty(0)
         super().__init__(w, eps_cv, eps_obj)
 
+    @property
+    def _direction(self) -> np.ndarray | None:
+        if self.weights.size == 0:
+            return None
+        return np.sign(self.weights)
+
     def sort_population(self, population: Population) -> np.ndarray:
         """Sort by Pareto front rank; infeasible individuals come last."""
         f = population.get("f")
@@ -491,7 +509,7 @@ class ParetoComparator(Comparator):
 
         sorted_feasible = np.empty(0, int)
         if len(feasible):
-            ranks, _ = non_dominated_sort(f[feasible])
+            ranks, _ = non_dominated_sort(f[feasible], direction=self._direction)
             order = np.argsort(ranks, kind="stable")
             sorted_feasible = feasible[order]
 
@@ -520,9 +538,10 @@ class ParetoComparator(Comparator):
         elif cv_b > self.eps_cv:
             return -1
 
-        if _pareto_dominates(fa, fb):
+        direction = self._direction
+        if _pareto_dominates(fa, fb, direction):
             return -1
-        if _pareto_dominates(fb, fa):
+        if _pareto_dominates(fb, fa, direction):
             return 1
         return 0
 
@@ -580,7 +599,7 @@ class NSGA2Comparator(ParetoComparator):
 
         sorted_feasible = np.empty(0, int)
         if len(feasible):
-            ranks, fronts = non_dominated_sort(f[feasible])
+            ranks, fronts = non_dominated_sort(f[feasible], direction=self._direction)
             cd = crowding_distance_all_fronts(f[feasible], fronts)
             order = np.lexsort((-cd, ranks))
             sorted_feasible = feasible[order]

--- a/tests/test_moo.py
+++ b/tests/test_moo.py
@@ -378,16 +378,14 @@ class TestParetoComparator:
         comp = ParetoComparator()
         assert comp.compare_population(pop, 0, 1) == -1
 
-    def test_weights_stored_but_not_used(self) -> None:
-        """Weights are stored for interface compatibility but ignored."""
-        f = np.array([[0.0, 1.0], [1.0, 0.0]])
+    def test_weights_direction_affects_ranking(self) -> None:
+        """Weights sign determines optimization direction: negative=minimize, positive=maximize."""
+        f = np.array([[3.0, 3.0], [1.0, 1.0]])
         pop = _make_pop(f)
-        comp_no_w = ParetoComparator()
-        comp_with_w = ParetoComparator(weights=np.array([1.0, 2.0]))
-        np.testing.assert_array_equal(
-            comp_no_w.sort_population(pop),
-            comp_with_w.sort_population(pop),
-        )
+        comp_min = ParetoComparator(weights=np.array([-1.0, -1.0]))
+        comp_max = ParetoComparator(weights=np.array([1.0, 1.0]))
+        assert comp_min.sort_population(pop)[0] == 1  # [1,1] wins under minimization
+        assert comp_max.sort_population(pop)[0] == 0  # [3,3] wins under maximization
 
 
 # ===========================================================================
@@ -473,15 +471,13 @@ class TestNSGA2Comparator:
         order = comp.sort_population(pop)
         assert order.dtype == np.intp or np.issubdtype(order.dtype, np.integer)
 
-    def test_weights_stored_but_not_used_in_sorting(self) -> None:
-        """weights is stored for interface compatibility but ignored in sorting."""
-        f = np.array([[0.0, 1.0], [1.0, 0.0]])
-        pop = _make_pop(f)
-        comp_no_w = NSGA2Comparator()
-        comp_with_w = NSGA2Comparator(weights=np.array([1.0, 2.0]))
-        order_no_w = comp_no_w.sort_population(pop)
-        order_with_w = comp_with_w.sort_population(pop)
-        np.testing.assert_array_equal(order_no_w, order_with_w)
+    def test_weights_direction_affects_sorting(self) -> None:
+        """Weights sign determines optimization direction: negative=minimize, positive=maximize."""
+        f = np.array([[3.0, 3.0], [1.0, 1.0]])
+        comp_min = NSGA2Comparator(weights=np.array([-1.0, -1.0]))
+        comp_max = NSGA2Comparator(weights=np.array([1.0, 1.0]))
+        assert comp_min.sort_population(_make_pop(f))[0] == 1  # [1,1] wins under minimization
+        assert comp_max.sort_population(_make_pop(f))[0] == 0  # [3,3] wins under maximization
 
 
 # ===========================================================================

--- a/tests/test_moo.py
+++ b/tests/test_moo.py
@@ -379,7 +379,7 @@ class TestParetoComparator:
         assert comp.compare_population(pop, 0, 1) == -1
 
     def test_weights_direction_affects_ranking(self) -> None:
-        """Weights sign determines optimization direction: negative=minimize, positive=maximize."""
+        """Weights sign determines optimization direction."""
         f = np.array([[3.0, 3.0], [1.0, 1.0]])
         pop = _make_pop(f)
         comp_min = ParetoComparator(weights=np.array([-1.0, -1.0]))
@@ -472,12 +472,16 @@ class TestNSGA2Comparator:
         assert order.dtype == np.intp or np.issubdtype(order.dtype, np.integer)
 
     def test_weights_direction_affects_sorting(self) -> None:
-        """Weights sign determines optimization direction: negative=minimize, positive=maximize."""
+        """Weights sign determines optimization direction."""
         f = np.array([[3.0, 3.0], [1.0, 1.0]])
         comp_min = NSGA2Comparator(weights=np.array([-1.0, -1.0]))
         comp_max = NSGA2Comparator(weights=np.array([1.0, 1.0]))
-        assert comp_min.sort_population(_make_pop(f))[0] == 1  # [1,1] wins under minimization
-        assert comp_max.sort_population(_make_pop(f))[0] == 0  # [3,3] wins under maximization
+        assert (
+            comp_min.sort_population(_make_pop(f))[0] == 1
+        )  # [1,1] wins under minimization
+        assert (
+            comp_max.sort_population(_make_pop(f))[0] == 0
+        )  # [3,3] wins under maximization
 
 
 # ===========================================================================


### PR DESCRIPTION
## Related Issue
Closes #93 

## Overview
Fixed an issue in the NDS implementation where the _pareto_dominates function was hard-coded during minimization

## Changes
- Add direction parameters to _pareto_dominates

## Verification Steps
run pytest