### PR TITLE
feat: [#75] Implement MOO acquisition functions (ParEGO, SMS-EGO, HV-based)

### DIFF
--- a/src/saealib/acquisition/__init__.py
+++ b/src/saealib/acquisition/__init__.py
@@ -7,17 +7,23 @@ scores used to rank candidates for true evaluation.
 """
 
 from saealib.acquisition.base import AcquisitionFunction
+from saealib.acquisition.ehvi import EHVIAcquisition
 from saealib.acquisition.ei import ExpectedImprovement
 from saealib.acquisition.lcb import LowerConfidenceBound
 from saealib.acquisition.mean import MeanPrediction
+from saealib.acquisition.parego import ParEGOAcquisition
 from saealib.acquisition.pof import ProbabilityOfFeasibility
+from saealib.acquisition.smsego import SMSEGOAcquisition
 from saealib.acquisition.uncertainty import MaxUncertainty
 
 __all__ = [
     "AcquisitionFunction",
+    "EHVIAcquisition",
     "ExpectedImprovement",
     "LowerConfidenceBound",
     "MaxUncertainty",
     "MeanPrediction",
+    "ParEGOAcquisition",
     "ProbabilityOfFeasibility",
+    "SMSEGOAcquisition",
 ]

--- a/src/saealib/acquisition/ehvi.py
+++ b/src/saealib/acquisition/ehvi.py
@@ -1,0 +1,139 @@
+"""EHVI (Expected Hypervolume Improvement) acquisition function module."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from saealib.acquisition.base import AcquisitionFunction
+from saealib.surrogate.prediction import SurrogatePrediction
+from saealib.utils.indicators import _non_dominated, hypervolume
+
+if TYPE_CHECKING:
+    from saealib.population import Archive
+
+
+class EHVIAcquisition(AcquisitionFunction):
+    """
+    Expected Hypervolume Improvement (EHVI) acquisition function.
+
+    Estimates EHVI via Monte Carlo sampling (Hupkens 2015 Eq. 1; HVI
+    definition from Daulton 2020 Definition 2)::
+
+        EHVI(x) = (1/S) * sum_s HVI(y_s, P, r)
+        y_s ~ N(mu(x), diag(sigma^2(x)))   [independent objectives]
+
+    where HVI(y, P, r) = HV(P u {y}, r) - HV(P, r).
+
+    Parameters
+    ----------
+    n_samples : int
+        Number of MC samples per candidate.  Default: 256.
+    reference_point : array-like or None
+        Hypervolume reference point (minimisation convention).  If None,
+        auto-computed from the archive nadir with a 10 % margin.
+    rng : np.random.Generator or None
+        Random number generator for MC sampling.
+    """
+
+    requires_uncertainty: bool = True
+
+    def __init__(
+        self,
+        n_samples: int = 256,
+        reference_point: np.ndarray | None = None,
+        rng: np.random.Generator | None = None,
+    ) -> None:
+        self.n_samples = n_samples
+        self.reference_point = (
+            np.asarray(reference_point, dtype=float)
+            if reference_point is not None
+            else None
+        )
+        self._rng = rng if rng is not None else np.random.default_rng()
+
+    def compute_reference(
+        self, archive: Archive
+    ) -> tuple[np.ndarray, np.ndarray, float]:
+        """
+        Extract the Pareto front and (if needed) compute the reference point.
+
+        Parameters
+        ----------
+        archive : Archive
+            Archive of evaluated solutions.
+
+        Returns
+        -------
+        tuple
+            ``(pareto_f, ref_point, base_hv)`` — non-dominated objective
+            matrix, hypervolume reference point, and current hypervolume.
+        """
+        f = archive.f
+        pareto_f = _non_dominated(f)
+
+        if self.reference_point is not None:
+            ref = self.reference_point
+        else:
+            nadir = f.max(axis=0)
+            span = nadir - f.min(axis=0)
+            ref = nadir + 0.1 * np.maximum(span, 1e-6)
+
+        base_hv = hypervolume(pareto_f, ref)
+        return pareto_f, ref, base_hv
+
+    def score(
+        self,
+        prediction: SurrogatePrediction,
+        reference: Any,
+    ) -> np.ndarray:
+        """
+        Estimate EHVI via Monte Carlo sampling.
+
+        Parameters
+        ----------
+        prediction : SurrogatePrediction
+            Surrogate predictions.  Must have std (has_uncertainty == True).
+        reference : tuple
+            ``(pareto_f, ref_point, base_hv)`` from ``compute_reference``.
+
+        Returns
+        -------
+        np.ndarray
+            EHVI scores.  shape: (n_samples,).  Higher is better.
+
+        Raises
+        ------
+        TypeError
+            If prediction does not contain uncertainty estimates.
+        """
+        if not prediction.has_uncertainty:
+            raise TypeError(
+                "EHVIAcquisition requires uncertainty estimates "
+                "(prediction.std must not be None)."
+            )
+        pareto_f, ref_point, base_hv = reference
+        mu = prediction.value    # (n_cand, n_obj)
+        sigma = prediction.std   # (n_cand, n_obj)
+        n_cand, n_obj = mu.shape
+
+        # Draw all MC samples at once: (n_samples, n_cand, n_obj)
+        eps = self._rng.standard_normal((self.n_samples, n_cand, n_obj))
+        mc_samples = mu[np.newaxis] + sigma[np.newaxis] * eps
+
+        ehvi = np.zeros(n_cand)
+        for i in range(n_cand):
+            hvi_sum = 0.0
+            for s in range(self.n_samples):
+                y = mc_samples[s, i]
+                if np.any(y >= ref_point):
+                    continue
+                combined = (
+                    y[np.newaxis] if len(pareto_f) == 0
+                    else np.vstack([pareto_f, y[np.newaxis]])
+                )
+                hvi_sum += max(hypervolume(combined, ref_point) - base_hv, 0.0)
+            ehvi[i] = hvi_sum / self.n_samples
+
+        return ehvi

--- a/src/saealib/acquisition/ehvi.py
+++ b/src/saealib/acquisition/ehvi.py
@@ -114,8 +114,8 @@ class EHVIAcquisition(AcquisitionFunction):
                 "(prediction.std must not be None)."
             )
         pareto_f, ref_point, base_hv = reference
