### PR TITLE
refactor: [#108] Introduce ConstraintHandler abstraction for modular constraint processing

### DIFF
--- a/docs/api/problem.md
+++ b/docs/api/problem.md
@@ -6,5 +6,11 @@
    :nosignatures:
 
    saealib.Problem
-   saealib.Constraint
+   saealib.InequalityConstraint
+   saealib.ConstraintHandler
+   saealib.StaticToleranceHandler
+```
+
+```{note}
+`saealib.Constraint` は `saealib.InequalityConstraint` の非推奨エイリアスです．新しいコードでは `InequalityConstraint` を使用してください．
 ```

--- a/docs/tutorials/constraints.md
+++ b/docs/tutorials/constraints.md
@@ -6,22 +6,26 @@
 今後制約処理の方法は強化する予定です．インターフェースの変更は未定ですが，変更される可能性があることに留意してください．
 ```
 
+```{note}
+`Constraint` は `InequalityConstraint` へリネームされました．`Constraint` は非推奨エイリアスとして当面残りますが，使用すると `DeprecationWarning` が発生します．新しいコードでは `InequalityConstraint` を使用してください．
+```
+
 ## 制約の定義
 
-`saealib` の制約は **不等式制約** `g(x) <= threshold` の形式で表現します．`Constraint` クラスを使って定義します．
+`saealib` の制約は **不等式制約** `g(x) <= threshold` の形式で表現します．`InequalityConstraint` クラスを使って定義します．
 
 ```python
-from saealib.problem import Constraint
+from saealib.problem import InequalityConstraint
 
 # g(x) = x[0]^2 + x[1]^2 - 1 <= 0  (原点からの距離が 1 以内)
-c1 = Constraint(func=lambda x: x[0]**2 + x[1]**2 - 1.0)
+c1 = InequalityConstraint(func=lambda x: x[0]**2 + x[1]**2 - 1.0)
 
 # g(x) <= threshold を明示する場合
 # g(x) = x[0] - 0.5 <= 0
-c2 = Constraint(func=lambda x: x[0], threshold=0.5)
+c2 = InequalityConstraint(func=lambda x: x[0], threshold=0.5)
 ```
 
-`Constraint` は `violation(x)` で違反量（`max(0, g(x) - threshold)`）を返します．制約を満たしていれば `0.0` になります．
+`InequalityConstraint` は `violation(x)` で違反量（`max(0, g(x) - threshold)`）を返します．制約を満たしていれば `0.0` になります．
 
 ---
 
@@ -31,13 +35,13 @@ c2 = Constraint(func=lambda x: x[0], threshold=0.5)
 
 ```python
 import numpy as np
-from saealib.problem import Problem, Constraint
+from saealib.problem import Problem, InequalityConstraint
 
 def objective(x):
     return np.sum(x ** 2)
 
 # x[0]^2 + x[1]^2 <= 1 の制約
-c1 = Constraint(func=lambda x: x[0]**2 + x[1]**2 - 1.0)
+c1 = InequalityConstraint(func=lambda x: x[0]**2 + x[1]**2 - 1.0)
 
 problem = Problem(
     func=objective,
@@ -69,8 +73,8 @@ print(result.fe)  # 真の関数評価回数
 制約が複数ある場合もリストに追加するだけです．
 
 ```python
-c1 = Constraint(func=lambda x: x[0]**2 + x[1]**2 - 1.0)   # x[0]^2 + x[1]^2 <= 1
-c2 = Constraint(func=lambda x: -x[0])                       # x[0] >= 0
+c1 = InequalityConstraint(func=lambda x: x[0]**2 + x[1]**2 - 1.0)  # x[0]^2 + x[1]^2 <= 1
+c2 = InequalityConstraint(func=lambda x: -x[0])                     # x[0] >= 0
 
 problem = Problem(
     func=objective,
@@ -89,7 +93,7 @@ result = minimize(problem, max_fe=300, seed=0)
 
 ## 不等式制約以外の表現方法
 
-`Constraint` は `g(x) <= threshold` のみをサポートしていますが，以下の変換で他の制約形式も扱えます．
+`InequalityConstraint` は `g(x) <= threshold` のみをサポートしていますが，以下の変換で他の制約形式も扱えます．
 
 ### `>=` 制約（下界制約）
 
@@ -97,7 +101,7 @@ result = minimize(problem, max_fe=300, seed=0)
 
 ```python
 # x[0] >= 0.5  →  -x[0] <= -0.5
-c_ge = Constraint(func=lambda x: -x[0], threshold=-0.5)
+c_ge = InequalityConstraint(func=lambda x: -x[0], threshold=-0.5)
 ```
 
 ### 等式制約
@@ -112,8 +116,8 @@ c_ge = Constraint(func=lambda x: -x[0], threshold=-0.5)
 ```python
 # x[0] + x[1] == 1.0  (許容誤差 ε = 1e-3)
 eps = 1e-3
-c_eq_upper = Constraint(func=lambda x:  (x[0] + x[1]),  threshold= 1.0 + eps)
-c_eq_lower = Constraint(func=lambda x: -(x[0] + x[1]),  threshold=-1.0 + eps)
+c_eq_upper = InequalityConstraint(func=lambda x:  (x[0] + x[1]),  threshold= 1.0 + eps)
+c_eq_lower = InequalityConstraint(func=lambda x: -(x[0] + x[1]),  threshold=-1.0 + eps)
 
 problem = Problem(
     func=objective,
@@ -188,9 +192,56 @@ if len(feasible_f):
 
 ---
 
+## 制約処理の差し替え（`ConstraintHandler`）
+
+制約処理の方法（制約違反量 `cv` の集約方法，目的関数へのペナルティ付与，実行可能判定のしきい値など）は `ConstraintHandler` として `Problem` に注入できます．既定では `StaticToleranceHandler` が使われ，`cv` は各制約違反量の総和 `sum(max(0, g_i - threshold_i))`，実行可能判定のしきい値は固定の `eps_cv` になります（従来の挙動）．
+
+```python
+from saealib.problem import Problem, InequalityConstraint, ConstraintHandler
+
+class PenaltyHandler(ConstraintHandler):
+    """違反量の総和を cv とし，目的関数にペナルティを加える例．"""
+
+    def __init__(self, coef: float = 1e3):
+        self.coef = coef
+
+    def compute_cv(self, constraints, x, g):
+        return float(sum(max(0.0, gi - c.threshold) for gi, c in zip(g, constraints)))
+
+    def augment_objective(self, f, constraints, x, g):
+        return f + self.coef * self.compute_cv(constraints, x, g)
+
+problem = Problem(
+    func=objective,
+    dim=2,
+    n_obj=1,
+    weight=np.array([-1.0]),
+    lb=[-2.0, -2.0],
+    ub=[ 2.0,  2.0],
+    constraints=[c1],
+    handler=PenaltyHandler(coef=1e3),
+)
+```
+
+`ConstraintHandler` は制約処理のライフサイクルをオーバーライド可能なフックとして公開します．
+
+| フック | 役割 | 既定 |
+|---|---|---|
+| `repair(x, constraints)` | 評価前の解修復 | 無修復（`x` を返す） |
+| `compute_cv(constraints, x, g)` | 制約違反量 `cv` の集約（抽象メソッド） | — |
+| `augment_objective(f, constraints, x, g)` | 目的関数の変換（ペナルティ等） | 恒等（`f` を返す） |
+| `feasibility_threshold` | 実行可能判定のしきい値 `eps_cv` | `1e-6` |
+| `on_generation_end(gen, population)` | 世代末の処理 | no-op |
+
+`compute_cv` のみが抽象メソッドで，残りのフックは既定で no-op です．必要なフックだけをオーバーライドしてください．勾配ベースの修復を行う場合は，`InequalityConstraint.gradient(x)` をサブクラスで実装して制約のヤコビアンを提供できます．
+
+---
+
 ## 参照
 
-- {py:class}`saealib.Constraint`
+- {py:class}`saealib.InequalityConstraint`
+- {py:class}`saealib.ConstraintHandler`
+- {py:class}`saealib.StaticToleranceHandler`
 - {py:class}`saealib.Problem`
 - {py:func}`saealib.minimize`
 - {py:class}`saealib.Optimizer`

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -83,6 +83,7 @@ from saealib.population import (
 )
 from saealib.problem import (
     Constraint,
+    InequalityConstraint,
     Problem,
 )
 from saealib.strategies.base import OptimizationStrategy
@@ -151,6 +152,7 @@ __all__ = [
     "GlobalSurrogateManager",
     "Individual",
     "IndividualBasedStrategy",
+    "InequalityConstraint",
     "Initializer",
     "LGBMSurrogate",
     "LHSInitializer",

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -83,8 +83,10 @@ from saealib.population import (
 )
 from saealib.problem import (
     Constraint,
+    ConstraintHandler,
     InequalityConstraint,
     Problem,
+    StaticToleranceHandler,
 )
 from saealib.strategies.base import OptimizationStrategy
 from saealib.strategies.gb import GenerationBasedStrategy
@@ -132,6 +134,7 @@ __all__ = [
     "CallbackManager",
     "Comparator",
     "Constraint",
+    "ConstraintHandler",
     "Crossover",
     "CrossoverBLXAlpha",
     "CrossoverOnePoint",
@@ -194,6 +197,7 @@ __all__ = [
     "SerialEvaluator",
     "SingleObjectiveComparator",
     "SklearnSurrogate",
+    "StaticToleranceHandler",
     "Surrogate",
     "SurrogateEndEvent",
     "SurrogateManager",

--- a/src/saealib/execution/evaluator.py
+++ b/src/saealib/execution/evaluator.py
@@ -96,8 +96,8 @@ class SerialEvaluator(Evaluator):
         cv = np.zeros(n, dtype=float)
 
         for i, xi in enumerate(x):
-            f[i] = problem.evaluate(xi)
             g_i, cv_i = problem.evaluate_constraints(xi)
+            f[i] = problem.evaluate(xi, g_i)
             g[i] = g_i
             cv[i] = cv_i
 

--- a/src/saealib/problem.py
+++ b/src/saealib/problem.py
@@ -8,6 +8,8 @@ Comparator classes and Pareto-related utilities are in saealib.comparators.
 from __future__ import annotations
 
 import warnings
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -16,6 +18,9 @@ from saealib.comparators import (
     NSGA2Comparator,
     SingleObjectiveComparator,
 )
+
+if TYPE_CHECKING:
+    from saealib.population import Population
 
 
 class InequalityConstraint:
@@ -97,6 +102,164 @@ class Constraint(InequalityConstraint):
         super().__init__(func, threshold)
 
 
+class ConstraintHandler(ABC):
+    """
+    Pluggable constraint-processing strategy.
+
+    A ``ConstraintHandler`` exposes the constraint-handling lifecycle as a set
+    of overridable hooks, decoupling the per-constraint violation formula and
+    the aggregation method from the core :class:`Problem`. This lets research
+    code swap in alternative strategies (e.g. ε-constraint, penalty functions,
+    gradient-based repair, augmented Lagrangian) without forking core classes.
+
+    Lifecycle::
+
+        Ask            -> [repair(x, constraints)]
+                       -> evaluate f, g
+                       -> [compute_cv(constraints, x, g)]        -> cv
+                       -> [augment_objective(f, constraints, x, g)] -> f'
+        Tell           -> Comparator(f', cv) with eps_cv = feasibility_threshold
+        Generation end -> [on_generation_end(gen, population)]
+
+    Only :meth:`compute_cv` is abstract; the remaining hooks default to no-ops
+    so that subclasses implement just what they need.
+    """
+
+    def repair(
+        self, x: np.ndarray, constraints: list[InequalityConstraint]
+    ) -> np.ndarray:
+        """
+        Repair a design vector before evaluation.
+
+        Parameters
+        ----------
+        x : np.ndarray
+            The design vector to repair. shape = (dim, )
+        constraints : list[InequalityConstraint]
+            The problem's inequality constraints.
+
+        Returns
+        -------
+        np.ndarray
+            The (possibly) repaired design vector. The default returns ``x``
+            unchanged.
+        """
+        return x
+
+    @abstractmethod
+    def compute_cv(
+        self,
+        constraints: list[InequalityConstraint],
+        x: np.ndarray,
+        g: np.ndarray,
+    ) -> float:
+        """
+        Aggregate raw constraint values into a scalar constraint violation.
+
+        Parameters
+        ----------
+        constraints : list[InequalityConstraint]
+            The problem's inequality constraints, aligned with ``g``.
+        x : np.ndarray
+            The evaluated design vector. shape = (dim, )
+        g : np.ndarray
+            Raw constraint values g(x). shape = (n_constraints, )
+
+        Returns
+        -------
+        float
+            Aggregate constraint violation (``cv``); ``0.0`` means feasible.
+        """
+        ...
+
+    def augment_objective(
+        self,
+        f: np.ndarray,
+        constraints: list[InequalityConstraint],
+        x: np.ndarray,
+        g: np.ndarray,
+    ) -> np.ndarray:
+        """
+        Transform objective values using constraint information.
+
+        Used by penalty-based or augmented-Lagrangian strategies. The default
+        is the identity (objectives are returned unchanged).
+
+        Parameters
+        ----------
+        f : np.ndarray
+            Raw objective values. shape = (n_obj, )
+        constraints : list[InequalityConstraint]
+            The problem's inequality constraints, aligned with ``g``.
+        x : np.ndarray
+            The evaluated design vector. shape = (dim, )
+        g : np.ndarray
+            Raw constraint values g(x). shape = (n_constraints, )
+
+        Returns
+        -------
+        np.ndarray
+            The (possibly) augmented objective values. shape = (n_obj, )
+        """
+        return f
+
+    @property
+    def feasibility_threshold(self) -> float:
+        """Constraint-violation threshold below which a solution is feasible."""
+        return 1e-6
+
+    def on_generation_end(self, gen: int, population: Population) -> None:
+        """
+        Run end-of-generation bookkeeping.
+
+        Used by adaptive strategies (e.g. ε-level control) that update their
+        internal state between generations. The default is a no-op.
+
+        Parameters
+        ----------
+        gen : int
+            The generation index that just finished.
+        population : Population
+            The current population.
+        """
+
+
+class StaticToleranceHandler(ConstraintHandler):
+    """
+    Default constraint handler reproducing the static-tolerance behavior.
+
+    The constraint violation is the sum of per-constraint violations
+    ``sum(max(0, g_i - threshold_i))`` and the feasibility threshold is a
+    fixed ``eps_cv``. Objectives are not augmented.
+
+    Parameters
+    ----------
+    eps_cv : float, optional
+        Feasibility threshold returned by :attr:`feasibility_threshold`.
+        Default: 1e-6.
+    """
+
+    def __init__(self, eps_cv: float = 1e-6):
+        self._eps_cv = eps_cv
+
+    def compute_cv(
+        self,
+        constraints: list[InequalityConstraint],
+        x: np.ndarray,
+        g: np.ndarray,
+    ) -> float:
+        """Return the sum of per-constraint violations max(0, g_i - t_i)."""
+        cv = 0.0
+        for gi, c in zip(g, constraints):
+            cv += max(0.0, float(gi) - c.threshold)
+        return cv
+
+    @property
+    def feasibility_threshold(self) -> float:
+        """Fixed feasibility threshold ``eps_cv``."""
+        return self._eps_cv
+
+
 class Problem:
     """
     Definition of optimization problem.
@@ -123,6 +286,9 @@ class Problem:
         Objective function to evaluate solutions.
     constraints : list[InequalityConstraint]
         List of inequality constraint definitions.
+    handler : ConstraintHandler
+        Constraint-handling strategy used to aggregate violations and augment
+        objectives.
     """
 
     def __init__(
@@ -139,6 +305,7 @@ class Problem:
         *,
         eps_cv: float = 1e-6,
         eps_obj: float = 1e-6,
+        handler: ConstraintHandler | None = None,
     ):
         """
         Initialize Problem instance.
@@ -171,6 +338,10 @@ class Problem:
             Epsilon for constraint violation feasibility threshold. Default: 1e-6.
         eps_obj : float, optional
             Epsilon for objective value equality comparison. Default: 1e-6.
+        handler : ConstraintHandler, optional
+            Constraint-handling strategy. If None, a StaticToleranceHandler
+            (sum-of-violations, fixed eps_cv) is used, reproducing the default
+            behavior.
         """
         if eps is not None:
             warnings.warn(
@@ -189,6 +360,9 @@ class Problem:
         self.ub = np.asarray(ub)
         self.func = func
         self.constraints = constraints if constraints is not None else []
+        self.handler = (
+            handler if handler is not None else StaticToleranceHandler(eps_cv=eps_cv)
+        )
 
         if comparator is not None:
             self.comparator = comparator
@@ -232,26 +406,35 @@ class Problem:
             Raw constraint values. shape = (n_constraints, )
             Empty array when no constraints are defined.
         cv : float
-            Aggregate constraint violation = sum(max(0, g_i - threshold_i)).
+            Aggregate constraint violation as computed by ``handler.compute_cv``.
             0.0 when no constraints are defined.
         """
         if not self.constraints:
             return np.empty(0, dtype=float), 0.0
         g = np.empty(len(self.constraints), dtype=float)
-        cv = 0.0
         for i, c in enumerate(self.constraints):
-            g[i], v = c.evaluate_with_violation(x)
-            cv += v
+            g[i] = c.evaluate(x)
+        cv = self.handler.compute_cv(self.constraints, x, g)
         return g, float(cv)
 
-    def evaluate(self, x: np.ndarray) -> np.ndarray:
+    def evaluate(self, x: np.ndarray, g: np.ndarray | None = None) -> np.ndarray:
         """
         Evaluate the objective function at given solution x.
+
+        After computing the raw objective, ``handler.augment_objective`` is
+        applied so that penalty-based or augmented-Lagrangian handlers can
+        transform the objective using constraint information. The default
+        ``StaticToleranceHandler`` leaves the objective unchanged.
 
         Parameters
         ----------
         x : np.ndarray
             The solution to evaluate.
+        g : np.ndarray, optional
+            Pre-computed raw constraint values g(x), shape = (n_constraints, ).
+            When None, constraints are evaluated internally if any are defined.
+            Pass this to avoid re-evaluating constraints when ``g`` is already
+            available (e.g. from :meth:`evaluate_constraints`).
 
         Returns
         -------
@@ -259,4 +442,7 @@ class Problem:
             The objective value(s) at solution x. shape = (n_obj, )
         """
         result = self.func(x)
-        return np.atleast_1d(np.asarray(result, dtype=float))
+        f = np.atleast_1d(np.asarray(result, dtype=float))
+        if g is None:
+            g, _ = self.evaluate_constraints(x)
+        return self.handler.augment_objective(f, self.constraints, x, g)

--- a/src/saealib/problem.py
+++ b/src/saealib/problem.py
@@ -18,7 +18,7 @@ from saealib.comparators import (
 )
 
 
-class Constraint:
+class InequalityConstraint:
     """
     A single inequality constraint: g(x) <= threshold.
 
@@ -56,6 +56,46 @@ class Constraint:
         g = self.evaluate(x)
         return g, max(0.0, g - self.threshold)
 
+    def gradient(self, x: np.ndarray) -> np.ndarray | None:
+        """
+        Return the gradient of g(x) with respect to x, if available.
+
+        Override this in a subclass to enable gradient-based constraint
+        handlers (e.g. gradient-based repair). The default returns ``None``,
+        signalling that no analytical Jacobian is provided.
+
+        Parameters
+        ----------
+        x : np.ndarray
+            The solution at which to evaluate the gradient. shape = (dim, )
+
+        Returns
+        -------
+        np.ndarray or None
+            Gradient vector with shape = (dim, ), or ``None`` when no
+            gradient is available.
+        """
+        return None
+
+
+class Constraint(InequalityConstraint):
+    """
+    Deprecated alias of :class:`InequalityConstraint`.
+
+    .. deprecated::
+        Use :class:`InequalityConstraint`. ``Constraint`` will be removed
+        in a future release.
+    """
+
+    def __init__(self, func: callable, threshold: float = 0.0):
+        warnings.warn(
+            "Constraint is deprecated and will be removed in a future release. "
+            "Use InequalityConstraint instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(func, threshold)
+
 
 class Problem:
     """
@@ -81,7 +121,7 @@ class Problem:
         Epsilon for objective value equality comparison.
     func : callable -> float
         Objective function to evaluate solutions.
-    constraints : list[Constraint]
+    constraints : list[InequalityConstraint]
         List of inequality constraint definitions.
     """
 
@@ -95,7 +135,7 @@ class Problem:
         ub: list[float],
         eps: float | None = None,
         comparator: Comparator | None = None,
-        constraints: list[Constraint] | None = None,
+        constraints: list[InequalityConstraint] | None = None,
         *,
         eps_cv: float = 1e-6,
         eps_obj: float = 1e-6,
@@ -125,7 +165,7 @@ class Problem:
             Comparator instance to use. If None, auto-selected based on n_obj:
             n_obj == 1 -> SingleObjectiveComparator,
             n_obj >  1 -> NSGA2Comparator.
-        constraints : list[Constraint], optional
+        constraints : list[InequalityConstraint], optional
             List of inequality constraint definitions. Default: empty list.
         eps_cv : float, optional
             Epsilon for constraint violation feasibility threshold. Default: 1e-6.

--- a/tests/test_constraint_handler.py
+++ b/tests/test_constraint_handler.py
@@ -1,0 +1,187 @@
+"""
+Tests for the ConstraintHandler abstraction (Issue #108).
+
+Tests cover:
+- InequalityConstraint: rename, gradient() default, deprecated Constraint alias
+- StaticToleranceHandler: sum-of-violations cv, feasibility_threshold, identity augment
+- Problem: default handler reproduces previous behavior; custom handler is honored
+- ConstraintHandler: compute_cv delegation and augment_objective in Problem.evaluate
+"""
+
+import numpy as np
+import pytest
+
+from saealib import (
+    Constraint,
+    ConstraintHandler,
+    InequalityConstraint,
+    Problem,
+    StaticToleranceHandler,
+)
+
+
+def _make_problem(constraints=None, handler=None):
+    return Problem(
+        func=lambda x: float(x[0]),
+        dim=2,
+        n_obj=1,
+        weight=1.0,
+        lb=[0.0, 0.0],
+        ub=[1.0, 1.0],
+        constraints=constraints,
+        handler=handler,
+    )
+
+
+# ---------------------------------------------------------------------------
+# InequalityConstraint / deprecated alias
+# ---------------------------------------------------------------------------
+
+
+class TestInequalityConstraint:
+    def test_gradient_default_none(self):
+        c = InequalityConstraint(lambda x: float(x[0]))
+        assert c.gradient(np.array([0.5, 0.5])) is None
+
+    def test_gradient_overridable(self):
+        class Linear(InequalityConstraint):
+            def gradient(self, x):
+                return np.array([1.0, 0.0])
+
+        c = Linear(lambda x: float(x[0]))
+        np.testing.assert_array_equal(c.gradient(np.zeros(2)), [1.0, 0.0])
+
+    def test_constraint_alias_is_subclass(self):
+        assert issubclass(Constraint, InequalityConstraint)
+
+    def test_constraint_alias_warns(self):
+        with pytest.warns(DeprecationWarning):
+            Constraint(lambda x: float(x[0]))
+
+    def test_inequality_constraint_does_not_warn(self):
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            InequalityConstraint(lambda x: float(x[0]))
+
+
+# ---------------------------------------------------------------------------
+# StaticToleranceHandler
+# ---------------------------------------------------------------------------
+
+
+class TestStaticToleranceHandler:
+    def test_is_constraint_handler(self):
+        assert isinstance(StaticToleranceHandler(), ConstraintHandler)
+
+    def test_compute_cv_sum_of_violations(self):
+        constraints = [
+            InequalityConstraint(lambda x: x[0] - 0.3),
+            InequalityConstraint(lambda x: x[1] - 0.4),
+        ]
+        x = np.array([0.5, 0.5])
+        g = np.array([0.2, 0.1])
+        cv = StaticToleranceHandler().compute_cv(constraints, x, g)
+        assert cv == pytest.approx(0.3)
+
+    def test_compute_cv_respects_threshold(self):
+        c = [InequalityConstraint(lambda x: float(x[0]), threshold=0.8)]
+        cv = StaticToleranceHandler().compute_cv(c, np.array([0.0]), np.array([0.9]))
+        assert cv == pytest.approx(0.1)
+
+    def test_feasibility_threshold_default(self):
+        assert StaticToleranceHandler().feasibility_threshold == pytest.approx(1e-6)
+
+    def test_feasibility_threshold_custom(self):
+        assert StaticToleranceHandler(
+            eps_cv=1e-3
+        ).feasibility_threshold == pytest.approx(1e-3)
+
+    def test_augment_objective_identity(self):
+        f = np.array([1.0, 2.0])
+        out = StaticToleranceHandler().augment_objective(
+            f, [], np.zeros(2), np.empty(0)
+        )
+        np.testing.assert_array_equal(out, f)
+
+
+# ---------------------------------------------------------------------------
+# Problem integration
+# ---------------------------------------------------------------------------
+
+
+class TestProblemHandlerIntegration:
+    def test_default_handler_is_static_tolerance(self):
+        p = _make_problem()
+        assert isinstance(p.handler, StaticToleranceHandler)
+
+    def test_default_handler_eps_cv_matches(self):
+        p = _make_problem()
+        p2 = Problem(
+            func=lambda x: float(x[0]),
+            dim=1,
+            n_obj=1,
+            weight=1.0,
+            lb=[0.0],
+            ub=[1.0],
+            eps_cv=1e-3,
+        )
+        assert p.handler.feasibility_threshold == pytest.approx(1e-6)
+        assert p2.handler.feasibility_threshold == pytest.approx(1e-3)
+
+    def test_evaluate_constraints_delegates_cv(self):
+        c = [InequalityConstraint(lambda x: x[0] - 0.3)]
+        p = _make_problem(constraints=c)
+        g, cv = p.evaluate_constraints(np.array([0.5, 0.5]))
+        assert g[0] == pytest.approx(0.2)
+        assert cv == pytest.approx(0.2)
+
+    def test_custom_handler_cv(self):
+        class MaxHandler(ConstraintHandler):
+            def compute_cv(self, constraints, x, g):
+                return float(max((max(0.0, gi) for gi in g), default=0.0))
+
+        constraints = [
+            InequalityConstraint(lambda x: x[0] - 0.3),
+            InequalityConstraint(lambda x: x[1] - 0.4),
+        ]
+        p = _make_problem(constraints=constraints, handler=MaxHandler())
+        _g, cv = p.evaluate_constraints(np.array([0.5, 0.5]))
+        # max(0.2, 0.1) instead of sum 0.3
+        assert cv == pytest.approx(0.2)
+
+    def test_evaluate_applies_augment_objective(self):
+        class PenaltyHandler(ConstraintHandler):
+            def compute_cv(self, constraints, x, g):
+                return float(sum(max(0.0, gi) for gi in g))
+
+            def augment_objective(self, f, constraints, x, g):
+                cv = self.compute_cv(constraints, x, g)
+                return f + 100.0 * cv
+
+        c = [InequalityConstraint(lambda x: x[0] - 0.3)]
+        p = _make_problem(constraints=c, handler=PenaltyHandler())
+        # f = x[0] = 0.5, cv = 0.2 -> f' = 0.5 + 100 * 0.2 = 20.5
+        f = p.evaluate(np.array([0.5, 0.5]))
+        assert f[0] == pytest.approx(20.5)
+
+    def test_evaluate_with_precomputed_g(self):
+        class PenaltyHandler(ConstraintHandler):
+            def compute_cv(self, constraints, x, g):
+                return 0.0
+
+            def augment_objective(self, f, constraints, x, g):
+                return f + float(g[0])
+
+        c = [InequalityConstraint(lambda x: x[0])]
+        p = _make_problem(constraints=c, handler=PenaltyHandler())
+        f = p.evaluate(np.array([0.5, 0.5]), g=np.array([7.0]))
+        # augment uses the passed g (7.0), not a recomputed one (0.5)
+        assert f[0] == pytest.approx(0.5 + 7.0)
+
+    def test_default_evaluate_unchanged(self):
+        c = [InequalityConstraint(lambda x: x[0] - 0.3)]
+        p = _make_problem(constraints=c)
+        f = p.evaluate(np.array([0.5, 0.5]))
+        assert f[0] == pytest.approx(0.5)


### PR DESCRIPTION
## Related Issue
Closes #108

## Overview
Constraint processing previously hard-coded the per-constraint violation formula (`Constraint.violation()`) and the aggregation method (sum, in `Problem.evaluate_constraints()`), so alternative strategies (ε-constraint, penalty, gradient-based repair, etc.) required forking core classes.

This PR makes the strategy injectable via a `ConstraintHandler` ABC. The default `StaticToleranceHandler` reproduces the previous behavior exactly.

## Changes
- Add `ConstraintHandler` ABC with lifecycle hooks: `compute_cv` (abstract), `repair`, `augment_objective`, `feasibility_threshold`, `on_generation_end`.
- Add default `StaticToleranceHandler` (sum-of-violations, fixed `eps_cv`).
- Rename `Constraint` → `InequalityConstraint`; keep `Constraint` as a deprecated alias.
- Add `InequalityConstraint.gradient()` (default `None`) for gradient-based handlers.
- `Problem` accepts `handler`; `evaluate_constraints()` delegates `cv` to `handler.compute_cv()`, and `evaluate()` applies `handler.augment_objective()`.
- Export the new classes and add `tests/test_constraint_handler.py`.

## Verification Steps
pytest

## Concerns
- Breaking change: the `Constraint` rename, mitigated by the deprecated alias.
- `repair` / `on_generation_end` hooks are defined but not yet wired into the ask pipeline / generation loop — left for the follow-up issues (#85, #87) that will consume them.