### PR TITLE
feat: [#109] Add EpsilonConstraintHandler (dynamic ε-constraint method)

### DIFF
--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -104,10 +104,13 @@ from saealib.population import (
 from saealib.problem import (
     Constraint,
     ConstraintHandler,
+    EpsilonConstraintHandler,
     EqualityConstraint,
     InequalityConstraint,
     Problem,
     StaticToleranceHandler,
+    exponential_epsilon_schedule,
+    linear_epsilon_schedule,
 )
 from saealib.strategies.base import OptimizationStrategy
 from saealib.strategies.gb import GenerationBasedStrategy
@@ -176,6 +179,7 @@ __all__ = [
     "DensityManager",
     "Dominator",
     "EnsembleSurrogateManager",
+    "EpsilonConstraintHandler",
     "EpsilonDominanceComparator",
     "EpsilonDominator",
     "EqualityConstraint",
@@ -260,10 +264,12 @@ __all__ = [
     "crowding_distance",
     "crowding_distance_all_fronts",
     "dda_non_dominated_sort",
+    "exponential_epsilon_schedule",
     "f_target",
     "gaussian_kernel",
     "hypervolume",
     "hypervolume_contributions",
+    "linear_epsilon_schedule",
     "logging_generation",
     "logging_generation_hv",
     "max_fe",

--- a/src/saealib/execution/runner.py
+++ b/src/saealib/execution/runner.py
@@ -46,6 +46,7 @@ class Runner:
         """
         opt = self.optimizer
         ctx = opt.initializer.initialize(opt, opt.problem)
+        ctx.comparator.eps_cv = ctx.problem.handler.feasibility_threshold
 
         opt.dispatch(RunStartEvent(ctx=ctx, provider=opt))
         yield ctx
@@ -53,6 +54,9 @@ class Runner:
         while not opt.termination.is_terminated(ctx):
             opt.dispatch(GenerationStartEvent(ctx=ctx, provider=opt))
             opt.strategy.step(ctx, opt)
+            handler = ctx.problem.handler
+            handler.on_generation_end(ctx.gen, ctx.population)
+            ctx.comparator.eps_cv = handler.feasibility_threshold
             opt.dispatch(GenerationEndEvent(ctx=ctx, provider=opt))
             yield ctx
 

--- a/src/saealib/problem.py
+++ b/src/saealib/problem.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -318,6 +319,124 @@ class StaticToleranceHandler(ConstraintHandler):
     def feasibility_threshold(self) -> float:
         """Fixed feasibility threshold ``eps_cv``."""
         return self._eps_cv
+
+
+class EpsilonConstraintHandler(ConstraintHandler):
+    """
+    Dynamic ε-constraint handler.
+
+    The feasibility threshold ε starts at ``schedule(0)`` and is updated
+    to ``schedule(gen)`` at the end of each generation via
+    :meth:`on_generation_end`. As ε decreases toward 0 the population is
+    gradually driven into the feasible region.
+
+    Each call to :meth:`on_generation_end` sets
+    ``comparator.eps_cv = feasibility_threshold`` via the runner, so the
+    comparator's feasibility criterion tightens in sync with ε.
+
+    Parameters
+    ----------
+    schedule : callable
+        Maps generation index (int) → current ε value (float).
+        ``schedule(0)`` is the initial ε; it should decrease toward 0
+        over generations.
+
+    Notes
+    -----
+    :meth:`compute_cv` aggregates violations as:
+
+    - *Equality* constraints: ``|h(x)|``  (raw absolute value; the
+      ``EqualityConstraint.tolerance`` field is intentionally bypassed so
+      that ε controls the feasibility threshold globally).
+    - *Inequality* constraints: ``max(0, g(x) - threshold)``  (standard
+      positive part; the constraint's ``threshold`` still applies).
+
+    This is a simplified form of the sum-of-constraint-violation measure
+    in Eq. (7) of Mezura-Montes & Coello Coello (2011) — inequality
+    violations are not squared and values are not normalised.
+
+    References
+    ----------
+    Mezura-Montes, E., & Coello Coello, C. A. (2011).
+    *Constraint-handling in nature-inspired numerical optimization: Past,
+    present and future.*
+    Swarm and Evolutionary Computation, 1(4), 173-194.
+    https://doi.org/10.1016/j.swevo.2011.10.001
+    """
+
+    def __init__(self, schedule: Callable[[int], float]):
+        self._schedule = schedule
+        self._eps: float = float(schedule(0))
+
+    def compute_cv(
+        self,
+        constraints: list[InequalityConstraint],
+        x: np.ndarray,
+        g: np.ndarray,
+    ) -> float:
+        """Return ``|h|`` for equality and ``max(0, g-threshold)`` for inequality."""
+        cv = 0.0
+        for gi, c in zip(g, constraints):
+            if isinstance(c, EqualityConstraint):
+                cv += abs(float(gi))
+            else:
+                cv += max(0.0, float(gi) - c.threshold)
+        return cv
+
+    @property
+    def feasibility_threshold(self) -> float:
+        """Current ε; the comparator treats ``cv <= ε`` as feasible."""
+        return self._eps
+
+    def on_generation_end(self, gen: int, population: Population) -> None:
+        """Update internal ε to ``schedule(gen)``."""
+        self._eps = float(self._schedule(gen))
+
+
+def linear_epsilon_schedule(eps0: float, n_gen: int) -> Callable[[int], float]:
+    """
+    Return a linear ε schedule: ``eps0`` at gen 0, ``0.0`` at gen ``n_gen``.
+
+    Parameters
+    ----------
+    eps0 : float
+        Initial ε value (gen 0).
+    n_gen : int
+        Generation at which ε reaches 0.
+
+    Returns
+    -------
+    callable
+        ``schedule(gen) -> float``
+    """
+
+    def _schedule(gen: int) -> float:
+        return max(0.0, eps0 * (1.0 - gen / n_gen))
+
+    return _schedule
+
+
+def exponential_epsilon_schedule(eps0: float, decay: float) -> Callable[[int], float]:
+    """
+    Return an exponential ε schedule: ``eps0 * decay**gen``.
+
+    Parameters
+    ----------
+    eps0 : float
+        Initial ε value (gen 0).
+    decay : float
+        Multiplicative decay factor per generation (0 < decay < 1).
+
+    Returns
+    -------
+    callable
+        ``schedule(gen) -> float``
+    """
+
+    def _schedule(gen: int) -> float:
+        return eps0 * (decay**gen)
+
+    return _schedule
 
 
 class Problem:

--- a/tests/test_epsilon_constraint_handler.py
+++ b/tests/test_epsilon_constraint_handler.py
@@ -1,0 +1,186 @@
+"""
+Tests for EpsilonConstraintHandler and schedule helpers (Issue #109).
+
+Tests cover:
+- linear_epsilon_schedule / exponential_epsilon_schedule: decay behaviour
+- EpsilonConstraintHandler: initial eps, on_generation_end, compute_cv
+- compute_cv for equality (bypasses tolerance) and inequality (uses threshold)
+- feasibility_threshold tracks internal eps
+"""
+
+import numpy as np
+import pytest
+
+from saealib import (
+    ConstraintHandler,
+    EpsilonConstraintHandler,
+    EqualityConstraint,
+    InequalityConstraint,
+    Problem,
+    exponential_epsilon_schedule,
+    linear_epsilon_schedule,
+)
+
+# ---------------------------------------------------------------------------
+# linear_epsilon_schedule
+# ---------------------------------------------------------------------------
+
+
+def test_linear_schedule_at_zero():
+    s = linear_epsilon_schedule(eps0=1.0, n_gen=10)
+    assert s(0) == pytest.approx(1.0)
+
+
+def test_linear_schedule_at_T():
+    s = linear_epsilon_schedule(eps0=1.0, n_gen=10)
+    assert s(10) == pytest.approx(0.0)
+
+
+def test_linear_schedule_clips_zero():
+    s = linear_epsilon_schedule(eps0=1.0, n_gen=10)
+    assert s(15) == pytest.approx(0.0)
+
+
+def test_linear_schedule_midpoint():
+    s = linear_epsilon_schedule(eps0=2.0, n_gen=10)
+    assert s(5) == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# exponential_epsilon_schedule
+# ---------------------------------------------------------------------------
+
+
+def test_exponential_schedule_at_zero():
+    s = exponential_epsilon_schedule(eps0=2.0, decay=0.9)
+    assert s(0) == pytest.approx(2.0)
+
+
+def test_exponential_schedule_decays():
+    s = exponential_epsilon_schedule(eps0=2.0, decay=0.5)
+    assert s(1) == pytest.approx(1.0)
+    assert s(2) == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# EpsilonConstraintHandler — initialisation and lifecycle
+# ---------------------------------------------------------------------------
+
+
+def _make_handler(eps0=1.0, n_gen=10):
+    return EpsilonConstraintHandler(linear_epsilon_schedule(eps0=eps0, n_gen=n_gen))
+
+
+def test_is_constraint_handler():
+    assert isinstance(_make_handler(), ConstraintHandler)
+
+
+def test_initial_eps():
+    h = _make_handler(eps0=0.5, n_gen=10)
+    assert h.feasibility_threshold == pytest.approx(0.5)
+
+
+def test_on_generation_end_updates_eps():
+    h = _make_handler(eps0=1.0, n_gen=10)
+    h.on_generation_end(gen=5, population=None)
+    assert h.feasibility_threshold == pytest.approx(0.5)
+
+
+def test_on_generation_end_reaches_zero():
+    h = _make_handler(eps0=1.0, n_gen=10)
+    h.on_generation_end(gen=10, population=None)
+    assert h.feasibility_threshold == pytest.approx(0.0)
+
+
+def test_eps_decreases_over_generations():
+    h = _make_handler(eps0=1.0, n_gen=5)
+    prev = h.feasibility_threshold
+    for gen in range(1, 6):
+        h.on_generation_end(gen=gen, population=None)
+        assert h.feasibility_threshold <= prev
+        prev = h.feasibility_threshold
+    assert h.feasibility_threshold == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# EpsilonConstraintHandler.compute_cv
+# ---------------------------------------------------------------------------
+
+_x = np.zeros(1)
+
+
+def test_compute_cv_inequality_feasible():
+    h = _make_handler()
+    c = InequalityConstraint(lambda x: 0.3, threshold=0.5)
+    cv = h.compute_cv([c], _x, np.array([0.3]))
+    assert cv == pytest.approx(0.0)
+
+
+def test_compute_cv_inequality_violated():
+    h = _make_handler()
+    c = InequalityConstraint(lambda x: 0.8, threshold=0.5)
+    cv = h.compute_cv([c], _x, np.array([0.8]))
+    assert cv == pytest.approx(0.3)
+
+
+def test_compute_cv_equality_raw_absolute_ignores_tolerance():
+    """EpsilonConstraintHandler uses |h|, not max(0, |h| - tolerance)."""
+    h = _make_handler()
+    # tolerance=1e-6 would make cv ≈ 0 with StaticToleranceHandler,
+    # but EpsilonConstraintHandler should return |0.01| = 0.01.
+    c = EqualityConstraint(lambda x: 0.01, tolerance=1e-6)
+    cv = h.compute_cv([c], _x, np.array([0.01]))
+    assert cv == pytest.approx(0.01)
+
+
+def test_compute_cv_equality_negative_value():
+    h = _make_handler()
+    c = EqualityConstraint(lambda x: -0.05, tolerance=0.0)
+    cv = h.compute_cv([c], _x, np.array([-0.05]))
+    assert cv == pytest.approx(0.05)
+
+
+def test_compute_cv_mixed_constraints():
+    h = _make_handler()
+    ineq = InequalityConstraint(lambda x: 0.3, threshold=0.0)
+    eq = EqualityConstraint(lambda x: -0.2, tolerance=0.0)
+    cv = h.compute_cv([ineq, eq], _x, np.array([0.3, -0.2]))
+    assert cv == pytest.approx(0.3 + 0.2)
+
+
+def test_compute_cv_no_constraints():
+    h = _make_handler()
+    cv = h.compute_cv([], _x, np.empty(0))
+    assert cv == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Problem integration
+# ---------------------------------------------------------------------------
+
+
+def _make_constrained_problem(handler):
+    return Problem(
+        func=lambda x: float(x[0]),
+        dim=1,
+        n_obj=1,
+        direction=np.array([-1.0]),
+        lb=[-1.0],
+        ub=[1.0],
+        constraints=[EqualityConstraint(lambda x: float(x[0]), tolerance=0.0)],
+        handler=handler,
+    )
+
+
+def test_problem_uses_epsilon_handler_compute_cv():
+    h = _make_handler(eps0=1.0, n_gen=10)
+    prob = _make_constrained_problem(h)
+    x = np.array([0.3])
+    _, cv = prob.evaluate_constraints(x)
+    assert cv == pytest.approx(0.3)
+
+
+def test_problem_feasibility_threshold_from_handler():
+    h = _make_handler(eps0=0.5, n_gen=10)
+    prob = _make_constrained_problem(h)
+    assert prob.handler.feasibility_threshold == pytest.approx(0.5)

--- a/tests/test_epsilon_constraint_handler.py
+++ b/tests/test_epsilon_constraint_handler.py
@@ -184,3 +184,84 @@ def test_problem_feasibility_threshold_from_handler():
     h = _make_handler(eps0=0.5, n_gen=10)
     prob = _make_constrained_problem(h)
     assert prob.handler.feasibility_threshold == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Runner integration: comparator.eps_cv tracks handler.feasibility_threshold
+# ---------------------------------------------------------------------------
+
+
+def _make_optimizer(problem, n_gen: int):
+    from saealib import (
+        GA,
+        CrossoverBLXAlpha,
+        IndividualBasedStrategy,
+        LHSInitializer,
+        MutationUniform,
+        Optimizer,
+        SequentialSelection,
+        Termination,
+        TruncationSelection,
+        max_gen,
+    )
+    from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+
+    return (
+        Optimizer(problem)
+        .set_initializer(LHSInitializer(n_init_archive=8, n_init_population=6, seed=0))
+        .set_algorithm(
+            GA(
+                crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4),
+                mutation=MutationUniform(mutation_rate=0.1),
+                parent_selection=SequentialSelection(),
+                survivor_selection=TruncationSelection(),
+            )
+        )
+        .set_surrogate(RBFsurrogate(gaussian_kernel, problem.dim), n_neighbors=5)
+        .set_strategy(IndividualBasedStrategy(evaluation_ratio=1.0))
+        .set_termination(Termination(max_gen(n_gen)))
+    )
+
+
+def test_comparator_eps_cv_synced_at_start():
+    """comparator.eps_cv equals handler.feasibility_threshold before gen 0."""
+    from saealib import RunStartEvent
+
+    eps0 = 0.5
+    h = EpsilonConstraintHandler(linear_epsilon_schedule(eps0=eps0, n_gen=20))
+    prob = _make_constrained_problem(h)
+    opt = _make_optimizer(prob, n_gen=1)
+
+    eps_at_start = []
+
+    def _capture(e):
+        eps_at_start.append(e.ctx.comparator.eps_cv)
+
+    opt.cbmanager.register(RunStartEvent, _capture)
+    opt.run()
+
+    assert len(eps_at_start) == 1
+    assert eps_at_start[0] == pytest.approx(eps0)
+
+
+def test_comparator_eps_cv_decreases_each_generation():
+    """comparator.eps_cv is updated after every generation via on_generation_end."""
+    from saealib import GenerationEndEvent
+
+    n_gen = 5
+    h = EpsilonConstraintHandler(linear_epsilon_schedule(eps0=1.0, n_gen=n_gen))
+    prob = _make_constrained_problem(h)
+    opt = _make_optimizer(prob, n_gen=n_gen)
+
+    eps_history = []
+
+    def _capture(e):
+        eps_history.append(e.ctx.comparator.eps_cv)
+
+    opt.cbmanager.register(GenerationEndEvent, _capture)
+    opt.run()
+
+    assert len(eps_history) == n_gen
+    for i in range(1, len(eps_history)):
+        assert eps_history[i] < eps_history[i - 1]
+    assert eps_history[-1] == pytest.approx(0.0)


### PR DESCRIPTION
## Related Issue
Closes #109

## Overview
Implements the dynamic ε-constraint method, allowing infeasible solutions early in the search while tightening feasibility requirements each generation. Wires the existing `on_generation_end` / `feasibility_threshold` hooks in `runner.py` so `Comparator.eps_cv` is kept in sync automatically.

## Changes
- Add `EpsilonConstraintHandler` to `problem.py`: `compute_cv` returns `|h|` for equality and `max(0, g − threshold)` for inequality constraints; `on_generation_end` advances the ε schedule each generation
- Add `linear_epsilon_schedule` and `exponential_epsilon_schedule` factory helpers
- Wire `handler.on_generation_end` + `comparator.eps_cv` sync into `runner.py` (initial sync before `RunStartEvent`; update after each `strategy.step()`)
- Export the three new symbols from `saealib.__init__`
- Add 21 tests covering schedules, handler lifecycle, `compute_cv`, `Problem` integration, and runner integration

## Verification Steps
run pytest (tests/test_epsilon_constraint_handler.py)

## Concerns
- `runner.py` calls `on_generation_end` once per outer loop iteration; for `GenerationBasedStrategy`, ε is indexed by the final `ctx.gen` value of that iteration.
- `StaticToleranceHandler` is unaffected: `feasibility_threshold` returns a constant, so re-assigning `eps_cv` each generation is a no-op.

## Other
Reference: Mezura-Montes & Coello Coello (2011), Swarm and Evolutionary Computation 1(4), 173–194 — Eqs. (7)–(9).