-        mu = prediction.value    # (n_cand, n_obj)
-        sigma = prediction.std   # (n_cand, n_obj)
+        mu = prediction.value  # (n_cand, n_obj)
+        sigma = prediction.std  # (n_cand, n_obj)
         n_cand, n_obj = mu.shape
 
         # Draw all MC samples at once: (n_samples, n_cand, n_obj)
@@ -130,7 +130,8 @@ class EHVIAcquisition(AcquisitionFunction):
                 if np.any(y >= ref_point):
                     continue
                 combined = (
-                    y[np.newaxis] if len(pareto_f) == 0
+                    y[np.newaxis]
+                    if len(pareto_f) == 0
                     else np.vstack([pareto_f, y[np.newaxis]])
                 )
                 hvi_sum += max(hypervolume(combined, ref_point) - base_hv, 0.0)

--- a/src/saealib/acquisition/parego.py
+++ b/src/saealib/acquisition/parego.py
@@ -65,8 +65,8 @@ class ParEGOAcquisition(AcquisitionFunction):
         z_star: np.ndarray,
     ) -> np.ndarray:
         """Augmented Tchebycheff scalarization (Chugh 2020 Eq. 8)."""
-        diff = np.abs(f - z_star)            # (..., n_obj)
-        weighted = weights * diff            # (..., n_obj)
+        diff = np.abs(f - z_star)  # (..., n_obj)
+        weighted = weights * diff  # (..., n_obj)
         return weighted.max(axis=-1) + self.alpha * weighted.sum(axis=-1)
 
     def compute_reference(
@@ -126,8 +126,8 @@ class ParEGOAcquisition(AcquisitionFunction):
             )
         z_star, weights, f_best = reference
 
-        mu_s = self._scalarize(prediction.value, weights, z_star)   # (n,)
-        sigma_s = (weights * prediction.std).sum(axis=-1)            # (n,)
+        mu_s = self._scalarize(prediction.value, weights, z_star)  # (n,)
+        sigma_s = (weights * prediction.std).sum(axis=-1)  # (n,)
         sigma_s = np.maximum(sigma_s, 1e-9)
 
         z = (f_best - mu_s) / sigma_s

