### PR TITLE
feat: [#85] Introduce Evaluator abstraction and batch evaluation interface

### DIFF
--- a/docs/api/evaluation.md
+++ b/docs/api/evaluation.md
@@ -1,0 +1,11 @@
+# Evaluation
+
+```{eval-rst}
+.. autosummary::
+   :toctree: _autosummary
+   :nosignatures:
+
+   saealib.Evaluator
+   saealib.SerialEvaluator
+   saealib.EvaluationResult
+```

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -13,6 +13,7 @@ surrogate
 acquisition
 strategies
 initialization
+evaluation
 termination
 callbacks
 utils

--- a/docs/tutorials/custom_components.md
+++ b/docs/tutorials/custom_components.md
@@ -176,8 +176,84 @@ print(f"パレートフロント上の解数: {len(fronts[0])}")
 
 ---
 
+## カスタム評価器（Evaluator）の実装
+
+ライブラリ内で真の（高コストな）目的関数評価を行う処理は，すべて `Evaluator` という単一の入口に集約されています．`Evaluator` を継承して `evaluate_batch` を実装すると，並列実行・リモート実行・キャッシュなどの評価バックエンドを，パイプライン本体に手を入れずに差し替えられます．
+
+| 役割 | 内容 |
+|---------|------|
+| `evaluate_batch(x, problem)` | 設計変数のバッチ `x`（shape: `(n, dim)`）を評価し，`EvaluationResult` を返す |
+| `EvaluationResult` | `f`（目的関数値 `(n, n_obj)`）・`g`（生制約値 `(n, n_constraints)`）・`cv`（制約違反量 `(n,)`）を保持する |
+
+デフォルトは候補を逐次評価する `SerialEvaluator` です．
+
+### 実装例: スレッドプールによる並列評価
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+from saealib import Problem
+from saealib.execution.evaluator import EvaluationResult, Evaluator
+
+
+class ParallelEvaluator(Evaluator):
+    """スレッドプールで候補バッチを並列評価する評価器．"""
+
+    def __init__(self, max_workers: int | None = None):
+        self.max_workers = max_workers
+
+    def evaluate_batch(self, x: np.ndarray, problem: Problem) -> EvaluationResult:
+        x = np.atleast_2d(np.asarray(x, dtype=float))
+        n = len(x)
+        f = np.empty((n, problem.n_obj), dtype=float)
+        g = np.empty((n, problem.n_constraints), dtype=float)
+        cv = np.zeros(n, dtype=float)
+
+        def _eval(xi):
+            g_i, cv_i = problem.evaluate_constraints(xi)
+            return problem.evaluate(xi), g_i, cv_i
+
+        with ThreadPoolExecutor(max_workers=self.max_workers) as pool:
+            for i, (f_i, g_i, cv_i) in enumerate(pool.map(_eval, x)):
+                f[i], g[i], cv[i] = f_i, g_i, cv_i
+
+        return EvaluationResult(f=f, g=g, cv=cv)
+```
+
+`Optimizer.set_evaluator()` で差し込みます：
+
+```python
+optimizer.set_evaluator(ParallelEvaluator(max_workers=4))
+```
+
+```{note}
+真の並列性が必要な場合は，`ThreadPoolExecutor` を `ProcessPoolExecutor`・joblib・MPI などに置き換えてください（目的関数が pickle 可能である必要があります）．
+```
+
+### 追加の評価出力を持たせたい場合
+
+評価コスト・勾配・ノイズ推定など，`f` / `g` / `cv` 以外の値を扱いたい場合は，`EvaluationResult` を**継承**して必要なフィールドを追加します．コア最適化ループは基底クラスの `f` / `g` / `cv` のみを参照するため，追加フィールドを持つサブクラスを返しても安全に動作します．
+
+```python
+from dataclasses import dataclass
+
+import numpy as np
+from saealib.execution.evaluator import EvaluationResult
+
+
+@dataclass
+class CostAwareResult(EvaluationResult):
+    cost: np.ndarray  # 各候補の評価コスト. shape: (n,)
+```
+
+追加フィールドは，独自の `SurrogateManager` やコールバックから参照して活用できます．
+
+---
+
 ## 参照
 
 - {py:class}`saealib.AcquisitionFunction` / {py:class}`saealib.SurrogatePrediction`
 - {py:class}`saealib.PostAskEvent` / {py:class}`saealib.PostCrossoverEvent` / {py:class}`saealib.PostMutationEvent`
 - {py:class}`saealib.CallbackManager`
+- {py:class}`saealib.Evaluator` / {py:class}`saealib.SerialEvaluator` / {py:class}`saealib.EvaluationResult`

--- a/examples/sample_custom_evaluator.py
+++ b/examples/sample_custom_evaluator.py
@@ -1,0 +1,118 @@
+"""Custom Evaluator example: parallel batch evaluation.
+
+Demonstrates how to plug a custom Evaluator into the optimizer via
+``Optimizer.set_evaluator()``. The ``ParallelEvaluator`` below evaluates the
+candidate batch concurrently with a thread pool; swap in a process pool,
+joblib, or an MPI backend for true parallelism with picklable objectives.
+"""
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+from opfunu.cec_based import cec2015
+
+from saealib import (
+    GA,
+    CrossoverBLXAlpha,
+    IndividualBasedStrategy,
+    LHSInitializer,
+    MutationUniform,
+    Optimizer,
+    Problem,
+    RBFsurrogate,
+    SequentialSelection,
+    Termination,
+    TruncationSelection,
+    gaussian_kernel,
+    max_fe,
+)
+from saealib.execution.evaluator import EvaluationResult, Evaluator
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger("saealib.surrogate.rbf").setLevel(logging.CRITICAL)
+
+
+class ParallelEvaluator(Evaluator):
+    """Evaluate a batch of candidates concurrently with a thread pool.
+
+    Parameters
+    ----------
+    max_workers : int or None
+        Maximum number of worker threads. None lets the executor choose.
+    """
+
+    def __init__(self, max_workers: int | None = None):
+        self.max_workers = max_workers
+
+    def evaluate_batch(self, x: np.ndarray, problem: Problem) -> EvaluationResult:
+        """Evaluate every row of ``x`` in parallel, preserving input order."""
+        x = np.atleast_2d(np.asarray(x, dtype=float))
+        n = len(x)
+        f = np.empty((n, problem.n_obj), dtype=float)
+        g = np.empty((n, problem.n_constraints), dtype=float)
+        cv = np.zeros(n, dtype=float)
+
+        def _eval(xi: np.ndarray) -> tuple[np.ndarray, np.ndarray, float]:
+            g_i, cv_i = problem.evaluate_constraints(xi)
+            return problem.evaluate(xi), g_i, cv_i
+
+        with ThreadPoolExecutor(max_workers=self.max_workers) as pool:
+            for i, (f_i, g_i, cv_i) in enumerate(pool.map(_eval, x)):
+                f[i] = f_i
+                g[i] = g_i
+                cv[i] = cv_i
+
+        return EvaluationResult(f=f, g=g, cv=cv)
+
+
+def main():
+    """Run SAGA-RBF optimization with a custom parallel evaluator."""
+    # parameters
+    dim = 10
+    seed = 1
+    knn = 50
+    rsm = 0.1
+    ub = [100] * dim
+    lb = [-100] * dim
+
+    # benchmark function
+    f1 = cec2015.F12015(ndim=10)
+
+    problem = Problem(
+        func=f1.evaluate,
+        dim=dim,
+        n_obj=1,
+        weight=np.array([-1.0]),
+        lb=lb,
+        ub=ub,
+    )
+    initializer = LHSInitializer(
+        n_init_archive=5 * dim,
+        n_init_population=4 * dim,
+        seed=seed,
+    )
+    algorithm = GA(
+        crossover=CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4),
+        mutation=MutationUniform(mutation_rate=0.3),
+        parent_selection=SequentialSelection(),
+        survivor_selection=TruncationSelection(),
+    )
+    termination = Termination(max_fe(200 * dim))
+    surrogate = RBFsurrogate(gaussian_kernel, dim)
+    strategy = IndividualBasedStrategy(evaluation_ratio=rsm)
+
+    opt = (
+        Optimizer(problem)
+        .set_initializer(initializer)
+        .set_algorithm(algorithm)
+        .set_termination(termination)
+        .set_surrogate(surrogate, n_neighbors=knn)
+        .set_strategy(strategy)
+        .set_evaluator(ParallelEvaluator(max_workers=4))
+    )
+    opt.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -44,6 +44,11 @@ from saealib.comparators import (
     crowding_distance_all_fronts,
     non_dominated_sort,
 )
+from saealib.execution.evaluator import (
+    EvaluationResult,
+    Evaluator,
+    SerialEvaluator,
+)
 from saealib.execution.initializer import Initializer, LHSInitializer
 from saealib.operators.crossover import (
     Crossover,
@@ -135,6 +140,8 @@ __all__ = [
     "DTSurrogate",
     "DensityManager",
     "EnsembleSurrogateManager",
+    "EvaluationResult",
+    "Evaluator",
     "Event",
     "ExpectedImprovement",
     "GPSurrogate",
@@ -182,6 +189,7 @@ __all__ = [
     "RunStartEvent",
     "SVMSurrogate",
     "SequentialSelection",
+    "SerialEvaluator",
     "SingleObjectiveComparator",
     "SklearnSurrogate",
     "Surrogate",

--- a/src/saealib/execution/evaluator.py
+++ b/src/saealib/execution/evaluator.py
@@ -1,0 +1,104 @@
+"""
+Evaluator abstraction.
+
+An ``Evaluator`` is the single entry point through which Strategies and
+Initializers turn a batch of design vectors into objective values, raw
+constraint values, and aggregate constraint violations. Centralizing
+evaluation here enables pluggable execution backends (serial, parallel, ...)
+without touching the pipeline code.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from saealib.problem import Problem
+
+
+@dataclass
+class EvaluationResult:
+    """
+    Batched result of evaluating a set of design vectors.
+
+    Attributes
+    ----------
+    f : np.ndarray
+        Objective values. shape = (n, n_obj)
+    g : np.ndarray
+        Raw constraint values. shape = (n, n_constraints).
+        Has shape (n, 0) when the problem defines no constraints.
+    cv : np.ndarray
+        Aggregate constraint violation per candidate. shape = (n, )
+        All zeros when the problem defines no constraints.
+    """
+
+    f: np.ndarray
+    g: np.ndarray
+    cv: np.ndarray
+
+
+class Evaluator(ABC):
+    """Base class for batch evaluators."""
+
+    @abstractmethod
+    def evaluate_batch(self, x: np.ndarray, problem: Problem) -> EvaluationResult:
+        """
+        Evaluate a batch of design vectors.
+
+        Parameters
+        ----------
+        x : np.ndarray
+            Design vectors to evaluate. shape = (n, dim)
+        problem : Problem
+            The optimization problem providing the objective and constraints.
+
+        Returns
+        -------
+        EvaluationResult
+            Batched objective values, raw constraint values, and violations.
+        """
+        ...
+
+
+class SerialEvaluator(Evaluator):
+    """Default evaluator: evaluates each candidate sequentially."""
+
+    def evaluate_batch(self, x: np.ndarray, problem: Problem) -> EvaluationResult:
+        """
+        Evaluate each row of ``x`` one at a time.
+
+        Produces results equivalent to the per-candidate evaluation loops that
+        previously lived in each Strategy and Initializer.
+
+        Parameters
+        ----------
+        x : np.ndarray
+            Design vectors to evaluate. shape = (n, dim)
+        problem : Problem
+            The optimization problem providing the objective and constraints.
+
+        Returns
+        -------
+        EvaluationResult
+            Batched objective values, raw constraint values, and violations.
+        """
+        x = np.atleast_2d(np.asarray(x, dtype=float))
+        n = len(x)
+        n_constraints = problem.n_constraints
+
+        f = np.empty((n, problem.n_obj), dtype=float)
+        g = np.empty((n, n_constraints), dtype=float)
+        cv = np.zeros(n, dtype=float)
+
+        for i, xi in enumerate(x):
+            f[i] = problem.evaluate(xi)
+            g_i, cv_i = problem.evaluate_constraints(xi)
+            g[i] = g_i
+            cv[i] = cv_i
+
+        return EvaluationResult(f=f, g=g, cv=cv)

--- a/src/saealib/execution/initializer.py
+++ b/src/saealib/execution/initializer.py
@@ -161,12 +161,18 @@ class LHSInitializer(Initializer):
             self.n_init_archive
         )
         archive_x = scipy.stats.qmc.scale(archive_x, problem.lb, problem.ub)
-        archive_f = np.array([problem.evaluate(ind) for ind in archive_x])
+        result = provider.evaluator.evaluate_batch(archive_x, problem)
 
         # TODO: Register algorithm-specific attributes in the archive.
         for i in range(self.n_init_archive):
-            g, cv = problem.evaluate_constraints(archive_x[i])
-            archive.add({"x": archive_x[i], "f": archive_f[i], "g": g, "cv": cv})
+            archive.add(
+                {
+                    "x": archive_x[i],
+                    "f": result.f[i],
+                    "g": result.g[i],
+                    "cv": float(result.cv[i]),
+                }
+            )
 
         sorted_idx = problem.comparator.sort_population(archive)
         archive_sorted = archive.extract(sorted_idx)

--- a/src/saealib/optimizer.py
+++ b/src/saealib/optimizer.py
@@ -13,6 +13,7 @@ from saealib.callback import (
     logging_generation,
 )
 from saealib.context import OptimizationContext
+from saealib.execution.evaluator import Evaluator, SerialEvaluator
 from saealib.execution.runner import Runner
 from saealib.surrogate.manager import LocalSurrogateManager, SurrogateManager
 
@@ -41,6 +42,11 @@ class ComponentProvider(Protocol):
     @property
     def surrogate_manager(self) -> SurrogateManager:
         """Return the surrogate manager instance."""
+        ...
+
+    @property
+    def evaluator(self) -> Evaluator:
+        """Return the evaluator instance."""
         ...
 
     @property
@@ -109,6 +115,7 @@ class Optimizer:
         self.cbmanager: CallbackManager = CallbackManager()
         self.cbmanager.register(GenerationStartEvent, logging_generation)
         self.initializer: Initializer | None = None
+        self.evaluator: Evaluator = SerialEvaluator()
         self.instance_name: str = ""
 
     # --- setters (all return self for chaining) ---
@@ -147,6 +154,11 @@ class Optimizer:
     def set_strategy(self, strategy: OptimizationStrategy) -> Optimizer:
         """Set the optimization strategy. Returns self."""
         self.strategy = strategy
+        return self
+
+    def set_evaluator(self, evaluator: Evaluator) -> Optimizer:
+        """Set the evaluator. Returns self."""
+        self.evaluator = evaluator
         return self
 
     def set_termination(self, termination: Termination) -> Optimizer:

--- a/src/saealib/problem.py
+++ b/src/saealib/problem.py
@@ -42,6 +42,20 @@ class Constraint:
         """Return constraint violation: max(0, g(x) - threshold)."""
         return max(0.0, self.evaluate(x) - self.threshold)
 
+    def evaluate_with_violation(self, x: np.ndarray) -> tuple[float, float]:
+        """
+        Return the raw value and violation with a single function evaluation.
+
+        Returns
+        -------
+        g : float
+            Raw constraint value g(x).
+        cv : float
+            Constraint violation: max(0, g(x) - threshold).
+        """
+        g = self.evaluate(x)
+        return g, max(0.0, g - self.threshold)
+
 
 class Problem:
     """
@@ -183,9 +197,12 @@ class Problem:
         """
         if not self.constraints:
             return np.empty(0, dtype=float), 0.0
-        g = np.array([c.evaluate(x) for c in self.constraints], dtype=float)
-        cv = float(sum(c.violation(x) for c in self.constraints))
-        return g, cv
+        g = np.empty(len(self.constraints), dtype=float)
+        cv = 0.0
+        for i, c in enumerate(self.constraints):
+            g[i], v = c.evaluate_with_violation(x)
+            cv += v
+        return g, float(cv)
 
     def evaluate(self, x: np.ndarray) -> np.ndarray:
         """

--- a/src/saealib/strategies/gb.py
+++ b/src/saealib/strategies/gb.py
@@ -65,14 +65,13 @@ class GenerationBasedStrategy(OptimizationStrategy):
         offspring = provider.algorithm.ask(ctx, provider)
         n_offspring = len(offspring)
 
+        result = provider.evaluator.evaluate_batch(offspring.x, ctx.problem)
         for i in range(n_offspring):
-            offspring[i].f = ctx.problem.evaluate(offspring[i].x)
-            g, cv = ctx.problem.evaluate_constraints(offspring[i].x)
-            offspring[i].cv = cv
-            offspring[i].g = g
-            ctx.archive.add(
-                {"x": offspring[i].x, "f": offspring[i].f, "g": g, "cv": cv}
-            )
+            f_i, g_i, cv_i = result.f[i], result.g[i], float(result.cv[i])
+            offspring[i].f = f_i
+            offspring[i].g = g_i
+            offspring[i].cv = cv_i
+            ctx.archive.add({"x": offspring[i].x, "f": f_i, "g": g_i, "cv": cv_i})
         ctx.count_fe(n_offspring)
 
         provider.dispatch(

--- a/src/saealib/strategies/ib.py
+++ b/src/saealib/strategies/ib.py
@@ -71,14 +71,13 @@ class IndividualBasedStrategy(OptimizationStrategy):
         idx = np.argsort(-scores)
         offspring = offspring.extract(idx)
 
+        result = provider.evaluator.evaluate_batch(offspring.x[:n_eval], ctx.problem)
         for i in range(n_eval):
-            offspring[i].f = ctx.problem.evaluate(offspring[i].x)
-            g, cv = ctx.problem.evaluate_constraints(offspring[i].x)
-            offspring[i].cv = cv
-            offspring[i].g = g
-            ctx.archive.add(
-                {"x": offspring[i].x, "f": offspring[i].f, "g": g, "cv": cv}
-            )
+            f_i, g_i, cv_i = result.f[i], result.g[i], float(result.cv[i])
+            offspring[i].f = f_i
+            offspring[i].g = g_i
+            offspring[i].cv = cv_i
+            ctx.archive.add({"x": offspring[i].x, "f": f_i, "g": g_i, "cv": cv_i})
         ctx.count_fe(n_eval)
 
         evaluated = offspring.extract(list(range(n_eval)))

--- a/src/saealib/strategies/ps.py
+++ b/src/saealib/strategies/ps.py
@@ -68,14 +68,13 @@ class PreSelectionStrategy(OptimizationStrategy):
         candidates = candidates.extract(idx)
         n_eval = min(self.n_select, len(candidates))
 
+        result = provider.evaluator.evaluate_batch(candidates.x[:n_eval], ctx.problem)
         for i in range(n_eval):
-            candidates[i].f = ctx.problem.evaluate(candidates[i].x)
-            g, cv = ctx.problem.evaluate_constraints(candidates[i].x)
-            candidates[i].cv = cv
-            candidates[i].g = g
-            ctx.archive.add(
-                {"x": candidates[i].x, "f": candidates[i].f, "g": g, "cv": cv}
-            )
+            f_i, g_i, cv_i = result.f[i], result.g[i], float(result.cv[i])
+            candidates[i].f = f_i
+            candidates[i].g = g_i
+            candidates[i].cv = cv_i
+            ctx.archive.add({"x": candidates[i].x, "f": f_i, "g": g_i, "cv": cv_i})
         ctx.count_fe(n_eval)
 
         evaluated = candidates.extract(list(range(n_eval)))

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -45,6 +45,28 @@ class TestConstraint:
         assert c.violation(np.array([-1.0])) == pytest.approx(0.0)
         assert c.violation(np.array([2.0])) == pytest.approx(2.0)
 
+    def test_evaluate_with_violation_returns_both(self):
+        """Returns (g, cv) consistent with evaluate / violation."""
+        c = Constraint(lambda x: float(x[0]), threshold=5.0)
+        g, cv = c.evaluate_with_violation(np.array([7.0]))
+        assert g == pytest.approx(7.0)
+        assert cv == pytest.approx(2.0)
+        g2, cv2 = c.evaluate_with_violation(np.array([3.0]))
+        assert g2 == pytest.approx(3.0)
+        assert cv2 == pytest.approx(0.0)
+
+    def test_evaluate_with_violation_calls_func_once(self):
+        """A single function evaluation yields both g and cv (no double-eval)."""
+        calls = {"n": 0}
+
+        def func(x):
+            calls["n"] += 1
+            return float(x[0])
+
+        c = Constraint(func, threshold=1.0)
+        c.evaluate_with_violation(np.array([3.0]))
+        assert calls["n"] == 1
+
 
 # ---------------------------------------------------------------------------
 # Problem.n_constraints
@@ -161,3 +183,19 @@ class TestEvaluateConstraints:
         p = self._make_problem(constraints=[c])
         g, _ = p.evaluate_constraints(np.array([0.5, 0.5]))
         assert g.dtype == float
+
+    def test_evaluates_each_constraint_once(self):
+        """Each constraint func is evaluated once, not twice (no double-eval)."""
+        calls = [0, 0]
+
+        def make_func(i):
+            def func(x):
+                calls[i] += 1
+                return float(x[i])
+
+            return func
+
+        constraints = [Constraint(make_func(0)), Constraint(make_func(1))]
+        p = self._make_problem(constraints=constraints)
+        p.evaluate_constraints(np.array([0.5, 0.5]))
+        assert calls == [1, 1]

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,0 +1,83 @@
+"""
+Tests for the Evaluator abstraction (Issue #85, Commit 1).
+
+Tests cover:
+- SerialEvaluator: batch shapes for f / g / cv
+- Equivalence with per-candidate Problem.evaluate / evaluate_constraints
+- No-constraint problems (g shape (n, 0), cv all zeros)
+- Single-row input handling
+- Optimizer wiring: default evaluator and set_evaluator chaining
+"""
+
+import numpy as np
+import pytest
+
+from saealib import EvaluationResult, Evaluator, Optimizer, SerialEvaluator
+from saealib.problem import Constraint, Problem
+
+
+def _sphere_problem(constraints=None):
+    return Problem(
+        func=lambda x: np.sum(x**2),
+        dim=2,
+        n_obj=1,
+        weight=np.array([-1.0]),
+        lb=[-5.0, -5.0],
+        ub=[5.0, 5.0],
+        constraints=constraints,
+    )
+
+
+class TestSerialEvaluator:
+    def test_is_evaluator_subclass(self):
+        assert issubclass(SerialEvaluator, Evaluator)
+
+    def test_batch_shapes_with_constraints(self):
+        p = _sphere_problem(constraints=[Constraint(lambda x: x[0] - 1.0)])
+        x = np.array([[0.0, 0.0], [2.0, 0.0]])
+        result = SerialEvaluator().evaluate_batch(x, p)
+        assert isinstance(result, EvaluationResult)
+        assert result.f.shape == (2, 1)
+        assert result.g.shape == (2, 1)
+        assert result.cv.shape == (2,)
+
+    def test_values_match_per_candidate(self):
+        p = _sphere_problem(constraints=[Constraint(lambda x: x[0] - 1.0)])
+        x = np.array([[0.0, 0.0], [2.0, 0.0], [-3.0, 1.0]])
+        result = SerialEvaluator().evaluate_batch(x, p)
+        for i, xi in enumerate(x):
+            assert result.f[i] == pytest.approx(p.evaluate(xi))
+            g_i, cv_i = p.evaluate_constraints(xi)
+            assert result.g[i] == pytest.approx(g_i)
+            assert result.cv[i] == pytest.approx(cv_i)
+
+    def test_cv_aggregation(self):
+        p = _sphere_problem(constraints=[Constraint(lambda x: x[0] - 1.0)])
+        x = np.array([[0.0, 0.0], [2.0, 0.0]])
+        result = SerialEvaluator().evaluate_batch(x, p)
+        assert result.cv == pytest.approx([0.0, 1.0])
+
+    def test_no_constraints(self):
+        p = _sphere_problem()
+        x = np.array([[0.0, 0.0], [2.0, 0.0]])
+        result = SerialEvaluator().evaluate_batch(x, p)
+        assert result.g.shape == (2, 0)
+        assert np.all(result.cv == 0.0)
+
+    def test_single_row_input(self):
+        p = _sphere_problem()
+        result = SerialEvaluator().evaluate_batch(np.array([[3.0, 4.0]]), p)
+        assert result.f.shape == (1, 1)
+        assert result.f[0, 0] == pytest.approx(25.0)
+
+
+class TestOptimizerWiring:
+    def test_default_evaluator_is_serial(self):
+        opt = Optimizer(_sphere_problem())
+        assert isinstance(opt.evaluator, SerialEvaluator)
+
+    def test_set_evaluator_chains(self):
+        opt = Optimizer(_sphere_problem())
+        ev = SerialEvaluator()
+        assert opt.set_evaluator(ev) is opt
+        assert opt.evaluator is ev

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -18,6 +18,7 @@ from saealib import (
 from saealib.acquisition import MeanPrediction
 from saealib.comparators import SingleObjectiveComparator
 from saealib.context import OptimizationContext
+from saealib.execution.evaluator import SerialEvaluator
 from saealib.population import Archive, Population, PopulationAttribute
 from saealib.problem import Problem
 from saealib.strategies.gb import GenerationBasedStrategy
@@ -107,6 +108,7 @@ class _MockProvider:
     def __init__(self, algorithm, surrogate_manager):
         self.algorithm = algorithm
         self.surrogate_manager = surrogate_manager
+        self.evaluator = SerialEvaluator()
 
     def dispatch(self, event):
         pass


### PR DESCRIPTION
## Related Issue
Closes #85 

## Overview
Introduce an `Evaluator` abstraction as the single entry point for true (expensive) evaluation, and route all in-library evaluation through it. 
This enables pluggable execution backends (serial, parallel, remote, ...) without forking pipeline code, and fixes a constraint double-evaluation bug along the way.

## Changes
- Add the `Evaluator` abstraction: `Evaluator` ABC, `EvaluationResult` dataclass (`f` / `g` / `cv`), and the default `SerialEvaluator`. Exposed via `Optimizer.set_evaluator()` and the `ComponentProvider` protocol.
- Fix constraint double-evaluation: `Problem.evaluate_constraints()` used to evaluate each constraint function twice (once for the raw value `g`, once for the violation `cv`). Added `Constraint.evaluate_with_violation()` so each constraint function is evaluated exactly once.
- Route all true evaluation through the Evaluator: migrated `IndividualBasedStrategy`, `GenerationBasedStrategy`, `PreSelectionStrategy`, and `LHSInitializer` from direct `Problem.evaluate` / `evaluate_constraints` calls to `provider.evaluator.evaluate_batch()`.
- Documentation & example: API reference page (`docs/api/evaluation.md`), a custom-Evaluator tutorial section, and a runnable `ParallelEvaluator` example (`examples/sample_custom_evaluator.py`).

## Verification Steps
- Passed pytest 
- Confirmed the example's `ParallelEvaluator` produces results identical to `SerialEvaluator` on a constrained sphere problem.

## Concerns
- **Breaking change (additive)**: the `ComponentProvider` protocol gains an `evaluator` property. Custom providers that do not subclass `Optimizer` must now expose an `evaluator` (e.g. a default `SerialEvaluator`).
- Extra evaluation outputs (cost, gradients, ...) are intentionally not added to the base `EvaluationResult`; they are meant to be supported by subclassing `EvaluationResult`, keeping the core `f` / `g` / `cv` frozen for the v0.1.0b3 API freeze
