### PR TITLE
feat: [#94] Add equality constraint support (EqualityConstraint)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ from saealib import (
     IndividualBasedStrategy,
     Termination,
     max_fe,
+    f_target,
     gaussian_kernel
 )
 
@@ -133,7 +134,9 @@ surrogate = RBFsurrogate(gaussian_kernel, dim)
 strategy = IndividualBasedStrategy(evaluation_ratio=0.1)
 
 # Termination Criterion
-termination = Termination(max_fe(100))  # Stop after 100 function evaluations
+# Conditions compose with & (AND), | (OR), and ~ (NOT).
+# Here: stop after 100 evaluations OR once the objective reaches the target.
+termination = Termination(max_fe(100) | f_target(1e-6))
 
 # 4. Build and Run the Optimizer
 opt = (

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -119,7 +119,14 @@ from saealib.surrogate.sklearn_surrogate import (
     XGBSurrogate,
 )
 from saealib.surrogate.torch_surrogate import TorchSurrogate
-from saealib.termination import Termination, max_fe, max_gen
+from saealib.termination import (
+    Termination,
+    TerminationCondition,
+    f_target,
+    max_fe,
+    max_gen,
+    stalled,
+)
 from saealib.utils.indicators import hypervolume
 
 logger = logging.getLogger(__name__).addHandler(logging.NullHandler())
@@ -207,6 +214,7 @@ __all__ = [
     "SurrogateStartEvent",
     "SurvivorSelection",
     "Termination",
+    "TerminationCondition",
     "TorchSurrogate",
     "TournamentSelection",
     "TruncationSelection",
@@ -214,6 +222,7 @@ __all__ = [
     "XGBSurrogate",
     "crowding_distance",
     "crowding_distance_all_fronts",
+    "f_target",
     "gaussian_kernel",
     "hypervolume",
     "logging_generation",
@@ -224,4 +233,5 @@ __all__ = [
     "minimize",
     "non_dominated_sort",
     "repair_clipping",
+    "stalled",
 ]

--- a/src/saealib/termination.py
+++ b/src/saealib/termination.py
@@ -178,13 +178,18 @@ class Termination:
                     "Termination condition must be callable, "
                     f"got {type(cond).__name__}."
                 )
-        self.conditions: tuple[ConditionFunc | TerminationCondition, ...] = conditions
-        # Combine all conditions with OR so that ``is_terminated`` evaluates a
-        # single composed ``TerminationCondition``.
-        self._combined: TerminationCondition = reduce(
+        # Combine all conditions with OR into a single composed
+        # ``TerminationCondition``, which is the sole source of truth used by
+        # ``is_terminated``.
+        self._condition: TerminationCondition = reduce(
             operator.or_,
             (TerminationCondition._coerce(cond) for cond in conditions),
         )
+
+    @property
+    def condition(self) -> TerminationCondition:
+        """Return the composed termination condition (read-only)."""
+        return self._condition
 
     @classmethod
     def any_of(cls, *conditions: ConditionFunc | TerminationCondition) -> Termination:
@@ -265,7 +270,7 @@ class Termination:
         bool
             True if the termination condition is met, False otherwise.
         """
-        return self._combined(ctx)
+        return self._condition(ctx)
 
 
 # Built-in termination condition factories

--- a/src/saealib/termination.py
+++ b/src/saealib/termination.py
@@ -326,3 +326,92 @@ def max_gen(value: int) -> TerminationCondition:
         name=f"max_gen({value})",
         doc=f"Terminate when gen >= {value}.",
     )
+
+
+def f_target(value: float) -> TerminationCondition:
+    """
+    Create a termination condition based on a target objective value.
+
+    Intended for single-objective problems. The direction is taken from
+    ``ctx.weight`` (``-1`` for minimization, ``+1`` for maximization), so the
+    condition is met when the best objective found reaches ``value`` from the
+    correct side (``best <= value`` when minimizing, ``best >= value`` when
+    maximizing). Returns ``False`` while the archive is empty.
+
+    Parameters
+    ----------
+    value : float
+        Target objective value.
+
+    Returns
+    -------
+    TerminationCondition
+        A composable condition that returns True when the best objective in
+        the archive reaches ``value``.
+
+    Examples
+    --------
+    >>> termination = Termination(max_fe(2000), f_target(1e-6))
+    """
+
+    def _condition(ctx: OptimizationContext) -> bool:
+        f = ctx.archive.get("f")
+        if f is None or len(f) == 0:
+            return False
+        weight = ctx.weight
+        # Work in score space (higher is better) so a single comparison covers
+        # both minimization and maximization.
+        best_score = float((f @ weight).max())
+        return best_score >= value * float(weight[0])
+
+    return TerminationCondition(
+        _condition,
+        name=f"f_target({value})",
+        doc=f"Terminate when the best objective reaches {value}.",
+    )
+
+
+def stalled(window: int, tol: float = 1e-8) -> TerminationCondition:
+    """
+    Create a termination condition based on lack of improvement (stagnation).
+
+    Terminates when the best score (``f @ weight``, higher is better) has not
+    improved by more than ``tol`` for ``window`` consecutive generations.
+    Improvement is tracked across calls using ``ctx.gen``; the returned
+    condition is therefore stateful and intended to be used once per run.
+
+    Parameters
+    ----------
+    window : int
+        Number of generations without improvement before terminating.
+    tol : float, optional
+        Minimum score increase counted as an improvement, by default ``1e-8``.
+
+    Returns
+    -------
+    TerminationCondition
+        A composable condition that returns True after ``window`` stagnant
+        generations.
+
+    Examples
+    --------
+    >>> termination = Termination(max_fe(2000), stalled(20))
+    """
+    state: dict[str, float | None] = {"best": None, "stall_gen": None}
+
+    def _condition(ctx: OptimizationContext) -> bool:
+        f = ctx.archive.get("f")
+        if f is None or len(f) == 0:
+            return False
+        best_score = float((f @ ctx.weight).max())
+        if state["best"] is None or best_score > state["best"] + tol:
+            state["best"] = best_score
+            state["stall_gen"] = ctx.gen
+            return False
+        return (ctx.gen - state["stall_gen"]) >= window
+
+    return TerminationCondition(
+        _condition,
+        name=f"stalled({window})",
+        doc=f"Terminate after {window} generations without improvement.",
+    )

--- a/src/saealib/termination.py
+++ b/src/saealib/termination.py
@@ -14,10 +14,123 @@ if TYPE_CHECKING:
     from saealib.context import OptimizationContext
 
 
-#: Type alias for a termination condition function.
-#: A callable that takes an OptimizationContext and returns True
-#: when the optimization should stop.
-TerminationCondition = Callable[["OptimizationContext"], bool]
+#: Type alias for a plain termination condition function.
+#: A callable that takes an ``OptimizationContext`` and returns ``True``
+#: when the optimization should stop. Accepted everywhere a
+#: :class:`TerminationCondition` is, and wrapped automatically when composed.
+ConditionFunc = Callable[["OptimizationContext"], bool]
+
+
+class TerminationCondition:
+    """
+    Composable termination condition.
+
+    Wraps a callable ``ctx -> bool`` and adds logical operators so that
+    conditions can be combined declaratively:
+
+    - ``a | b`` : terminate when **either** ``a`` or ``b`` is met (OR)
+    - ``a & b`` : terminate when **both** ``a`` and ``b`` are met (AND)
+    - ``~a``    : terminate when ``a`` is **not** met (NOT)
+
+    The other operand may be a plain ``Callable[[ctx], bool]``; it is
+    wrapped automatically. Reflected operators (``__ror__`` / ``__rand__``)
+    let a plain callable appear on the left-hand side as well.
+
+    Parameters
+    ----------
+    func : Callable[[OptimizationContext], bool]
+        The underlying condition callable.
+    name : str, optional
+        Human-readable name used for ``repr`` and ``__qualname__``.
+        Defaults to ``func.__qualname__`` when available.
+    doc : str, optional
+        Docstring for the wrapped condition. Defaults to ``func.__doc__``.
+
+    Raises
+    ------
+    TypeError
+        If ``func`` is not callable.
+
+    Examples
+    --------
+    >>> cond = max_fe(2000) & (lambda ctx: ctx.archive.get("f").min() < 1e-6)
+    >>> cond = max_gen(100) | max_fe(2000)
+    >>> cond = ~stalled(20)
+    """
+
+    def __init__(
+        self,
+        func: ConditionFunc,
+        *,
+        name: str | None = None,
+        doc: str | None = None,
+    ) -> None:
+        if not callable(func):
+            raise TypeError(
+                "Termination condition must be callable, "
+                f"got {type(func).__name__}."
+            )
+        self._func = func
+        self.__qualname__ = (
+            name if name is not None else getattr(func, "__qualname__", repr(func))
+        )
+        resolved_doc = doc if doc is not None else getattr(func, "__doc__", None)
+        if resolved_doc is not None:
+            self.__doc__ = resolved_doc
+
+    @staticmethod
+    def _coerce(cond: ConditionFunc | TerminationCondition) -> TerminationCondition:
+        """Wrap a plain callable into a ``TerminationCondition`` if needed."""
+        if isinstance(cond, TerminationCondition):
+            return cond
+        return TerminationCondition(cond)
+
+    def __call__(self, ctx: OptimizationContext) -> bool:
+        """Evaluate the wrapped condition against ``ctx``."""
+        return bool(self._func(ctx))
+
+    def __or__(
+        self, other: ConditionFunc | TerminationCondition
+    ) -> TerminationCondition:
+        """Compose with OR: terminate when either condition is met."""
+        other = self._coerce(other)
+        return TerminationCondition(
+            lambda ctx: self(ctx) or other(ctx),
+            name=f"({self.__qualname__} | {other.__qualname__})",
+        )
+
+    def __ror__(
+        self, other: ConditionFunc | TerminationCondition
+    ) -> TerminationCondition:
+        """Compose with OR when a plain callable is on the left-hand side."""
+        return self._coerce(other) | self
+
+    def __and__(
+        self, other: ConditionFunc | TerminationCondition
+    ) -> TerminationCondition:
+        """Compose with AND: terminate when both conditions are met."""
+        other = self._coerce(other)
+        return TerminationCondition(
+            lambda ctx: self(ctx) and other(ctx),
+            name=f"({self.__qualname__} & {other.__qualname__})",
+        )
+
+    def __rand__(
+        self, other: ConditionFunc | TerminationCondition
+    ) -> TerminationCondition:
+        """Compose with AND when a plain callable is on the left-hand side."""
+        return self._coerce(other) & self
+
+    def __invert__(self) -> TerminationCondition:
+        """Negate the condition with NOT."""
+        return TerminationCondition(
+            lambda ctx: not self(ctx),
+            name=f"~{self.__qualname__}",
+        )
+
+    def __repr__(self) -> str:
+        """Return a readable representation including the condition name."""
+        return f"TerminationCondition({self.__qualname__})"
 
 
 class Termination:
@@ -83,7 +196,7 @@ class Termination:
 # Built-in termination condition factories
 
 
-def max_fe(value: int) -> TerminationCondition:
+def max_fe(value: int) -> ConditionFunc:
     """
     Create a termination condition based on maximum function evaluations.
 
@@ -94,7 +207,7 @@ def max_fe(value: int) -> TerminationCondition:
 
     Returns
     -------
-    TerminationCondition
+    ConditionFunc
         A callable that returns True when ``ctx.fe >= value``.
 
     Examples
@@ -110,7 +223,7 @@ def max_fe(value: int) -> TerminationCondition:
     return _condition
 
 
-def max_gen(value: int) -> TerminationCondition:
+def max_gen(value: int) -> ConditionFunc:
     """
     Create a termination condition based on maximum generations.
 
@@ -121,7 +234,7 @@ def max_gen(value: int) -> TerminationCondition:
 
     Returns
     -------
-    TerminationCondition
+    ConditionFunc
         A callable that returns True when ``ctx.gen >= value``.
 
     Examples

--- a/src/saealib/termination.py
+++ b/src/saealib/termination.py
@@ -69,8 +69,7 @@ class TerminationCondition:
     ) -> None:
         if not callable(func):
             raise TypeError(
-                "Termination condition must be callable, "
-                f"got {type(func).__name__}."
+                f"Termination condition must be callable, got {type(func).__name__}."
             )
         self._func = func
         self.__qualname__ = (

--- a/src/saealib/termination.py
+++ b/src/saealib/termination.py
@@ -276,7 +276,7 @@ class Termination:
 # Built-in termination condition factories
 
 
-def max_fe(value: int) -> ConditionFunc:
+def max_fe(value: int) -> TerminationCondition:
     """
     Create a termination condition based on maximum function evaluations.
 
@@ -287,23 +287,22 @@ def max_fe(value: int) -> ConditionFunc:
 
     Returns
     -------
-    ConditionFunc
-        A callable that returns True when ``ctx.fe >= value``.
+    TerminationCondition
+        A composable condition that returns True when ``ctx.fe >= value``.
 
     Examples
     --------
     >>> termination = Termination(max_fe(2000))
+    >>> condition = max_fe(2000) & max_gen(100)
     """
-
-    def _condition(ctx: OptimizationContext) -> bool:
-        return ctx.fe >= value
-
-    _condition.__doc__ = f"Terminate when fe >= {value}."
-    _condition.__qualname__ = f"max_fe({value})"
-    return _condition
+    return TerminationCondition(
+        lambda ctx: ctx.fe >= value,
+        name=f"max_fe({value})",
+        doc=f"Terminate when fe >= {value}.",
+    )
 
 
-def max_gen(value: int) -> ConditionFunc:
+def max_gen(value: int) -> TerminationCondition:
     """
     Create a termination condition based on maximum generations.
 
@@ -314,17 +313,16 @@ def max_gen(value: int) -> ConditionFunc:
 
     Returns
     -------
-    ConditionFunc
-        A callable that returns True when ``ctx.gen >= value``.
+    TerminationCondition
+        A composable condition that returns True when ``ctx.gen >= value``.
 
     Examples
     --------
     >>> termination = Termination(max_gen(100))
+    >>> condition = max_gen(100) | max_fe(2000)
     """
-
-    def _condition(ctx: OptimizationContext) -> bool:
-        return ctx.gen >= value
-
-    _condition.__doc__ = f"Terminate when gen >= {value}."
-    _condition.__qualname__ = f"max_gen({value})"
-    return _condition
+    return TerminationCondition(
+        lambda ctx: ctx.gen >= value,
+        name=f"max_gen({value})",
+        doc=f"Terminate when gen >= {value}.",
+    )

--- a/src/saealib/termination.py
+++ b/src/saealib/termination.py
@@ -7,7 +7,9 @@ Users can specify arbitrary termination conditions as callable objects.
 
 from __future__ import annotations
 
+import operator
 from collections.abc import Callable
+from functools import reduce
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -144,7 +146,7 @@ class Termination:
 
     Parameters
     ----------
-    *conditions : TerminationCondition
+    *conditions : ConditionFunc or TerminationCondition
         One or more callable conditions. Each must accept an
         ``OptimizationContext`` and return ``bool``.
 
@@ -163,9 +165,11 @@ class Termination:
     ...     max_fe(2000),
     ...     lambda ctx: ctx.archive.get("f").min() < 1e-6,
     ... )
+    >>> termination = Termination.all_of(max_fe(2000), max_gen(100))
+    >>> termination = Termination.not_(max_gen(100))
     """
 
-    def __init__(self, *conditions: TerminationCondition):
+    def __init__(self, *conditions: ConditionFunc | TerminationCondition):
         if not conditions:
             raise ValueError("At least one termination condition must be provided.")
         for cond in conditions:
@@ -174,11 +178,82 @@ class Termination:
                     "Termination condition must be callable, "
                     f"got {type(cond).__name__}."
                 )
-        self.conditions: tuple[TerminationCondition, ...] = conditions
+        self.conditions: tuple[ConditionFunc | TerminationCondition, ...] = conditions
+        # Combine all conditions with OR so that ``is_terminated`` evaluates a
+        # single composed ``TerminationCondition``.
+        self._combined: TerminationCondition = reduce(
+            operator.or_,
+            (TerminationCondition._coerce(cond) for cond in conditions),
+        )
+
+    @classmethod
+    def any_of(cls, *conditions: ConditionFunc | TerminationCondition) -> Termination:
+        """
+        Build a Termination that stops when **any** condition is met (OR).
+
+        Equivalent to ``Termination(*conditions)``; provided for symmetry
+        with :meth:`all_of` and :meth:`not_`.
+
+        Parameters
+        ----------
+        *conditions : ConditionFunc or TerminationCondition
+            One or more callable conditions.
+
+        Returns
+        -------
+        Termination
+            A termination combining the conditions with OR.
+        """
+        return cls(*conditions)
+
+    @classmethod
+    def all_of(cls, *conditions: ConditionFunc | TerminationCondition) -> Termination:
+        """
+        Build a Termination that stops when **all** conditions are met (AND).
+
+        Parameters
+        ----------
+        *conditions : ConditionFunc or TerminationCondition
+            One or more callable conditions.
+
+        Returns
+        -------
+        Termination
+            A termination combining the conditions with AND.
+
+        Raises
+        ------
+        ValueError
+            If no conditions are provided.
+        """
+        if not conditions:
+            raise ValueError("At least one termination condition must be provided.")
+        combined = reduce(
+            operator.and_,
+            (TerminationCondition._coerce(cond) for cond in conditions),
+        )
+        return cls(combined)
+
+    @classmethod
+    def not_(cls, condition: ConditionFunc | TerminationCondition) -> Termination:
+        """
+        Build a Termination that stops when ``condition`` is **not** met (NOT).
+
+        Parameters
+        ----------
+        condition : ConditionFunc or TerminationCondition
+            The condition to negate.
+
+        Returns
+        -------
+        Termination
+            A termination that negates the given condition.
+        """
+        return cls(~TerminationCondition._coerce(condition))
 
     def is_terminated(self, ctx: OptimizationContext) -> bool:
         """
-        Check if any termination condition is met.
+        Check if the composed termination condition is met.
 
         Parameters
         ----------
@@ -188,9 +263,9 @@ class Termination:
         Returns
         -------
         bool
-            True if any termination condition is met, False otherwise.
+            True if the termination condition is met, False otherwise.
         """
-        return any(cond(ctx) for cond in self.conditions)
+        return self._combined(ctx)
 
 
 # Built-in termination condition factories

--- a/tests/test_termination.py
+++ b/tests/test_termination.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from saealib.termination import Termination, max_fe, max_gen
+from saealib.termination import Termination, TerminationCondition, max_fe, max_gen
 
 
 def _make_ctx(fe: int = 0, gen: int = 0) -> SimpleNamespace:
@@ -28,15 +28,15 @@ class TestTerminationInit:
 
     def test_single_condition(self) -> None:
         t = Termination(max_fe(100))
-        assert len(t.conditions) == 1
+        assert isinstance(t.condition, TerminationCondition)
 
     def test_multiple_conditions(self) -> None:
         t = Termination(max_fe(100), max_gen(50))
-        assert len(t.conditions) == 2
+        assert isinstance(t.condition, TerminationCondition)
 
     def test_lambda_condition(self) -> None:
         t = Termination(lambda ctx: ctx.fe >= 10)
-        assert len(t.conditions) == 1
+        assert isinstance(t.condition, TerminationCondition)
 
     def test_no_conditions_raises_value_error(self) -> None:
         with pytest.raises(ValueError, match="At least one"):
@@ -50,9 +50,10 @@ class TestTerminationInit:
         with pytest.raises(TypeError, match="must be callable"):
             Termination(max_fe(100), "not_callable")
 
-    def test_conditions_stored_as_tuple(self) -> None:
+    def test_condition_is_read_only(self) -> None:
         t = Termination(max_fe(100))
-        assert isinstance(t.conditions, tuple)
+        with pytest.raises(AttributeError):
+            t.condition = max_gen(50)  # type: ignore[misc]
 
 
 # ===========================================================================

--- a/tests/test_termination.py
+++ b/tests/test_termination.py
@@ -10,14 +10,41 @@ Tests cover:
 
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
 
-from saealib.termination import Termination, TerminationCondition, max_fe, max_gen
+from saealib.termination import (
+    Termination,
+    TerminationCondition,
+    f_target,
+    max_fe,
+    max_gen,
+    stalled,
+)
 
 
 def _make_ctx(fe: int = 0, gen: int = 0) -> SimpleNamespace:
     """Create a minimal context-like object with fe and gen attributes."""
     return SimpleNamespace(fe=fe, gen=gen)
+
+
+def _make_obj_ctx(
+    f_values, weight: float = -1.0, gen: int = 0, fe: int = 0
+) -> SimpleNamespace:
+    """
+    Create a context-like object with an archive of objective values.
+
+    ``f_values`` is a sequence of single-objective values (shape ``(n,)``);
+    ``weight`` is the optimization direction (-1 minimize, +1 maximize).
+    """
+    f_arr = np.asarray(f_values, dtype=float).reshape(-1, 1)
+    archive = SimpleNamespace(get=lambda key: f_arr if key == "f" else None)
+    return SimpleNamespace(
+        archive=archive,
+        weight=np.array([weight], dtype=float),
+        gen=gen,
+        fe=fe,
+    )
 
 
 # ===========================================================================
@@ -221,3 +248,163 @@ class TestTerminationEdgeCases:
                 assert t.is_terminated(ctx) is False
             else:
                 assert t.is_terminated(ctx) is True
+
+
+# ===========================================================================
+# TerminationCondition Operator Tests
+# ===========================================================================
+class TestTerminationConditionOperators:
+    """Tests for the composable TerminationCondition class."""
+
+    def test_factories_return_termination_condition(self) -> None:
+        assert isinstance(max_fe(100), TerminationCondition)
+        assert isinstance(max_gen(50), TerminationCondition)
+
+    def test_call_returns_bool(self) -> None:
+        cond = TerminationCondition(lambda ctx: ctx.fe)
+        result = cond(_make_ctx(fe=5))
+        assert result is True
+        assert isinstance(result, bool)
+
+    def test_or_operator(self) -> None:
+        cond = max_fe(100) | max_gen(50)
+        assert cond(_make_ctx(fe=10, gen=10)) is False
+        assert cond(_make_ctx(fe=100, gen=10)) is True
+        assert cond(_make_ctx(fe=10, gen=50)) is True
+
+    def test_and_operator(self) -> None:
+        cond = max_fe(100) & max_gen(50)
+        assert cond(_make_ctx(fe=100, gen=10)) is False
+        assert cond(_make_ctx(fe=10, gen=50)) is False
+        assert cond(_make_ctx(fe=100, gen=50)) is True
+
+    def test_invert_operator(self) -> None:
+        cond = ~max_gen(50)
+        assert cond(_make_ctx(gen=10)) is True
+        assert cond(_make_ctx(gen=50)) is False
+
+    def test_operators_accept_plain_callable(self) -> None:
+        cond = max_fe(100) & (lambda ctx: ctx.gen >= 5)
+        assert cond(_make_ctx(fe=100, gen=4)) is False
+        assert cond(_make_ctx(fe=100, gen=5)) is True
+
+    def test_reflected_operators_with_plain_callable_on_left(self) -> None:
+        and_cond = (lambda ctx: ctx.gen >= 5) & max_fe(100)
+        assert and_cond(_make_ctx(fe=100, gen=4)) is False
+        assert and_cond(_make_ctx(fe=100, gen=5)) is True
+
+        or_cond = (lambda ctx: ctx.gen >= 5) | max_fe(100)
+        assert or_cond(_make_ctx(fe=10, gen=4)) is False
+        assert or_cond(_make_ctx(fe=10, gen=5)) is True
+
+    def test_non_callable_raises_type_error(self) -> None:
+        with pytest.raises(TypeError, match="must be callable"):
+            TerminationCondition(42)
+
+    def test_qualname_reflects_composition(self) -> None:
+        assert "max_fe(100)" in (max_fe(100) | max_gen(50)).__qualname__
+        assert "max_gen(50)" in (max_fe(100) | max_gen(50)).__qualname__
+
+    def test_repr(self) -> None:
+        assert repr(max_fe(100)) == "TerminationCondition(max_fe(100))"
+
+
+# ===========================================================================
+# Termination classmethod Tests (any_of / all_of / not_)
+# ===========================================================================
+class TestTerminationClassMethods:
+    """Tests for Termination.any_of / all_of / not_."""
+
+    def test_any_of_or_logic(self) -> None:
+        t = Termination.any_of(max_fe(100), max_gen(50))
+        assert t.is_terminated(_make_ctx(fe=10, gen=10)) is False
+        assert t.is_terminated(_make_ctx(fe=100, gen=10)) is True
+
+    def test_all_of_and_logic(self) -> None:
+        t = Termination.all_of(max_fe(100), max_gen(50))
+        assert t.is_terminated(_make_ctx(fe=100, gen=10)) is False
+        assert t.is_terminated(_make_ctx(fe=100, gen=50)) is True
+
+    def test_all_of_single_condition(self) -> None:
+        t = Termination.all_of(max_fe(100))
+        assert t.is_terminated(_make_ctx(fe=99)) is False
+        assert t.is_terminated(_make_ctx(fe=100)) is True
+
+    def test_all_of_no_conditions_raises(self) -> None:
+        with pytest.raises(ValueError, match="At least one"):
+            Termination.all_of()
+
+    def test_not_negates(self) -> None:
+        t = Termination.not_(max_gen(50))
+        assert t.is_terminated(_make_ctx(gen=10)) is True
+        assert t.is_terminated(_make_ctx(gen=50)) is False
+
+    def test_not_accepts_plain_callable(self) -> None:
+        t = Termination.not_(lambda ctx: ctx.fe >= 100)
+        assert t.is_terminated(_make_ctx(fe=10)) is True
+        assert t.is_terminated(_make_ctx(fe=100)) is False
+
+    def test_returns_termination_instance(self) -> None:
+        assert isinstance(Termination.any_of(max_fe(100)), Termination)
+        assert isinstance(Termination.all_of(max_fe(100)), Termination)
+        assert isinstance(Termination.not_(max_fe(100)), Termination)
+
+
+# ===========================================================================
+# f_target Tests
+# ===========================================================================
+class TestFTarget:
+    """Tests for the f_target factory function."""
+
+    def test_returns_termination_condition(self) -> None:
+        assert isinstance(f_target(1e-6), TerminationCondition)
+
+    def test_minimize_not_reached(self) -> None:
+        cond = f_target(1e-6)
+        assert cond(_make_obj_ctx([0.5, 0.1], weight=-1.0)) is False
+
+    def test_minimize_reached(self) -> None:
+        cond = f_target(1e-6)
+        assert cond(_make_obj_ctx([0.5, 1e-9], weight=-1.0)) is True
+
+    def test_maximize_not_reached(self) -> None:
+        cond = f_target(100.0)
+        assert cond(_make_obj_ctx([10.0, 50.0], weight=1.0)) is False
+
+    def test_maximize_reached(self) -> None:
+        cond = f_target(100.0)
+        assert cond(_make_obj_ctx([10.0, 150.0], weight=1.0)) is True
+
+    def test_empty_archive_returns_false(self) -> None:
+        cond = f_target(1e-6)
+        assert cond(_make_obj_ctx([], weight=-1.0)) is False
+
+
+# ===========================================================================
+# stalled Tests
+# ===========================================================================
+class TestStalled:
+    """Tests for the stalled factory function."""
+
+    def test_returns_termination_condition(self) -> None:
+        assert isinstance(stalled(5), TerminationCondition)
+
+    def test_terminates_after_window(self) -> None:
+        cond = stalled(3)
+        # First call sets the baseline best; no improvement afterwards.
+        assert cond(_make_obj_ctx([1.0], weight=-1.0, gen=0)) is False
+        assert cond(_make_obj_ctx([1.0], weight=-1.0, gen=1)) is False
+        assert cond(_make_obj_ctx([1.0], weight=-1.0, gen=2)) is False
+        assert cond(_make_obj_ctx([1.0], weight=-1.0, gen=3)) is True
+
+    def test_improvement_resets_counter(self) -> None:
+        cond = stalled(2)
+        assert cond(_make_obj_ctx([1.0], weight=-1.0, gen=0)) is False
+        assert cond(_make_obj_ctx([1.0], weight=-1.0, gen=1)) is False
+        # Improvement (lower is better when minimizing) resets the stall gen.
+        assert cond(_make_obj_ctx([0.5], weight=-1.0, gen=2)) is False
+        assert cond(_make_obj_ctx([0.5], weight=-1.0, gen=4)) is True
+
+    def test_empty_archive_returns_false(self) -> None:
+        cond = stalled(3)
+        assert cond(_make_obj_ctx([], weight=-1.0, gen=10)) is False


### PR DESCRIPTION
## Related Issue
Closes #94

## Overview
`Termination` previously supported OR-only composition (`any(...)`), so complex stopping rules such as "max_fe AND best_f < tol" or "max_gen AND NOT stalled" required hand-written lambdas. This PR turns `TerminationCondition` into a composable class with `&` / `|` / `~` operator overloads, adds `any_of` / `all_of` / `not_` helpers on `Termination`, and ships ready-made `f_target` and `stalled` conditions. Existing OR behavior and plain `Callable[[ctx], bool]` conditions remain fully supported.

## Changes
- Replace the `TerminationCondition` type alias with a composable class implementing `__call__`, `__or__`, `__and__`, `__invert__` (plus reflected `__ror__` / `__rand__`); plain callables are coerced automatically.
- Refactor `Termination.__init__` to fold conditions into a single composed condition via `|`, and add the `any_of` (OR) / `all_of` (AND) / `not_` (NOT) classmethods.
- Unify `Termination` on a single source of truth: drop the redundant `conditions` tuple (it was read only by tests and could desync from the evaluated condition) and expose a read-only `condition` property.
- Return `TerminationCondition` from `max_fe` / `max_gen` so the built-ins compose directly without manual wrapping (names/docstrings preserved).
- Add `f_target(value)` (target objective, direction taken from `ctx.weight`) and `stalled(window, tol)` (terminate after stagnant generations); export `TerminationCondition`, `f_target`, and `stalled` from the package.
- Expand unit tests (33 → 60) and integrate a composition example into the README quickstart.

## Verification Steps
run pytest (tests/test_termination.py)

## Concerns
- The public `Termination.conditions` attribute was removed in favor of the read-only `condition` property. No production code referenced it (only tests); behavior of `Termination(*conds)` is unchanged.
- `stalled(...)` is stateful (tracks the last-improving generation via `ctx.gen`) and is intended to be used as a single instance per run.
- `f_target(...)` targets single-objective problems.