--- a/src/saealib/acquisition/parego.py
+++ b/src/saealib/acquisition/parego.py
@@ -1,0 +1,135 @@
+"""ParEGO acquisition function module."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from scipy.stats import norm
+
+from saealib.acquisition.base import AcquisitionFunction
+from saealib.surrogate.prediction import SurrogatePrediction
+
+if TYPE_CHECKING:
+    from saealib.population import Archive
+
+
+class ParEGOAcquisition(AcquisitionFunction):
+    """
+    ParEGO acquisition function for multi-objective Bayesian optimisation.
+
+    Scalarises objectives using the Augmented Tchebycheff function with a
+    randomly sampled weight vector, then applies Expected Improvement on the
+    scalarised prediction (Knowles 2006; formula from Chugh 2020 Eq. 8).
+
+    Scalarised objective (minimised)::
+
+        g(f; w, z*) = max_i [w_i |f_i - z_i*|] + alpha * sum_i w_i |f_i - z_i*|
+
+    where z* is the component-wise minimum of the current archive and w is
+    drawn uniformly from the (k-1)-simplex at each call to
+    ``compute_reference``.
+
+    Because saealib's ABC receives ``(n_samples, n_obj)`` predictions rather
+    than per-objective GP posteriors, the scalarised GP is approximated::
+
+        mu_s  = g(mu; w, z*)
+        std_s = (w . std).sum(axis=-1)   [linear-combination approximation]
+
+    EI is then computed on (mu_s, std_s) against the best scalarised archive
+    value.
+
+    Parameters
+    ----------
+    alpha : float
+        Augmentation coefficient (rho in some references).
+        Default: 0.05 (mlr3mbo convention).
+    rng : np.random.Generator or None
+        Random number generator for weight sampling.
+    """
+
+    requires_uncertainty: bool = True
+
+    def __init__(
+        self,
+        alpha: float = 0.05,
+        rng: np.random.Generator | None = None,
+    ) -> None:
+        self.alpha = alpha
+        self._rng = rng if rng is not None else np.random.default_rng()
+
+    def _scalarize(
+        self,
+        f: np.ndarray,
+        weights: np.ndarray,
+        z_star: np.ndarray,
+    ) -> np.ndarray:
+        """Augmented Tchebycheff scalarization (Chugh 2020 Eq. 8)."""
+        diff = np.abs(f - z_star)            # (..., n_obj)
+        weighted = weights * diff            # (..., n_obj)
+        return weighted.max(axis=-1) + self.alpha * weighted.sum(axis=-1)
+
+    def compute_reference(
+        self, archive: Archive
+    ) -> tuple[np.ndarray, np.ndarray, float]:
+        """
+        Sample a new weight vector and compute the ideal point.
+
+        Parameters
+        ----------
+        archive : Archive
+            Archive of evaluated solutions.
+
+        Returns
+        -------
+        tuple
+            ``(z_star, weights, f_best_scalar)`` — component-wise minimum of
+            archive objective values, a new weight vector drawn uniformly from
+            the (k-1)-simplex, and the minimum scalarised archive value under
+            these weights.
+        """
+        n_obj = archive.f.shape[1]
+        z_star = archive.f.min(axis=0)
+        weights = self._rng.dirichlet(np.ones(n_obj))
+        f_best = float(self._scalarize(archive.f, weights, z_star).min())
+        return z_star, weights, f_best
+
+    def score(
+        self,
+        prediction: SurrogatePrediction,
+        reference: Any,
+    ) -> np.ndarray:
+        """
+        Compute EI on the Augmented Tchebycheff scalarised prediction.
+
+        Parameters
+        ----------
+        prediction : SurrogatePrediction
+            Surrogate predictions.  Must have std (has_uncertainty == True).
+        reference : tuple
+            ``(z_star, weights, f_best_scalar)`` from ``compute_reference``.
+
+        Returns
+        -------
+        np.ndarray
+            EI scores.  shape: (n_samples,).  Higher is better.
+
+        Raises
+        ------
+        TypeError
+            If prediction does not contain uncertainty estimates.
+        """
+        if not prediction.has_uncertainty:
+            raise TypeError(
+                "ParEGOAcquisition requires uncertainty estimates "
+                "(prediction.std must not be None)."
+            )
+        z_star, weights, f_best = reference
+
+        mu_s = self._scalarize(prediction.value, weights, z_star)   # (n,)
+        sigma_s = (weights * prediction.std).sum(axis=-1)            # (n,)
+        sigma_s = np.maximum(sigma_s, 1e-9)
+
+        z = (f_best - mu_s) / sigma_s
+        ei = (f_best - mu_s) * norm.cdf(z) + sigma_s * norm.pdf(z)
+        return np.maximum(ei, 0.0)

--- a/src/saealib/acquisition/smsego.py
+++ b/src/saealib/acquisition/smsego.py
@@ -123,7 +123,8 @@ class SMSEGOAcquisition(AcquisitionFunction):
             if np.any(y >= ref_point):
                 continue
             combined = (
-                y[np.newaxis] if len(pareto_f) == 0
+                y[np.newaxis]
+                if len(pareto_f) == 0
                 else np.vstack([pareto_f, y[np.newaxis]])
             )
             hvi[i] = max(hypervolume(combined, ref_point) - base_hv, 0.0)

--- a/src/saealib/acquisition/smsego.py
+++ b/src/saealib/acquisition/smsego.py
@@ -1,0 +1,131 @@
+"""SMS-EGO acquisition function module."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from saealib.acquisition.base import AcquisitionFunction
+from saealib.surrogate.prediction import SurrogatePrediction
+from saealib.utils.indicators import _non_dominated, hypervolume
+
+if TYPE_CHECKING:
+    from saealib.population import Archive
+
+
+class SMSEGOAcquisition(AcquisitionFunction):
+    """
+    SMS-EGO acquisition function for multi-objective Bayesian optimisation.
+
+    Scores each candidate by the hypervolume improvement (HVI) of its
+    per-objective LCB prediction over the current Pareto front (Ponweiser
+    2008; LCB formula from mlr3mbo ``AcqFunctionSmsEgo.R``).
+
+    LCB per objective::
+
+        y_hat_j(x) = mu_j(x) - lambda * sigma_j(x)
+
+    Acquisition score::
+
+        SMS(x) = HV(P u {y_hat(x)}, r) - HV(P, r)
+
+    Parameters
+    ----------
+    lam : float
+        LCB width parameter λ.  Default: 1.0 (mlr3mbo convention).
+    reference_point : array-like or None
+        Hypervolume reference point (minimisation convention).  If None,
+        auto-computed from the archive nadir with a 10 % margin.
+    """
+
+    requires_uncertainty: bool = True
+
+    def __init__(
+        self,
+        lam: float = 1.0,
+        reference_point: np.ndarray | None = None,
+    ) -> None:
+        self.lam = lam
+        self.reference_point = (
+            np.asarray(reference_point, dtype=float)
+            if reference_point is not None
+            else None
+        )
+
+    def compute_reference(
+        self, archive: Archive
+    ) -> tuple[np.ndarray, np.ndarray, float]:
+        """
+        Extract the Pareto front and (if needed) compute the reference point.
+
+        Parameters
+        ----------
+        archive : Archive
+            Archive of evaluated solutions.
+
+        Returns
+        -------
+        tuple
+            ``(pareto_f, ref_point, base_hv)`` — non-dominated objective
+            matrix, hypervolume reference point, and current hypervolume.
+        """
+        f = archive.f
+        pareto_f = _non_dominated(f)
+
+        if self.reference_point is not None:
+            ref = self.reference_point
+        else:
+            nadir = f.max(axis=0)
+            span = nadir - f.min(axis=0)
+            ref = nadir + 0.1 * np.maximum(span, 1e-6)
+
+        base_hv = hypervolume(pareto_f, ref)
+        return pareto_f, ref, base_hv
+
+    def score(
+        self,
+        prediction: SurrogatePrediction,
+        reference: Any,
+    ) -> np.ndarray:
+        """
+        Compute hypervolume improvement of the LCB-predicted candidates.
+
+        Parameters
+        ----------
+        prediction : SurrogatePrediction
+            Surrogate predictions.  Must have std (has_uncertainty == True).
+        reference : tuple
+            ``(pareto_f, ref_point, base_hv)`` from ``compute_reference``.
+
+        Returns
+        -------
+        np.ndarray
+            HVI scores.  shape: (n_samples,).  Higher is better.
+
+        Raises
+        ------
+        TypeError
+            If prediction does not contain uncertainty estimates.
+        """
+        if not prediction.has_uncertainty:
+            raise TypeError(
+                "SMSEGOAcquisition requires uncertainty estimates "
+                "(prediction.std must not be None)."
+            )
+        pareto_f, ref_point, base_hv = reference
+        lcb = prediction.value - self.lam * prediction.std  # (n, n_obj)
+        n = lcb.shape[0]
+        hvi = np.zeros(n)
+
+        for i in range(n):
+            y = lcb[i]
+            if np.any(y >= ref_point):
+                continue
+            combined = (
+                y[np.newaxis] if len(pareto_f) == 0
+                else np.vstack([pareto_f, y[np.newaxis]])
+            )
+            hvi[i] = max(hypervolume(combined, ref_point) - base_hv, 0.0)
+
+        return hvi

