### PR TITLE
feat: [#87] Add equality constraint support (EqualityConstraint)  

### DIFF
--- a/examples/sample_equality_constraint.py
+++ b/examples/sample_equality_constraint.py
@@ -1,0 +1,58 @@
+import logging
+
+import numpy as np
+
+from saealib import (
+    EqualityConstraint,
+    Problem,
+    minimize,
+)
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger("saealib.surrogate.rbf").setLevel(logging.CRITICAL)
+
+
+def main():
+    """Minimize on the equality surface x1 + x2 = 1.
+
+    Objective: f(x) = x1^2 + x2^2 (minimize)
+    Constraint: h(x) = x1 + x2 - 1 = 0
+
+    The constrained optimum lies at x1 = x2 = 0.5 with f = 0.5, the point on
+    the line x1 + x2 = 1 closest to the origin. The equality constraint is
+    expressed with EqualityConstraint, whose violation max(0, |h(x)| - tol)
+    is aggregated through the default StaticToleranceHandler.
+
+    The tolerance softens the equality into a feasible band
+    |x1 + x2 - 1| <= tolerance; a non-trivial band is what makes the surface
+    reachable for a finite-budget surrogate-assisted search.
+    """
+    dim = 2
+    seed = 1
+    lb = [-2.0] * dim
+    ub = [2.0] * dim
+
+    # tolerance defines the feasible band |x1 + x2 - 1| <= tolerance.
+    equality = EqualityConstraint(lambda x: x[0] + x[1] - 1.0, tolerance=5e-2)
+
+    problem = Problem(
+        func=lambda x: float(x[0] ** 2 + x[1] ** 2),
+        dim=dim,
+        n_obj=1,
+        weight=np.array([-1.0]),
+        lb=lb,
+        ub=ub,
+        constraints=[equality],
+    )
+
+    result = minimize(problem, max_fe=400, seed=seed)
+
+    x = result.X
+    h = x[0] + x[1] - 1.0
+    print(f"x = {x} (optimum: [0.5, 0.5])")
+    print(f"f(x) = {result.F[0]:.6f} (optimum: 0.5)")
+    print(f"h(x) = x1 + x2 - 1 = {h:.6e} (|h| <= {equality.tolerance:g})")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -84,6 +84,7 @@ from saealib.population import (
 from saealib.problem import (
     Constraint,
     ConstraintHandler,
+    EqualityConstraint,
     InequalityConstraint,
     Problem,
     StaticToleranceHandler,
@@ -144,6 +145,7 @@ __all__ = [
     "DTSurrogate",
     "DensityManager",
     "EnsembleSurrogateManager",
+    "EqualityConstraint",
     "EvaluationResult",
     "Evaluator",
     "Event",

--- a/src/saealib/problem.py
+++ b/src/saealib/problem.py
@@ -43,9 +43,31 @@ class InequalityConstraint:
         """Return the raw constraint value g(x)."""
         return float(self.func(x))
 
+    def violation_from_value(self, g: float) -> float:
+        """
+        Return the violation for an already-evaluated raw value g(x).
+
+        This is the single source of truth for the per-constraint violation
+        formula: :meth:`violation`, :meth:`evaluate_with_violation`, and
+        :class:`StaticToleranceHandler` all delegate to it. Subclasses (e.g.
+        :class:`EqualityConstraint`) override this one method to change how a
+        raw value maps to a violation, without re-evaluating ``func``.
+
+        Parameters
+        ----------
+        g : float
+            Raw constraint value g(x).
+
+        Returns
+        -------
+        float
+            Constraint violation: max(0, g - threshold).
+        """
+        return max(0.0, g - self.threshold)
+
     def violation(self, x: np.ndarray) -> float:
         """Return constraint violation: max(0, g(x) - threshold)."""
-        return max(0.0, self.evaluate(x) - self.threshold)
+        return self.violation_from_value(self.evaluate(x))
 
     def evaluate_with_violation(self, x: np.ndarray) -> tuple[float, float]:
         """
@@ -59,7 +81,7 @@ class InequalityConstraint:
             Constraint violation: max(0, g(x) - threshold).
         """
         g = self.evaluate(x)
-        return g, max(0.0, g - self.threshold)
+        return g, self.violation_from_value(g)
 
     def gradient(self, x: np.ndarray) -> np.ndarray | None:
         """
@@ -100,6 +122,41 @@ class Constraint(InequalityConstraint):
             stacklevel=2,
         )
         super().__init__(func, threshold)
+
+
+class EqualityConstraint(InequalityConstraint):
+    """
+    A single equality constraint: h(x) = 0, satisfied within a tolerance.
+
+    The violation is ``max(0, |h(x)| - tolerance)``, reusing the inequality
+    violation path so that mixed inequality/equality problems aggregate through
+    the same :class:`ConstraintHandler`. Only :meth:`violation_from_value` is
+    overridden; :meth:`violation` and :meth:`evaluate_with_violation` inherit
+    the equality behavior automatically.
+
+    Parameters
+    ----------
+    func : callable
+        Constraint function h(x). Should return a scalar float.
+    tolerance : float, optional
+        Feasibility tolerance for ``|h(x)| <= tolerance``. Default: 1e-6.
+        Set ``tolerance=0.0`` to defer the feasibility threshold to a handler
+        such as ``EpsilonConstraintHandler``, where the threshold is managed
+        externally rather than baked into the constraint.
+
+    Notes
+    -----
+    Provide an analytical Jacobian by overriding :meth:`gradient` to return
+    ``∇h(x)``; this enables gradient-based constraint handlers (e.g. repair).
+    """
+
+    def __init__(self, func: callable, tolerance: float = 1e-6):
+        super().__init__(func, threshold=0.0)
+        self.tolerance = tolerance
+
+    def violation_from_value(self, g: float) -> float:
+        """Return equality violation: max(0, |h(x)| - tolerance)."""
+        return max(0.0, abs(g) - self.tolerance)
 
 
 class ConstraintHandler(ABC):
@@ -229,8 +286,11 @@ class StaticToleranceHandler(ConstraintHandler):
     Default constraint handler reproducing the static-tolerance behavior.
 
     The constraint violation is the sum of per-constraint violations
-    ``sum(max(0, g_i - threshold_i))`` and the feasibility threshold is a
-    fixed ``eps_cv``. Objectives are not augmented.
+    ``sum(c_i.violation_from_value(g_i))`` and the feasibility threshold is a
+    fixed ``eps_cv``. Each constraint maps its own raw value to a violation,
+    so inequality (``max(0, g - threshold)``) and equality
+    (``max(0, |h| - tolerance)``) constraints can be mixed freely. Objectives
+    are not augmented.
 
     Parameters
     ----------
@@ -248,10 +308,10 @@ class StaticToleranceHandler(ConstraintHandler):
         x: np.ndarray,
         g: np.ndarray,
     ) -> float:
-        """Return the sum of per-constraint violations max(0, g_i - t_i)."""
+        """Return the sum of per-constraint ``c_i.violation_from_value(g_i)``."""
         cv = 0.0
         for gi, c in zip(g, constraints):
-            cv += max(0.0, float(gi) - c.threshold)
+            cv += c.violation_from_value(float(gi))
         return cv
 
     @property

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -12,7 +12,12 @@ Tests cover:
 import numpy as np
 import pytest
 
-from saealib.problem import Constraint, Problem
+from saealib.problem import (
+    Constraint,
+    EqualityConstraint,
+    InequalityConstraint,
+    Problem,
+)
 
 # ---------------------------------------------------------------------------
 # Constraint unit tests
@@ -199,3 +204,117 @@ class TestEvaluateConstraints:
         p = self._make_problem(constraints=constraints)
         p.evaluate_constraints(np.array([0.5, 0.5]))
         assert calls == [1, 1]
+
+
+# ---------------------------------------------------------------------------
+# EqualityConstraint
+# ---------------------------------------------------------------------------
+
+
+class TestEqualityConstraint:
+    def test_is_constraint_subclass(self):
+        """EqualityConstraint is a concrete subclass of the Constraint ABC."""
+        c = EqualityConstraint(lambda x: float(x[0]))
+        assert isinstance(c, InequalityConstraint)
+
+    def test_evaluate_returns_raw_value(self):
+        """evaluate(x) returns the raw h(x), not its absolute value."""
+        c = EqualityConstraint(lambda x: float(x[0]) - 1.0)
+        assert c.evaluate(np.array([-2.0])) == pytest.approx(-3.0)
+
+    def test_violation_uses_absolute_value(self):
+        """Both signs of h(x) violate symmetrically: |h(x)| - tolerance."""
+        c = EqualityConstraint(lambda x: float(x[0]), tolerance=0.0)
+        assert c.violation(np.array([0.3])) == pytest.approx(0.3)
+        assert c.violation(np.array([-0.3])) == pytest.approx(0.3)
+
+    def test_violation_within_tolerance_is_zero(self):
+        """|h(x)| <= tolerance → violation == 0."""
+        c = EqualityConstraint(lambda x: float(x[0]), tolerance=0.1)
+        assert c.violation(np.array([0.05])) == pytest.approx(0.0)
+        assert c.violation(np.array([-0.05])) == pytest.approx(0.0)
+
+    def test_violation_on_tolerance_boundary(self):
+        """|h(x)| == tolerance → violation == 0 (boundary is feasible)."""
+        c = EqualityConstraint(lambda x: float(x[0]), tolerance=0.1)
+        assert c.violation(np.array([0.1])) == pytest.approx(0.0)
+        assert c.violation(np.array([-0.1])) == pytest.approx(0.0)
+
+    def test_violation_outside_tolerance(self):
+        """|h(x)| > tolerance → violation == |h(x)| - tolerance."""
+        c = EqualityConstraint(lambda x: float(x[0]), tolerance=0.1)
+        assert c.violation(np.array([0.3])) == pytest.approx(0.2)
+        assert c.violation(np.array([-0.3])) == pytest.approx(0.2)
+
+    def test_default_tolerance(self):
+        """Default tolerance is 1e-6."""
+        c = EqualityConstraint(lambda x: float(x[0]))
+        assert c.tolerance == pytest.approx(1e-6)
+        assert c.violation(np.array([1e-7])) == pytest.approx(0.0)
+
+    def test_tolerance_zero_valid(self):
+        """tolerance=0.0 is valid (threshold managed externally by a handler)."""
+        c = EqualityConstraint(lambda x: float(x[0]), tolerance=0.0)
+        assert c.tolerance == pytest.approx(0.0)
+        assert c.violation(np.array([0.0])) == pytest.approx(0.0)
+        assert c.violation(np.array([1e-9])) == pytest.approx(1e-9)
+
+    def test_gradient_default_none(self):
+        """gradient(x) defaults to None unless overridden."""
+        c = EqualityConstraint(lambda x: float(x[0]))
+        assert c.gradient(np.array([0.5])) is None
+
+    def test_evaluate_with_violation_single_call(self):
+        """(g, cv) is consistent and computed with a single function evaluation."""
+        calls = {"n": 0}
+
+        def func(x):
+            calls["n"] += 1
+            return float(x[0]) - 1.0
+
+        c = EqualityConstraint(func, tolerance=0.0)
+        g, cv = c.evaluate_with_violation(np.array([0.4]))
+        assert g == pytest.approx(-0.6)
+        assert cv == pytest.approx(0.6)
+        assert calls["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Mixed inequality + equality constraints
+# ---------------------------------------------------------------------------
+
+
+class TestMixedConstraints:
+    def _make_problem(self, constraints=None):
+        return Problem(
+            func=lambda x: float(x[0]),
+            dim=2,
+            n_obj=1,
+            weight=1.0,
+            lb=[0.0, 0.0],
+            ub=[1.0, 1.0],
+            constraints=constraints,
+        )
+
+    def test_mixed_cv_is_sum(self):
+        """cv aggregates inequality and equality violations through one handler."""
+        constraints = [
+            InequalityConstraint(lambda x: x[0] - 0.3),  # violated by 0.2 at 0.5
+            EqualityConstraint(lambda x: x[1] - 1.0, tolerance=0.0),  # |0.5-1|=0.5
+        ]
+        p = self._make_problem(constraints=constraints)
+        g, cv = p.evaluate_constraints(np.array([0.5, 0.5]))
+        assert g.shape == (2,)
+        assert g[0] == pytest.approx(0.2)
+        assert g[1] == pytest.approx(-0.5)  # raw equality value, signed
+        assert cv == pytest.approx(0.7)  # 0.2 + 0.5
+
+    def test_mixed_all_feasible(self):
+        """Feasible inequality and within-tolerance equality → cv == 0."""
+        constraints = [
+            InequalityConstraint(lambda x: x[0] - 0.8),  # satisfied at 0.5
+            EqualityConstraint(lambda x: x[1] - 0.5, tolerance=1e-6),  # exact
+        ]
+        p = self._make_problem(constraints=constraints)
+        _g, cv = p.evaluate_constraints(np.array([0.5, 0.5]))
+        assert cv == pytest.approx(0.0)


### PR DESCRIPTION
## Related Issue
Closes #87

## Overview
The existing `Constraint` only supported inequalities `g(x) ≤ threshold`. This PR adds　`EqualityConstraint` for `h(x) = 0`, expressed as `|h(x)| ≤ tolerance` so it flows through　the existing constraint-violation path and can be mixed freely with inequality constraints.

## Changes
- Add `EqualityConstraint(func, tolerance=1e-6)` to `problem.py`, overriding only `violation_from_value` → `max(0, |h(x)| - tolerance)`
- Introduce `InequalityConstraint.violation_from_value()` as the single source of truth for the per-constraint violation formula (reused by `violation`, `evaluate_with_violation`, and `StaticToleranceHandler`)
- Update `StaticToleranceHandler.compute_cv` to delegate per-constraint, enabling mixed inequality/equality aggregation
- Export `EqualityConstraint` from `saealib.__init__`
- Add unit tests (`|h(x)|`, tolerance boundary, mixed constraints) and an `examples/` entry minimizing on `x1 + x2 = 1`

## Verification Steps
- run pytest tests/test_constraint.py
- run python examples/sample_equality_constraint.py

## Concerns
- Static tolerance only; dynamic ε-tightening is deferred to #109
- Existing `Constraint` (inequality) behavior is unchanged

## Other
- Builds on the `ConstraintHandler` framework (#108)