--- a/tests/test_moo_acquisition.py
+++ b/tests/test_moo_acquisition.py
@@ -1,0 +1,300 @@
+"""
+Tests for MOO acquisition functions: ParEGOAcquisition, SMSEGOAcquisition,
+EHVIAcquisition.
+"""
+
+import numpy as np
+import pytest
+
+from saealib.acquisition import (
+    EHVIAcquisition,
+    ParEGOAcquisition,
+    SMSEGOAcquisition,
+)
+from saealib.population import Archive, PopulationAttribute
+from saealib.surrogate.prediction import SurrogatePrediction
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _pred(value, std=None):
+    m = np.asarray(value, dtype=float)
+    s = np.asarray(std, dtype=float) if std is not None else None
+    return SurrogatePrediction(value=m, std=s)
+
+
+def _archive(*rows):
+    """Build an Archive from objective-value rows (2-objective assumed)."""
+    n_obj = len(rows[0])
+    attrs = [
+        PopulationAttribute(name="x", dtype=np.float64, shape=(1,)),
+        PopulationAttribute(name="f", dtype=np.float64, shape=(n_obj,)),
+    ]
+    arc = Archive(attrs, init_capacity=len(rows) + 5)
+    for i, f_row in enumerate(rows):
+        arc.add(x=np.array([float(i)]), f=np.asarray(f_row, dtype=float))
+    return arc
+
+
+# ===========================================================================
+# ParEGOAcquisition
+# ===========================================================================
+class TestParEGOAcquisition:
+    def test_requires_uncertainty(self) -> None:
+        arc = _archive([1.0, 2.0])
+        af = ParEGOAcquisition(rng=np.random.default_rng(0))
+        ref = af.compute_reference(arc)
+        pred = _pred(value=[[0.5, 1.5]])
+        with pytest.raises(TypeError, match="uncertainty"):
+            af.score(pred, ref)
+
+    def test_output_shape(self) -> None:
+        arc = _archive([1.0, 2.0], [2.0, 1.0])
+        af = ParEGOAcquisition(rng=np.random.default_rng(0))
+        ref = af.compute_reference(arc)
+        pred = _pred(value=np.zeros((5, 2)), std=np.ones((5, 2)))
+        scores = af.score(pred, ref)
+        assert scores.shape == (5,)
+
+    def test_nonnegative(self) -> None:
+        rng = np.random.default_rng(1)
+        arc = _archive([1.0, 3.0], [3.0, 1.0])
+        af = ParEGOAcquisition(rng=rng)
+        ref = af.compute_reference(arc)
+        pred = _pred(
+            value=rng.standard_normal((20, 2)),
+            std=np.abs(rng.standard_normal((20, 2))) + 0.1,
+        )
+        scores = af.score(pred, ref)
+        assert np.all(scores >= 0.0)
+
+    def test_better_candidate_scores_higher(self) -> None:
+        """Candidate near ideal point scores higher than one far away."""
+        arc = _archive([1.0, 3.0], [3.0, 1.0])
+        rng = np.random.default_rng(42)
+        af = ParEGOAcquisition(alpha=0.05, rng=rng)
+        ref = af.compute_reference(arc)
+        # Candidate A: near ideal = (1,1)
+        # Candidate B: far from ideal
+        pred = _pred(
+            value=[[1.1, 1.1], [5.0, 5.0]],
+            std=[[0.1, 0.1], [0.1, 0.1]],
+        )
+        scores = af.score(pred, ref)
+        assert scores[0] >= scores[1]
+
+    def test_compute_reference_returns_tuple(self) -> None:
+        arc = _archive([1.0, 2.0], [2.0, 1.0])
+        af = ParEGOAcquisition(rng=np.random.default_rng(0))
+        ref = af.compute_reference(arc)
+        z_star, weights, f_best = ref
+        assert z_star.shape == (2,)
+        assert weights.shape == (2,)
+        assert weights.sum() == pytest.approx(1.0, rel=1e-6)
+        assert np.all(weights >= 0)
+        assert isinstance(f_best, float)
+
+    def test_ideal_point_is_component_min(self) -> None:
+        arc = _archive([1.0, 5.0], [3.0, 2.0])
+        af = ParEGOAcquisition(rng=np.random.default_rng(0))
+        z_star, _, _ = af.compute_reference(arc)
+        np.testing.assert_array_equal(z_star, [1.0, 2.0])
+
+    def test_alpha_zero_is_pure_tchebycheff(self) -> None:
+        """alpha=0 reduces to pure Tchebycheff; aug term is zero."""
+        arc = _archive([1.0, 3.0], [3.0, 1.0])
+        rng = np.random.default_rng(7)
+        af = ParEGOAcquisition(alpha=0.0, rng=rng)
+        ref = af.compute_reference(arc)
+        # Should still produce valid EI scores
+        pred = _pred(value=[[0.5, 0.5]], std=[[0.1, 0.1]])
+        scores = af.score(pred, ref)
+        assert scores.shape == (1,)
+        assert scores[0] >= 0.0
+
+
+# ===========================================================================
+# SMSEGOAcquisition
+# ===========================================================================
+class TestSMSEGOAcquisition:
+    def test_requires_uncertainty(self) -> None:
+        arc = _archive([1.0, 2.0], [2.0, 1.0])
+        af = SMSEGOAcquisition()
+        ref = af.compute_reference(arc)
+        pred = _pred(value=[[0.5, 0.5]])
+        with pytest.raises(TypeError, match="uncertainty"):
+            af.score(pred, ref)
+
+    def test_output_shape(self) -> None:
+        arc = _archive([1.0, 2.0], [2.0, 1.0])
+        af = SMSEGOAcquisition(reference_point=[3.0, 3.0])
+        ref = af.compute_reference(arc)
+        pred = _pred(value=np.zeros((6, 2)), std=np.ones((6, 2)) * 0.1)
+        scores = af.score(pred, ref)
+        assert scores.shape == (6,)
+
+    def test_nonnegative(self) -> None:
+        arc = _archive([1.0, 3.0], [2.0, 1.5], [3.0, 1.0])
+        af = SMSEGOAcquisition(reference_point=[5.0, 5.0])
+        ref = af.compute_reference(arc)
+        pred = _pred(
+            value=np.random.default_rng(0).standard_normal((10, 2)) + 2,
+            std=np.ones((10, 2)) * 0.5,
+        )
+        scores = af.score(pred, ref)
+        assert np.all(scores >= 0.0)
+
+    def test_dominated_candidate_scores_zero(self) -> None:
+        """A candidate dominated by the Pareto front has HVI=0."""
+        arc = _archive([1.0, 1.0])
+        af = SMSEGOAcquisition(reference_point=[3.0, 3.0])
+        ref = af.compute_reference(arc)
+        # LCB well above the Pareto point → dominated
+        pred = _pred(value=[[2.0, 2.0]], std=[[0.01, 0.01]])
+        scores = af.score(pred, ref)
+        assert scores[0] == pytest.approx(0.0, abs=1e-9)
+
+    def test_improving_candidate_positive_hvi(self) -> None:
+        """A non-dominated candidate with low LCB has positive HVI."""
+        arc = _archive([2.0, 2.0])
+        af = SMSEGOAcquisition(reference_point=[4.0, 4.0])
+        ref = af.compute_reference(arc)
+        # LCB(x) = [0.5, 0.5] — non-dominated, within ref box
+        pred = _pred(value=[[0.6, 0.6]], std=[[0.1, 0.1]])
+        # lam=1 → lcb = [0.5, 0.5]
+        scores = af.score(pred, ref)
+        assert scores[0] > 0.0
+
+    def test_outside_ref_box_scores_zero(self) -> None:
+        """A candidate with LCB outside the reference box scores zero."""
+        arc = _archive([1.0, 1.0])
+        af = SMSEGOAcquisition(reference_point=[2.0, 2.0])
+        ref = af.compute_reference(arc)
+        # LCB = mu - sigma = [3.0-0.1, 1.0-0.1] = [2.9, 0.9] — f1 > ref[0]
+        pred = _pred(value=[[3.0, 1.0]], std=[[0.1, 0.1]])
+        scores = af.score(pred, ref)
+        assert scores[0] == pytest.approx(0.0, abs=1e-9)
+
+    def test_auto_reference_point(self) -> None:
+        """Auto-computed reference point should be strictly > nadir."""
+        arc = _archive([1.0, 3.0], [3.0, 1.0])
+        af = SMSEGOAcquisition()
+        _, ref, _ = af.compute_reference(arc)
+        assert np.all(ref > arc.f.max(axis=0))
+
+    def test_lam_parameter(self) -> None:
+        """Higher lam → more pessimistic LCB → generally lower or equal HVI."""
+        arc = _archive([2.0, 2.0])
+        ref_pt = np.array([5.0, 5.0])
+        # mu=[1.5, 1.5], std=[0.5, 0.5]: lam=1→lcb=[1.0,1.0], lam=2→lcb=[0.5,0.5]
+        pred = _pred(value=[[1.5, 1.5]], std=[[0.5, 0.5]])
+        af1 = SMSEGOAcquisition(lam=1.0, reference_point=ref_pt)
+        af2 = SMSEGOAcquisition(lam=2.0, reference_point=ref_pt)
+        ref1 = af1.compute_reference(arc)
+        ref2 = af2.compute_reference(arc)
+        s1 = af1.score(pred, ref1)
+        s2 = af2.score(pred, ref2)
+        # lam=2 gives smaller lcb → larger improvement region
+        assert s2[0] >= s1[0]
+
+
+# ===========================================================================
+# EHVIAcquisition
+# ===========================================================================
+class TestEHVIAcquisition:
+    def test_requires_uncertainty(self) -> None:
+        arc = _archive([1.0, 2.0], [2.0, 1.0])
+        af = EHVIAcquisition(rng=np.random.default_rng(0))
+        ref = af.compute_reference(arc)
+        pred = _pred(value=[[0.5, 0.5]])
+        with pytest.raises(TypeError, match="uncertainty"):
+            af.score(pred, ref)
+
+    def test_output_shape(self) -> None:
+        arc = _archive([1.0, 2.0], [2.0, 1.0])
+        af = EHVIAcquisition(
+            n_samples=32, reference_point=[3.0, 3.0],
+            rng=np.random.default_rng(0),
+        )
+        ref = af.compute_reference(arc)
+        pred = _pred(value=np.zeros((5, 2)), std=np.ones((5, 2)) * 0.1)
+        scores = af.score(pred, ref)
+        assert scores.shape == (5,)
+
+    def test_nonnegative(self) -> None:
+        arc = _archive([1.0, 3.0], [3.0, 1.0])
+        af = EHVIAcquisition(
+            n_samples=32, reference_point=[5.0, 5.0],
+            rng=np.random.default_rng(0),
+        )
+        ref = af.compute_reference(arc)
+        rng = np.random.default_rng(1)
+        pred = _pred(
+            value=rng.standard_normal((8, 2)) + 2.0,
+            std=np.abs(rng.standard_normal((8, 2))) + 0.1,
+        )
+        scores = af.score(pred, ref)
+        assert np.all(scores >= 0.0)
+
+    def test_dominated_region_scores_near_zero(self) -> None:
+        """Candidate well dominated by Pareto front has near-zero EHVI."""
+        arc = _archive([1.0, 1.0])
+        af = EHVIAcquisition(
+            n_samples=64, reference_point=[3.0, 3.0],
+            rng=np.random.default_rng(0),
+        )
+        ref = af.compute_reference(arc)
+        # mu=[2.5, 2.5], tiny std → nearly all samples are dominated
+        pred = _pred(value=[[2.5, 2.5]], std=[[0.001, 0.001]])
+        scores = af.score(pred, ref)
+        assert scores[0] < 0.01
+
+    def test_improving_candidate_positive_ehvi(self) -> None:
+        """Candidate that is likely to improve HV has positive EHVI."""
+        arc = _archive([2.0, 2.0])
+        af = EHVIAcquisition(
+            n_samples=128, reference_point=[4.0, 4.0],
+            rng=np.random.default_rng(0),
+        )
+        ref = af.compute_reference(arc)
+        # mu=[0.5, 0.5], small std → most samples non-dominated
+        pred = _pred(value=[[0.5, 0.5]], std=[[0.1, 0.1]])
+        scores = af.score(pred, ref)
+        assert scores[0] > 0.0
+
+    def test_better_candidate_scores_higher(self) -> None:
+        """Candidate closer to ideal point has higher EHVI."""
+        arc = _archive([2.0, 2.0])
+        af = EHVIAcquisition(
+            n_samples=256, reference_point=[4.0, 4.0],
+            rng=np.random.default_rng(0),
+        )
+        ref = af.compute_reference(arc)
+        pred = _pred(
+            value=[[0.5, 0.5], [1.5, 1.5]],
+            std=[[0.05, 0.05], [0.05, 0.05]],
+        )
+        scores = af.score(pred, ref)
+        assert scores[0] > scores[1]
+
+    def test_auto_reference_point(self) -> None:
+        arc = _archive([1.0, 3.0], [3.0, 1.0])
+        af = EHVIAcquisition(n_samples=16, rng=np.random.default_rng(0))
+        _, ref, _ = af.compute_reference(arc)
+        assert np.all(ref > arc.f.max(axis=0))
+
+    def test_n_samples_parameter(self) -> None:
+        """n_samples affects variance but both runs give valid shapes."""
+        arc = _archive([1.0, 2.0], [2.0, 1.0])
+        pred = _pred(value=[[0.5, 0.5]], std=[[0.1, 0.1]])
+        ref_pt = [3.0, 3.0]
+        for n in [16, 128]:
+            af = EHVIAcquisition(
+                n_samples=n, reference_point=ref_pt,
+                rng=np.random.default_rng(0),
+            )
+            ref = af.compute_reference(arc)
+            scores = af.score(pred, ref)
+            assert scores.shape == (1,)
+            assert scores[0] >= 0.0

--- a/tests/test_moo_acquisition.py
+++ b/tests/test_moo_acquisition.py
@@ -214,7 +214,8 @@ class TestEHVIAcquisition:
     def test_output_shape(self) -> None:
         arc = _archive([1.0, 2.0], [2.0, 1.0])
         af = EHVIAcquisition(
-            n_samples=32, reference_point=[3.0, 3.0],
+            n_samples=32,
+            reference_point=[3.0, 3.0],
             rng=np.random.default_rng(0),
         )
         ref = af.compute_reference(arc)
@@ -225,7 +226,8 @@ class TestEHVIAcquisition:
     def test_nonnegative(self) -> None:
         arc = _archive([1.0, 3.0], [3.0, 1.0])
         af = EHVIAcquisition(
-            n_samples=32, reference_point=[5.0, 5.0],
+            n_samples=32,
+            reference_point=[5.0, 5.0],
             rng=np.random.default_rng(0),
         )
         ref = af.compute_reference(arc)
@@ -241,7 +243,8 @@ class TestEHVIAcquisition:
         """Candidate well dominated by Pareto front has near-zero EHVI."""
         arc = _archive([1.0, 1.0])
         af = EHVIAcquisition(
-            n_samples=64, reference_point=[3.0, 3.0],
+            n_samples=64,
+            reference_point=[3.0, 3.0],
             rng=np.random.default_rng(0),
         )
         ref = af.compute_reference(arc)
@@ -254,7 +257,8 @@ class TestEHVIAcquisition:
         """Candidate that is likely to improve HV has positive EHVI."""
         arc = _archive([2.0, 2.0])
         af = EHVIAcquisition(
-            n_samples=128, reference_point=[4.0, 4.0],
+            n_samples=128,
+            reference_point=[4.0, 4.0],
             rng=np.random.default_rng(0),
         )
         ref = af.compute_reference(arc)
@@ -267,7 +271,8 @@ class TestEHVIAcquisition:
         """Candidate closer to ideal point has higher EHVI."""
         arc = _archive([2.0, 2.0])
         af = EHVIAcquisition(
-            n_samples=256, reference_point=[4.0, 4.0],
+            n_samples=256,
+            reference_point=[4.0, 4.0],
             rng=np.random.default_rng(0),
         )
         ref = af.compute_reference(arc)
@@ -291,7 +296,8 @@ class TestEHVIAcquisition:
         ref_pt = [3.0, 3.0]
         for n in [16, 128]:
             af = EHVIAcquisition(
-                n_samples=n, reference_point=ref_pt,
+                n_samples=n,
+                reference_point=ref_pt,
                 rng=np.random.default_rng(0),
             )
             ref = af.compute_reference(arc)


### PR DESCRIPTION
## Related Issue
Closes #75

## Overview
Implements three MOO acquisition functions for surrogate-assisted multi-objective Bayesian optimisation.
All three classes extend `AcquisitionFunction` and follow the `compute_reference` / `score` ABC contract.

## Changes
- `ParEGOAcquisition`: Augmented Tchebycheff scalarisation with randomly sampled weight vector (Dirichlet), then EI on the scalarised prediction. `alpha=0.05` default. `requires_uncertainty=True`.
- `SMSEGOAcquisition`: Per-objective LCB (`mu - lambda * sigma`), scored by hypervolume improvement (HVI) over the current Pareto front. `lam=1.0` default. `requires_uncertainty=True`.
- `EHVIAcquisition`: Monte Carlo EHVI — samples `y ~ N(mu, diag(sigma^2))` and averages HVI over `n_samples=256` draws. `requires_uncertainty=True`.
- Both `SMSEGOAcquisition` and `EHVIAcquisition` accept an optional `reference_point`; if omitted, it is auto-computed from the archive nadir with a 10% margin.
- All three classes exported from `saealib.acquisition`.
- 23 unit tests in `tests/test_moo_acquisition.py`.

## Verification Steps
run pytest (tests/test_moo_acquisition.py)


## Concerns
- ParEGO std approximation: The original algorithm refits the GP on scalarised observations each iteration. saealib's ABC does not support this; instead, the scalarised std is approximated as `(w · sigma).sum()` (linear combination). This is an acknowledged limitation of the ABC design.
- EHVI complexity: MC estimation runs `O(n_candidates × n_samples)` hypervolume calls. For large candidate sets or high `n_samples`, this can be slow. An exact 2-objective formula (box decomposition) is left as a future optimisation.
- Naming: `ParEGOAcquisition` and `SMSEGOAcquisition` follow algorithm-name conventions (consistent with `NSGA2Comparator` etc.) rather than concept-name conventions (consistent with `ExpectedImprovement` etc.). A naming-convention review is deferred to a pre-release refactoring pass.

## Other
All three acquisition functions assume minimisation convention for `archive.f`, consistent with the rest of saealib internals.
