### PR TITLE
feat: [#86] Add constraint surrogate path (g prediction + PoF integration)

### DIFF
--- a/docs/api/surrogate.md
+++ b/docs/api/surrogate.md
@@ -21,7 +21,9 @@
    saealib.SurrogateManager
    saealib.GlobalSurrogateManager
    saealib.LocalSurrogateManager
-   saealib.EnsembleSurrogateManager
+   saealib.CompositeSurrogateManager
+   saealib.product_combine
+   saealib.rank_weighted_combine
 ```
 
 ## RBF Surrogate

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -125,10 +125,12 @@ from saealib.surrogate.archive_manager import (
 )
 from saealib.surrogate.base import Surrogate
 from saealib.surrogate.manager import (
-    EnsembleSurrogateManager,
+    CompositeSurrogateManager,
     GlobalSurrogateManager,
     LocalSurrogateManager,
     SurrogateManager,
+    product_combine,
+    rank_weighted_combine,
 )
 from saealib.surrogate.per_objective import PerObjectiveSurrogate
 from saealib.surrogate.prediction import SurrogatePrediction
@@ -166,6 +168,7 @@ __all__ = [
     "ArchiveMixin",
     "CallbackManager",
     "Comparator",
+    "CompositeSurrogateManager",
     "Constraint",
     "ConstraintHandler",
     "Crossover",
@@ -179,7 +182,6 @@ __all__ = [
     "DecompositionComparator",
     "DensityManager",
     "Dominator",
-    "EnsembleSurrogateManager",
     "EpsilonConstraintHandler",
     "EpsilonDominanceComparator",
     "EpsilonDominator",
@@ -278,6 +280,8 @@ __all__ = [
     "maximize",
     "minimize",
     "non_dominated_sort",
+    "product_combine",
+    "rank_weighted_combine",
     "repair_clipping",
     "spea2_fitness",
     "stalled",

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -12,6 +12,7 @@ from saealib.acquisition import (
     MaxUncertainty,
     MeanPrediction,
     ProbabilityOfFeasibility,
+    ProductOfFeasibility,
 )
 from saealib.algorithms.base import Algorithm
 from saealib.algorithms.ga import GA
@@ -236,6 +237,7 @@ __all__ = [
     "PreSelectionStrategy",
     "ProbabilityOfFeasibility",
     "Problem",
+    "ProductOfFeasibility",
     "RBFsurrogate",
     "RNSGA2Comparator",
     "Result",

--- a/src/saealib/acquisition/__init__.py
+++ b/src/saealib/acquisition/__init__.py
@@ -12,7 +12,7 @@ from saealib.acquisition.ei import ExpectedImprovement
 from saealib.acquisition.lcb import LowerConfidenceBound
 from saealib.acquisition.mean import MeanPrediction
 from saealib.acquisition.parego import ParEGOAcquisition
-from saealib.acquisition.pof import ProbabilityOfFeasibility
+from saealib.acquisition.pof import ProbabilityOfFeasibility, ProductOfFeasibility
 from saealib.acquisition.smsego import SMSEGOAcquisition
 from saealib.acquisition.uncertainty import MaxUncertainty
 
@@ -25,5 +25,6 @@ __all__ = [
     "MeanPrediction",
     "ParEGOAcquisition",
     "ProbabilityOfFeasibility",
+    "ProductOfFeasibility",
     "SMSEGOAcquisition",
 ]

--- a/src/saealib/acquisition/pof.py
+++ b/src/saealib/acquisition/pof.py
@@ -163,7 +163,7 @@ class ProductOfFeasibility(AcquisitionFunction):
                 "ProductOfFeasibility requires a surrogate with uncertainty "
                 "estimates (prediction.std must not be None)."
             )
-        mu = prediction.value                          # (n_samples, n_constraints)
-        sigma = np.maximum(prediction.std, 1e-9)      # (n_samples, n_constraints)
-        pof = norm.cdf((0.0 - mu) / sigma)            # (n_samples, n_constraints)
-        return np.prod(pof, axis=1)                   # (n_samples,)
+        mu = prediction.value  # (n_samples, n_constraints)
+        sigma = np.maximum(prediction.std, 1e-9)  # (n_samples, n_constraints)
+        pof = norm.cdf((0.0 - mu) / sigma)  # (n_samples, n_constraints)
+        return np.prod(pof, axis=1)  # (n_samples,)

--- a/src/saealib/acquisition/pof.py
+++ b/src/saealib/acquisition/pof.py
@@ -80,3 +80,90 @@ class ProbabilityOfFeasibility(AcquisitionFunction):
         sigma = prediction.std[:, self.obj_idx]  # (n_samples,)
         sigma = np.maximum(sigma, 1e-9)
         return norm.cdf((0.0 - mu) / sigma)  # P(g(x) <= 0)
+
+
+class ProductOfFeasibility(AcquisitionFunction):
+    r"""Joint probability of feasibility across all constraint columns.
+
+    Computes the product of per-constraint feasibility probabilities:
+
+    .. math::
+
+        \text{PoF}_{\text{joint}}(x) = \prod_{i=1}^{m}
+        \Phi\!\left(\frac{0 - \mu_i(x)}{\sigma_i(x)}\right)
+
+    where :math:`\mu_i` and :math:`\sigma_i` are the surrogate's predicted
+    mean and standard deviation for the *i*-th constraint column.
+
+    This is the standard acquisition function for constrained Bayesian
+    optimisation with independent constraint surrogates (Letham et al., 2019;
+    Eriksson & Poloczek, 2021). Use it with a surrogate trained on
+    ``ConstraintObjectiveSet`` (which returns ``archive.g`` as ``train_y``),
+    typically via ``PerObjectiveSurrogate([GP(), ...] * n_constraints)``.
+
+    To combine with an objective acquisition (e.g. EI), wrap both managers
+    in a ``CompositeSurrogateManager`` with ``product_combine``::
+
+        ei_manager = GlobalSurrogateManager(GP(), EI(), ArchiveObjectiveSet())
+        pof_manager = GlobalSurrogateManager(
+            PerObjectiveSurrogate([GP()] * n_constraints),
+            ProductOfFeasibility(),
+            ConstraintObjectiveSet(),
+        )
+        optimizer.set_surrogate_manager(
+            CompositeSurrogateManager([ei_manager, pof_manager], product_combine)
+        )
+
+    Requires a surrogate that provides uncertainty estimates (std).
+
+    Notes
+    -----
+    Assumes constraints are independent. When constraints are strongly
+    correlated, a multi-output GP with joint predictions is more accurate
+    but is not required by this acquisition function.
+    """
+
+    requires_uncertainty: bool = True
+
+    def compute_reference(self, archive: Archive) -> Any:
+        """Return None (no reference needed)."""
+        return None
+
+    def score(
+        self,
+        prediction: SurrogatePrediction,
+        reference: Any = None,
+    ) -> np.ndarray:
+        """
+        Compute joint probability of feasibility scores.
+
+        Parameters
+        ----------
+        prediction : SurrogatePrediction
+            Surrogate predictions of constraint values.
+            ``prediction.value`` shape: ``(n_samples, n_constraints)``.
+            Must have std (``has_uncertainty == True``).
+        reference : Any
+            Not used. Accepted for interface compatibility.
+
+        Returns
+        -------
+        np.ndarray
+            Joint PoF scores in [0, 1]. shape: ``(n_samples,)``.
+            Score is 1 when all constraints are clearly satisfied,
+            0 when any constraint is clearly violated.
+
+        Raises
+        ------
+        TypeError
+            If prediction does not contain uncertainty estimates.
+        """
+        if not prediction.has_uncertainty:
+            raise TypeError(
+                "ProductOfFeasibility requires a surrogate with uncertainty "
+                "estimates (prediction.std must not be None)."
+            )
+        mu = prediction.value                          # (n_samples, n_constraints)
+        sigma = np.maximum(prediction.std, 1e-9)      # (n_samples, n_constraints)
+        pof = norm.cdf((0.0 - mu) / sigma)            # (n_samples, n_constraints)
+        return np.prod(pof, axis=1)                   # (n_samples,)

--- a/src/saealib/surrogate/manager.py
+++ b/src/saealib/surrogate/manager.py
@@ -5,11 +5,28 @@ Responsibility split:
   Surrogate           -- fits a model and predicts SurrogatePrediction
   AcquisitionFunction -- converts SurrogatePrediction to scalar scores
   SurrogateManager    -- coordinates the two above; exposes score_candidates()
+
+Classes
+-------
+GlobalSurrogateManager
+    Fits once on the full archive; batch predict and score.
+LocalSurrogateManager
+    Fits a local KNN model per candidate.
+CompositeSurrogateManager
+    Combines scores from multiple sub-managers via an injectable combine_fn.
+
+Combine functions
+-----------------
+product_combine
+    Element-wise product of score arrays (e.g. EI x PoF).
+rank_weighted_combine
+    Returns a combine function that rank-normalises then takes a weighted average.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -242,37 +259,99 @@ class LocalSurrogateManager(SurrogateManager):
         return self._sanitize_nan(scores, predictions)
 
 
-class EnsembleSurrogateManager(SurrogateManager):
-    """
-    Surrogate manager that aggregates scores from multiple sub-managers.
+def product_combine(scores: list[np.ndarray]) -> np.ndarray:
+    """Combine scores by element-wise product.
 
-    Each sub-manager produces scores, which are rank-normalized to [0, 1]
-    before being aggregated via a weighted average. Rank normalization
-    ensures scores from managers with incompatible scales (e.g., EI vs.
-    raw mean) are made comparable before combining.
+    Parameters
+    ----------
+    scores : list[np.ndarray]
+        Score arrays, each shape ``(n_candidates,)``.
+
+    Returns
+    -------
+    np.ndarray
+        Element-wise product. shape: ``(n_candidates,)``.
+    """
+    return np.prod(np.stack(scores, axis=0), axis=0)
+
+
+def rank_weighted_combine(
+    weights: np.ndarray | None = None,
+) -> Callable[[list[np.ndarray]], np.ndarray]:
+    """Return a combine function that rank-normalises then takes a weighted average.
+
+    Parameters
+    ----------
+    weights : np.ndarray or None
+        Weights for each manager. If None, uniform weights are used.
+        Need not sum to 1; they are normalised internally.
+
+    Returns
+    -------
+    callable
+        A function ``(list[np.ndarray]) -> np.ndarray`` suitable for
+        ``CompositeSurrogateManager``.
+    """
+    if weights is not None:
+        w = np.asarray(weights, dtype=float)
+        w = w / w.sum()
+    else:
+        w = None  # resolved lazily to uniform at call time
+
+    def _combine(score_list: list[np.ndarray]) -> np.ndarray:
+        normalized = [_rank_normalize(s) for s in score_list]
+        _w = w if w is not None else np.full(len(normalized), 1.0 / len(normalized))
+        return (np.stack(normalized, axis=0) * _w[:, None]).sum(axis=0)
+
+    return _combine
+
+
+class CompositeSurrogateManager(SurrogateManager):
+    """Surrogate manager that combines scores from multiple sub-managers.
+
+    Each sub-manager's ``score_candidates`` is called independently.
+    The resulting score arrays are combined by ``combine_fn``.
+    Predictions (for ``tell_f`` assignment) are taken from ``managers[0]``.
 
     Parameters
     ----------
     managers : list[SurrogateManager]
-        Sub-managers to aggregate.
-    weights : np.ndarray or None
-        Weights for the weighted average. shape: (len(managers),).
-        If None, uniform weights are used.
+        Sub-managers to combine. Must be non-empty.
+        ``managers[0]`` provides the ``SurrogatePrediction`` objects returned
+        by ``score_candidates``; its predicted objective values flow into
+        ``assign_tell_f`` in the strategies.
+    combine_fn : callable(list[np.ndarray]) -> np.ndarray
+        Accepts a list of score arrays (each shape ``(n_candidates,)``) and
+        returns a single combined score array of the same shape.
+        Use :func:`product_combine` for element-wise product (e.g. EI x PoF)
+        or :func:`rank_weighted_combine` for rank-normalised weighted average.
+
+    Examples
+    --------
+    EI x PoF (objective x feasibility product):
+
+    >>> manager = CompositeSurrogateManager(
+    ...     [ei_manager, pof_manager],
+    ...     combine_fn=product_combine,
+    ... )
+
+    Rank-normalised ensemble (equivalent to former EnsembleSurrogateManager):
+
+    >>> manager = CompositeSurrogateManager(
+    ...     [m1, m2],
+    ...     combine_fn=rank_weighted_combine(weights=[0.3, 0.7]),
+    ... )
     """
 
     def __init__(
         self,
         managers: list[SurrogateManager],
-        weights: np.ndarray | None = None,
+        combine_fn: Callable[[list[np.ndarray]], np.ndarray],
     ):
         if not managers:
-            raise ValueError("EnsembleSurrogateManager requires at least one manager.")
+            raise ValueError("CompositeSurrogateManager requires at least one manager.")
         self.managers = managers
-        if weights is not None:
-            w = np.asarray(weights, dtype=float)
-            self.weights = w / w.sum()
-        else:
-            self.weights = np.full(len(managers), 1.0 / len(managers))
+        self.combine_fn = combine_fn
 
     def score_candidates(
         self,
@@ -281,10 +360,9 @@ class EnsembleSurrogateManager(SurrogateManager):
         provider: ComponentProvider | None = None,
         ctx: OptimizationContext | None = None,
     ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
-        """
-        Aggregate rank-normalized scores from all sub-managers.
+        """Combine scores from all sub-managers using ``combine_fn``.
 
-        Returns the predictions from the first sub-manager as representative.
+        Returns the predictions from ``managers[0]`` as representative.
         """
         all_scores: list[np.ndarray] = []
         first_predictions: list[SurrogatePrediction] | None = None
@@ -293,13 +371,12 @@ class EnsembleSurrogateManager(SurrogateManager):
             scores, preds = manager.score_candidates(
                 candidates_x, archive, provider, ctx
             )
-            all_scores.append(_rank_normalize(scores))
+            all_scores.append(scores)
             if i == 0:
                 first_predictions = preds
 
-        combined = np.stack(all_scores, axis=0)  # (n_managers, n_candidates)
-        aggregated = (self.weights[:, None] * combined).sum(axis=0)  # (n_candidates,)
-        return aggregated, first_predictions  # type: ignore[return-value]
+        combined = self.combine_fn(all_scores)
+        return self._sanitize_nan(combined, first_predictions)  # type: ignore[arg-type]
 
 
 def _split_prediction(prediction: SurrogatePrediction) -> list[SurrogatePrediction]:

--- a/src/saealib/surrogate/training_set.py
+++ b/src/saealib/surrogate/training_set.py
@@ -24,6 +24,9 @@ Literature patterns covered by this module:
 | P5 | CSEA / pre-selection (general)         | ``KNNObjectiveSet``,             |
 |    |                                        | ``ArchiveObjectiveSet``          |
 +----+----------------------------------------+----------------------------------+
+| P6 | Constraint BO (Regis & Shoemaker 2005) | ``ConstraintObjectiveSet``,      |
+|    | Letham et al. (2019)                   | ``KNNConstraintObjectiveSet``    |
++----+----------------------------------------+----------------------------------+
 """
 
 from __future__ import annotations
@@ -145,6 +148,83 @@ class KNNObjectiveSet(TrainingSet):
             raise ValueError("KNNObjectiveSet requires candidate_x.")
         idx, _ = archive.get_knn(candidate_x, self.n_neighbors)
         return TrainingData(train_x=archive.x[idx], train_y=archive.f[idx])
+
+
+# ---------------------------------------------------------------------------
+# Constraint regression (raw g values)
+# ---------------------------------------------------------------------------
+
+
+class ConstraintObjectiveSet(TrainingSet):
+    """Use the entire archive as training data with raw constraint values.
+
+    Analogue of :class:`ArchiveObjectiveSet` for constraint surrogates.
+    Returns ``(archive.x, archive.g)`` so that a surrogate can learn to
+    predict the raw constraint values ``g(x)``.
+
+    Raises
+    ------
+    ValueError
+        If the archive has no constraint columns (``archive.g.shape[1] == 0``).
+        Use this class only with problems that define at least one constraint.
+    """
+
+    def build(
+        self,
+        archive: Archive,
+        population: Population | None,
+        ctx: OptimizationContext | None,
+        candidate_x: np.ndarray | None = None,
+    ) -> TrainingData:
+        """Return all archive points with raw constraint values."""
+        g = archive.g
+        if g.shape[1] == 0:
+            raise ValueError(
+                "ConstraintObjectiveSet requires at least one constraint "
+                "(archive.g has 0 columns)."
+            )
+        return TrainingData(train_x=archive.x, train_y=g)
+
+
+class KNNConstraintObjectiveSet(TrainingSet):
+    """Retrieve the *k* nearest archive neighbours of ``candidate_x``.
+
+    Analogue of :class:`KNNObjectiveSet` for constraint surrogates.
+    Returns the k-NN subset of ``(archive.x, archive.g)`` centred on
+    ``candidate_x``.
+
+    Parameters
+    ----------
+    n_neighbors:
+        Number of nearest neighbours to retrieve.
+
+    Raises
+    ------
+    ValueError
+        If ``candidate_x`` is None, or if the archive has no constraint columns.
+    """
+
+    def __init__(self, n_neighbors: int = 50) -> None:
+        self.n_neighbors = n_neighbors
+
+    def build(
+        self,
+        archive: Archive,
+        population: Population | None,
+        ctx: OptimizationContext | None,
+        candidate_x: np.ndarray | None = None,
+    ) -> TrainingData:
+        """Return k nearest-neighbour archive points with raw constraint values."""
+        if candidate_x is None:
+            raise ValueError("KNNConstraintObjectiveSet requires candidate_x.")
+        g = archive.g
+        if g.shape[1] == 0:
+            raise ValueError(
+                "KNNConstraintObjectiveSet requires at least one constraint "
+                "(archive.g has 0 columns)."
+            )
+        idx, _ = archive.get_knn(candidate_x, self.n_neighbors)
+        return TrainingData(train_x=archive.x[idx], train_y=g[idx])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -21,6 +21,7 @@ from saealib.acquisition import (
     MaxUncertainty,
     MeanPrediction,
     ProbabilityOfFeasibility,
+    ProductOfFeasibility,
 )
 from saealib.surrogate.prediction import SurrogatePrediction
 
@@ -334,3 +335,60 @@ class TestProbabilityOfFeasibility:
         s1 = ProbabilityOfFeasibility(obj_idx=1).score(pred, reference=None)
         assert s0[0] > 0.99  # mu=-5: clearly feasible
         assert s1[0] < 0.01  # mu=+5: clearly infeasible
+
+
+# ===========================================================================
+# ProductOfFeasibility Tests
+# ===========================================================================
+class TestProductOfFeasibility:
+    """Tests for ProductOfFeasibility acquisition function."""
+
+    def test_requires_uncertainty(self) -> None:
+        pred = _pred(value=[[0.5, 0.5]])
+        with pytest.raises(TypeError, match="uncertainty"):
+            ProductOfFeasibility().score(pred, reference=None)
+
+    def test_output_shape(self) -> None:
+        pred = _pred(value=np.zeros((5, 2)), std=np.ones((5, 2)))
+        scores = ProductOfFeasibility().score(pred, reference=None)
+        assert scores.shape == (5,)
+
+    def test_scores_in_0_1(self) -> None:
+        rng = np.random.default_rng(2)
+        pred = _pred(
+            value=rng.standard_normal((20, 3)),
+            std=np.abs(rng.standard_normal((20, 3))) + 0.01,
+        )
+        scores = ProductOfFeasibility().score(pred, reference=None)
+        assert np.all(scores >= 0.0)
+        assert np.all(scores <= 1.0)
+
+    def test_single_constraint_matches_pof(self) -> None:
+        """With one constraint column, equals ProbabilityOfFeasibility(obj_idx=0)."""
+        rng = np.random.default_rng(3)
+        mu = rng.standard_normal((10, 1))
+        sigma = np.abs(rng.standard_normal((10, 1))) + 0.01
+        pred = _pred(value=mu, std=sigma)
+        pof_scores = ProbabilityOfFeasibility(obj_idx=0).score(pred)
+        product_scores = ProductOfFeasibility().score(pred)
+        np.testing.assert_allclose(product_scores, pof_scores, rtol=1e-6)
+
+    def test_all_feasible_scores_near_one(self) -> None:
+        """If all mu << 0, joint PoF is near 1."""
+        pred = _pred(value=[[-10.0, -10.0]], std=[[0.1, 0.1]])
+        scores = ProductOfFeasibility().score(pred)
+        assert scores[0] > 0.99
+
+    def test_one_infeasible_constraint_pulls_score_to_zero(self) -> None:
+        """Even if one constraint has mu >> 0, joint PoF is near 0."""
+        pred = _pred(value=[[-10.0, 10.0]], std=[[0.1, 0.1]])
+        scores = ProductOfFeasibility().score(pred)
+        assert scores[0] < 0.01
+
+    def test_product_formula(self) -> None:
+        """PoF_joint = Phi(-mu1/s1) * Phi(-mu2/s2)."""
+        mu1, s1, mu2, s2 = -1.0, 0.5, 0.5, 1.0
+        expected = norm.cdf(-mu1 / s1) * norm.cdf(-mu2 / s2)
+        pred = _pred(value=[[mu1, mu2]], std=[[s1, s2]])
+        scores = ProductOfFeasibility().score(pred)
+        assert scores[0] == pytest.approx(expected, rel=1e-5)

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -40,9 +40,10 @@ from saealib.context import OptimizationContext
 from saealib.population import Archive, ParetoArchive, Population, PopulationAttribute
 from saealib.problem import Problem
 from saealib.surrogate.manager import (
-    EnsembleSurrogateManager,
+    CompositeSurrogateManager,
     GlobalSurrogateManager,
     LocalSurrogateManager,
+    product_combine,
 )
 from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
 from saealib.surrogate.training_set import KNNObjectiveSet
@@ -619,7 +620,7 @@ class TestPostSurrogateFitDispatch:
         candidates: np.ndarray,
         ctx: OptimizationContext,
     ) -> None:
-        """EnsembleSurrogateManager passes provider through to each sub-manager."""
+        """CompositeSurrogateManager passes provider through to each sub-manager."""
         prov = _MockProvider()
         m1 = GlobalSurrogateManager(
             RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
@@ -627,7 +628,7 @@ class TestPostSurrogateFitDispatch:
         m2 = GlobalSurrogateManager(
             RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
-        ensemble = EnsembleSurrogateManager([m1, m2])
+        ensemble = CompositeSurrogateManager([m1, m2], combine_fn=product_combine)
         ensemble.score_candidates(candidates, archive, provider=prov, ctx=ctx)
         fit_events = [
             e for e in prov.dispatched if isinstance(e, PostSurrogateFitEvent)

--- a/tests/test_constraint_surrogate.py
+++ b/tests/test_constraint_surrogate.py
@@ -146,10 +146,10 @@ class TestConstraintSurrogateG01:
     def test_feasible_solution_found(self) -> None:
         """With enough budget, at least one feasible solution is archived.
 
-        Note: the continuous [0, 1]^13 variant of G01 has ρ ≈ 64.6 % (g1–g3 are
-        always satisfied; the original binary x[10..12] reduce ρ to 0.011 %).
-        This test is therefore a smoke test for the EI × PoF pipeline, not a
-        surrogate-guidance validation.  See TestConstraintSurrogate2D for a
+        Note: the continuous [0, 1]^13 variant of G01 has feasibility rate ~64.6 %
+        (g1-g3 are always satisfied; the original binary x[10..12] reduce it to
+        0.011 %). This test is therefore a smoke test for the EI x PoF pipeline,
+        not a surrogate-guidance validation. See TestConstraintSurrogate2D for a
         direct test of PoF scoring quality.
         """
         problem = _make_g01_problem()
@@ -179,11 +179,13 @@ class TestConstraintSurrogateG01:
         )
         ctx = optimizer.run()
         cv_arr = ctx.archive.get_array("cv")
-        assert np.any(cv_arr <= 1e-6), "Expected at least one feasible solution in archive"
+        assert np.any(cv_arr <= 1e-6), (
+            "Expected at least one feasible solution in archive"
+        )
 
 
 # ---------------------------------------------------------------------------
-# 2-D circle-constraint problem (continuous, ρ ≈ 12.6 %)
+# 2-D circle-constraint problem (continuous, feasibility ~12.6 %)
 # ---------------------------------------------------------------------------
 
 # g(x) = (x0 - 0.5)^2 + (x1 - 0.5)^2 - 0.04 ≤ 0
@@ -213,15 +215,14 @@ def _make_circle_problem() -> Problem:
 
 
 class TestConstraintSurrogate2D:
-    """Functional test: PoF surrogate correctly ranks feasible vs. infeasible candidates."""
+    """Functional test: PoF surrogate correctly ranks feasible vs. infeasible."""
 
     def test_pof_scores_distinguish_feasibility(self) -> None:
-        """PoF surrogate trained on archive scores feasible candidates higher than infeasible ones.
+        """PoF surrogate assigns higher scores to feasible candidates than infeasible.
 
-        Uses a 2-D circle-constraint problem (ρ ≈ 12.6 %).  After seeding the archive
-        with 50 LHS points (~6 expected feasible), the constraint surrogate should have
-        learned the feasibility boundary well enough to rank inside-circle candidates above
-        outside-circle candidates.
+        Uses a 2-D circle-constraint problem (feasibility ~12.6 %). After seeding the
+        archive with 50 LHS points (~6 expected feasible), the constraint surrogate
+        should rank inside-circle candidates above outside-circle candidates.
         """
         problem = _make_circle_problem()
         optimizer = (
@@ -246,27 +247,31 @@ class TestConstraintSurrogate2D:
         )
 
         # Points clearly inside circle (g < 0)
-        inside = np.array([
-            [0.50, 0.50],  # centre: g = -0.04
-            [0.55, 0.50],  # g = -0.0375
-            [0.50, 0.55],  # g = -0.0375
-            [0.45, 0.50],  # g = -0.0375
-            [0.50, 0.45],  # g = -0.0375
-        ])
+        inside = np.array(
+            [
+                [0.50, 0.50],  # centre: g = -0.04
+                [0.55, 0.50],  # g = -0.0375
+                [0.50, 0.55],  # g = -0.0375
+                [0.45, 0.50],  # g = -0.0375
+                [0.50, 0.45],  # g = -0.0375
+            ]
+        )
         # Points clearly outside circle (g >> 0)
-        outside = np.array([
-            [0.0, 0.0],   # g = 0.46
-            [1.0, 0.0],   # g = 0.46
-            [0.0, 1.0],   # g = 0.46
-            [1.0, 1.0],   # g = 0.46
-            [0.5, 1.0],   # g = 0.21
-        ])
+        outside = np.array(
+            [
+                [0.0, 0.0],  # g = 0.46
+                [1.0, 0.0],  # g = 0.46
+                [0.0, 1.0],  # g = 0.46
+                [1.0, 1.0],  # g = 0.46
+                [0.5, 1.0],  # g = 0.21
+            ]
+        )
 
         candidates = np.vstack([inside, outside])
         scores, _ = pof_mgr.score_candidates(candidates, archive)
 
         pof_inside = scores[: len(inside)]
-        pof_outside = scores[len(inside):]
+        pof_outside = scores[len(inside) :]
 
         assert np.mean(pof_inside) > np.mean(pof_outside), (
             f"PoF should be higher for feasible candidates: "

--- a/tests/test_constraint_surrogate.py
+++ b/tests/test_constraint_surrogate.py
@@ -1,0 +1,227 @@
+"""End-to-end tests for constraint surrogate integration (issue #86).
+
+Tests that CompositeSurrogateManager([ei_mgr, pof_mgr], product_combine)
+correctly combines an objective surrogate (EI) with a constraint surrogate
+(ProductOfFeasibility) on the G01 constrained benchmark.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from saealib import (
+    GA,
+    CompositeSurrogateManager,
+    CrossoverBLXAlpha,
+    ExpectedImprovement,
+    GlobalSurrogateManager,
+    GPSurrogate,
+    InequalityConstraint,
+    LHSInitializer,
+    MutationUniform,
+    Optimizer,
+    PerObjectiveSurrogate,
+    PreSelectionStrategy,
+    Problem,
+    ProductOfFeasibility,
+    SequentialSelection,
+    StaticToleranceHandler,
+    Termination,
+    TruncationSelection,
+    max_fe,
+    product_combine,
+)
+from saealib.surrogate.training_set import ArchiveObjectiveSet, ConstraintObjectiveSet
+
+# ---------------------------------------------------------------------------
+# G01 benchmark definition
+# ---------------------------------------------------------------------------
+
+_DIM = 13
+_N_CONSTRAINTS = 9
+
+
+def _g01_obj(x: np.ndarray) -> np.ndarray:
+    return np.array([5.0 * np.sum(x[:4]) - 5.0 * np.sum(x[:4] ** 2) - np.sum(x[4:13])])
+
+
+_G01_CONSTRAINTS = [
+    InequalityConstraint(lambda x: 2 * x[0] + 2 * x[1] + x[9] + x[10] - 10.0),
+    InequalityConstraint(lambda x: 2 * x[0] + 2 * x[2] + x[9] + x[11] - 10.0),
+    InequalityConstraint(lambda x: 2 * x[1] + 2 * x[2] + x[10] + x[11] - 10.0),
+    InequalityConstraint(lambda x: -8.0 * x[0] + x[9]),
+    InequalityConstraint(lambda x: -8.0 * x[1] + x[10]),
+    InequalityConstraint(lambda x: -8.0 * x[2] + x[11]),
+    InequalityConstraint(lambda x: -2.0 * x[3] - x[4] + x[9]),
+    InequalityConstraint(lambda x: -2.0 * x[5] - x[6] + x[10]),
+    InequalityConstraint(lambda x: -2.0 * x[7] - x[8] + x[11]),
+]
+
+
+def _make_g01_problem() -> Problem:
+    return Problem(
+        func=_g01_obj,
+        dim=_DIM,
+        n_obj=1,
+        direction=np.array([-1.0]),
+        lb=[0.0] * _DIM,
+        ub=[1.0] * _DIM,
+        constraints=_G01_CONSTRAINTS,
+        handler=StaticToleranceHandler(eps_cv=1e-6),
+    )
+
+
+def _make_ga() -> GA:
+    return GA(
+        crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4),
+        mutation=MutationUniform(mutation_rate=0.1),
+        parent_selection=SequentialSelection(),
+        survivor_selection=TruncationSelection(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# G01 end-to-end test
+# ---------------------------------------------------------------------------
+
+
+class TestConstraintSurrogateG01:
+    """End-to-end test: EI x ProductOfFeasibility on G01."""
+
+    def test_optimizer_runs_without_error(self) -> None:
+        """CompositeSurrogateManager completes 5 generations on G01."""
+        problem = _make_g01_problem()
+
+        ei_mgr = GlobalSurrogateManager(
+            GPSurrogate(),
+            ExpectedImprovement(),
+            training_set=ArchiveObjectiveSet(),
+        )
+        pof_mgr = GlobalSurrogateManager(
+            PerObjectiveSurrogate([GPSurrogate() for _ in range(_N_CONSTRAINTS)]),
+            ProductOfFeasibility(),
+            training_set=ConstraintObjectiveSet(),
+        )
+        surrogate_manager = CompositeSurrogateManager(
+            [ei_mgr, pof_mgr],
+            combine_fn=product_combine,
+        )
+
+        optimizer = (
+            Optimizer(problem)
+            .set_initializer(
+                LHSInitializer(n_init_archive=20, n_init_population=10, seed=0)
+            )
+            .set_algorithm(_make_ga())
+            .set_strategy(PreSelectionStrategy(n_candidates=20, n_select=3))
+            .set_surrogate_manager(surrogate_manager)
+            .set_termination(Termination(max_fe(40)))
+        )
+        ctx = optimizer.run()
+        assert ctx is not None
+
+    def test_constraint_surrogate_trains_on_g(self) -> None:
+        """ConstraintObjectiveSet produces train_y with n_constraints columns."""
+        problem = _make_g01_problem()
+        optimizer = (
+            Optimizer(problem)
+            .set_initializer(
+                LHSInitializer(n_init_archive=15, n_init_population=10, seed=1)
+            )
+            .set_algorithm(_make_ga())
+            .set_strategy(PreSelectionStrategy(n_candidates=20, n_select=3))
+            .set_surrogate_manager(
+                GlobalSurrogateManager(GPSurrogate(), ExpectedImprovement())
+            )
+            .set_termination(Termination(max_fe(15)))
+        )
+        # Run initialisation only (max_fe equals initial archive sample size)
+        ctx = optimizer.run()
+        archive = ctx.archive
+        ts = ConstraintObjectiveSet()
+        data = ts.build(archive, None, None)
+        assert data.train_y.shape == (len(archive), _N_CONSTRAINTS)
+
+    def test_feasible_solution_found(self) -> None:
+        """With enough budget, at least one feasible solution is archived."""
+        problem = _make_g01_problem()
+
+        ei_mgr = GlobalSurrogateManager(
+            GPSurrogate(),
+            ExpectedImprovement(),
+            training_set=ArchiveObjectiveSet(),
+        )
+        pof_mgr = GlobalSurrogateManager(
+            PerObjectiveSurrogate([GPSurrogate() for _ in range(_N_CONSTRAINTS)]),
+            ProductOfFeasibility(),
+            training_set=ConstraintObjectiveSet(),
+        )
+
+        optimizer = (
+            Optimizer(problem)
+            .set_initializer(
+                LHSInitializer(n_init_archive=30, n_init_population=10, seed=42)
+            )
+            .set_algorithm(_make_ga())
+            .set_strategy(PreSelectionStrategy(n_candidates=30, n_select=5))
+            .set_surrogate_manager(
+                CompositeSurrogateManager([ei_mgr, pof_mgr], product_combine)
+            )
+            .set_termination(Termination(max_fe(60)))
+        )
+        ctx = optimizer.run()
+        assert ctx is not None
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: zero-constraint problems
+# ---------------------------------------------------------------------------
+
+
+class TestConstraintSurrogateBackwardCompat:
+    """Zero-constraint problems work as before; ConstraintObjectiveSet raises."""
+
+    def test_unconstrained_optimizer_unchanged(self) -> None:
+        """Unconstrained sphere problem runs identically with new imports loaded."""
+        problem = Problem(
+            func=lambda x: np.array([np.sum(x**2)]),
+            dim=3,
+            n_obj=1,
+            direction=np.array([-1.0]),
+            lb=[-5.0] * 3,
+            ub=[5.0] * 3,
+        )
+        optimizer = (
+            Optimizer(problem)
+            .set_initializer(
+                LHSInitializer(n_init_archive=10, n_init_population=5, seed=0)
+            )
+            .set_algorithm(_make_ga())
+            .set_strategy(PreSelectionStrategy(n_candidates=10, n_select=2))
+            .set_surrogate_manager(
+                GlobalSurrogateManager(GPSurrogate(), ExpectedImprovement())
+            )
+            .set_termination(Termination(max_fe(20)))
+        )
+        ctx = optimizer.run()
+        assert ctx is not None
+
+    def test_constraint_objective_set_raises_on_zero_constraints(self) -> None:
+        """ConstraintObjectiveSet raises ValueError when archive has no g columns."""
+        from saealib.population import Archive, PopulationAttribute
+
+        attrs = [
+            PopulationAttribute("x", np.float64, (3,)),
+            PopulationAttribute("f", np.float64, (1,)),
+            PopulationAttribute("g", np.float64, (0,)),
+            PopulationAttribute("cv", np.float64, ()),
+        ]
+        arc = Archive(attrs, init_capacity=10)
+        rng = np.random.default_rng(0)
+        for _ in range(5):
+            arc.add(x=rng.uniform(size=3), f=np.array([1.0]), cv=0.0)
+
+        ts = ConstraintObjectiveSet()
+        with pytest.raises(ValueError, match="0 columns"):
+            ts.build(arc, None, None)

--- a/tests/test_constraint_surrogate.py
+++ b/tests/test_constraint_surrogate.py
@@ -144,7 +144,14 @@ class TestConstraintSurrogateG01:
         assert data.train_y.shape == (len(archive), _N_CONSTRAINTS)
 
     def test_feasible_solution_found(self) -> None:
-        """With enough budget, at least one feasible solution is archived."""
+        """With enough budget, at least one feasible solution is archived.
+
+        Note: the continuous [0, 1]^13 variant of G01 has ρ ≈ 64.6 % (g1–g3 are
+        always satisfied; the original binary x[10..12] reduce ρ to 0.011 %).
+        This test is therefore a smoke test for the EI × PoF pipeline, not a
+        surrogate-guidance validation.  See TestConstraintSurrogate2D for a
+        direct test of PoF scoring quality.
+        """
         problem = _make_g01_problem()
 
         ei_mgr = GlobalSurrogateManager(
@@ -171,7 +178,100 @@ class TestConstraintSurrogateG01:
             .set_termination(Termination(max_fe(60)))
         )
         ctx = optimizer.run()
-        assert ctx is not None
+        cv_arr = ctx.archive.get_array("cv")
+        assert np.any(cv_arr <= 1e-6), "Expected at least one feasible solution in archive"
+
+
+# ---------------------------------------------------------------------------
+# 2-D circle-constraint problem (continuous, ρ ≈ 12.6 %)
+# ---------------------------------------------------------------------------
+
+# g(x) = (x0 - 0.5)^2 + (x1 - 0.5)^2 - 0.04 ≤ 0
+# Feasibility rate: π·r² = π·0.04 ≈ 12.6 % of [0, 1]²
+_CIRCLE_R2 = 0.04
+
+
+def _circle_obj(x: np.ndarray) -> np.ndarray:
+    return np.array([-(x[0] + x[1])])  # minimize → maximise x0 + x1
+
+
+def _make_circle_problem() -> Problem:
+    return Problem(
+        func=_circle_obj,
+        dim=2,
+        n_obj=1,
+        direction=np.array([-1.0]),
+        lb=[0.0, 0.0],
+        ub=[1.0, 1.0],
+        constraints=[
+            InequalityConstraint(
+                lambda x: (x[0] - 0.5) ** 2 + (x[1] - 0.5) ** 2 - _CIRCLE_R2
+            )
+        ],
+        handler=StaticToleranceHandler(eps_cv=1e-6),
+    )
+
+
+class TestConstraintSurrogate2D:
+    """Functional test: PoF surrogate correctly ranks feasible vs. infeasible candidates."""
+
+    def test_pof_scores_distinguish_feasibility(self) -> None:
+        """PoF surrogate trained on archive scores feasible candidates higher than infeasible ones.
+
+        Uses a 2-D circle-constraint problem (ρ ≈ 12.6 %).  After seeding the archive
+        with 50 LHS points (~6 expected feasible), the constraint surrogate should have
+        learned the feasibility boundary well enough to rank inside-circle candidates above
+        outside-circle candidates.
+        """
+        problem = _make_circle_problem()
+        optimizer = (
+            Optimizer(problem)
+            .set_initializer(
+                LHSInitializer(n_init_archive=50, n_init_population=10, seed=0)
+            )
+            .set_algorithm(_make_ga())
+            .set_strategy(PreSelectionStrategy(n_candidates=20, n_select=3))
+            .set_surrogate_manager(
+                GlobalSurrogateManager(GPSurrogate(), ExpectedImprovement())
+            )
+            .set_termination(Termination(max_fe(50)))
+        )
+        ctx = optimizer.run()
+        archive = ctx.archive
+
+        pof_mgr = GlobalSurrogateManager(
+            PerObjectiveSurrogate([GPSurrogate()]),
+            ProductOfFeasibility(),
+            training_set=ConstraintObjectiveSet(),
+        )
+
+        # Points clearly inside circle (g < 0)
+        inside = np.array([
+            [0.50, 0.50],  # centre: g = -0.04
+            [0.55, 0.50],  # g = -0.0375
+            [0.50, 0.55],  # g = -0.0375
+            [0.45, 0.50],  # g = -0.0375
+            [0.50, 0.45],  # g = -0.0375
+        ])
+        # Points clearly outside circle (g >> 0)
+        outside = np.array([
+            [0.0, 0.0],   # g = 0.46
+            [1.0, 0.0],   # g = 0.46
+            [0.0, 1.0],   # g = 0.46
+            [1.0, 1.0],   # g = 0.46
+            [0.5, 1.0],   # g = 0.21
+        ])
+
+        candidates = np.vstack([inside, outside])
+        scores, _ = pof_mgr.score_candidates(candidates, archive)
+
+        pof_inside = scores[: len(inside)]
+        pof_outside = scores[len(inside):]
+
+        assert np.mean(pof_inside) > np.mean(pof_outside), (
+            f"PoF should be higher for feasible candidates: "
+            f"inside={np.mean(pof_inside):.3f}, outside={np.mean(pof_outside):.3f}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -25,7 +25,11 @@ from saealib.strategies.gb import GenerationBasedStrategy
 from saealib.strategies.ib import IndividualBasedStrategy
 from saealib.strategies.ps import PreSelectionStrategy
 from saealib.surrogate.archive_manager import DensityManager, NoveltyManager
-from saealib.surrogate.manager import EnsembleSurrogateManager, LocalSurrogateManager
+from saealib.surrogate.manager import (
+    CompositeSurrogateManager,
+    LocalSurrogateManager,
+    rank_weighted_combine,
+)
 from saealib.surrogate.prediction import SurrogatePrediction
 from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
 
@@ -219,29 +223,29 @@ class TestPreSelectionStrategy:
 
 
 # ---------------------------------------------------------------------------
-# IndividualBasedStrategy + NoveltyManager (via EnsembleSurrogateManager)
+# IndividualBasedStrategy + NoveltyManager (via CompositeSurrogateManager)
 # ---------------------------------------------------------------------------
 
 
-def _make_ensemble_novelty() -> EnsembleSurrogateManager:
+def _make_ensemble_novelty() -> CompositeSurrogateManager:
     """Regression surrogate first (finite tell_f) + NoveltyManager second."""
-    return EnsembleSurrogateManager(
+    return CompositeSurrogateManager(
         [
             LocalSurrogateManager(RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()),
             NoveltyManager(k=3),
         ],
-        weights=np.array([0.7, 0.3]),
+        combine_fn=rank_weighted_combine(np.array([0.7, 0.3])),
     )
 
 
-def _make_ensemble_density() -> EnsembleSurrogateManager:
+def _make_ensemble_density() -> CompositeSurrogateManager:
     """Regression surrogate first (finite tell_f) + DensityManager second."""
-    return EnsembleSurrogateManager(
+    return CompositeSurrogateManager(
         [
             LocalSurrogateManager(RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()),
             DensityManager(eps=1.0),
         ],
-        weights=np.array([0.7, 0.3]),
+        combine_fn=rank_weighted_combine(np.array([0.7, 0.3])),
     )
 
 

--- a/tests/test_surrogate_manager.py
+++ b/tests/test_surrogate_manager.py
@@ -6,7 +6,7 @@ Tests cover:
 - _rank_normalize: rank-based normalization to [0, 1]
 - GlobalSurrogateManager: fits on full archive, batch predict and score
 - LocalSurrogateManager: KNN per candidate, per-candidate fit and score
-- EnsembleSurrogateManager: rank-normalized weighted aggregation of sub-managers
+- CompositeSurrogateManager: combines scores from multiple sub-managers via combine_fn
 """
 
 import numpy as np
@@ -21,12 +21,14 @@ from saealib.surrogate.archive_manager import (
     NoveltyManager,
 )
 from saealib.surrogate.manager import (
-    EnsembleSurrogateManager,
+    CompositeSurrogateManager,
     GlobalSurrogateManager,
     LocalSurrogateManager,
     SurrogateManager,
     _rank_normalize,
     _split_prediction,
+    product_combine,
+    rank_weighted_combine,
 )
 from saealib.surrogate.prediction import SurrogatePrediction
 from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
@@ -458,87 +460,82 @@ class TestLocalSurrogateManager:
 
 
 # ===========================================================================
-# EnsembleSurrogateManager Tests
+# CompositeSurrogateManager Tests
 # ===========================================================================
-class TestEnsembleSurrogateManager:
-    """Tests for EnsembleSurrogateManager."""
+class TestCompositeSurrogateManager:
+    """Tests for CompositeSurrogateManager."""
 
     def test_empty_managers_raises_value_error(self) -> None:
         with pytest.raises(ValueError, match="at least one"):
-            EnsembleSurrogateManager([])
+            CompositeSurrogateManager([], combine_fn=product_combine)
 
-    def test_uniform_weights_by_default(self) -> None:
+    def test_product_combine_scores_shape(
+        self, archive_1obj: Archive, candidates: np.ndarray
+    ) -> None:
         m1 = GlobalSurrogateManager(
             RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         m2 = GlobalSurrogateManager(
             RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
-        ensemble = EnsembleSurrogateManager([m1, m2])
-        np.testing.assert_array_almost_equal(ensemble.weights, [0.5, 0.5])
+        mgr = CompositeSurrogateManager([m1, m2], combine_fn=product_combine)
+        scores, _ = mgr.score_candidates(candidates, archive_1obj)
+        assert scores.shape == (len(candidates),)
 
-    def test_custom_weights_are_normalized(self) -> None:
+    def test_rank_weighted_combine_scores_in_0_1(
+        self, archive_1obj: Archive, candidates: np.ndarray
+    ) -> None:
         m1 = GlobalSurrogateManager(
             RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         m2 = GlobalSurrogateManager(
             RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
-        ensemble = EnsembleSurrogateManager([m1, m2], weights=np.array([1.0, 3.0]))
-        np.testing.assert_array_almost_equal(ensemble.weights, [0.25, 0.75])
+        mgr = CompositeSurrogateManager([m1, m2], combine_fn=rank_weighted_combine())
+        scores, _ = mgr.score_candidates(candidates, archive_1obj)
+        assert np.all(scores >= 0.0)
+        assert np.all(scores <= 1.0)
 
-    def test_scores_shape(self, archive_1obj: Archive, candidates: np.ndarray) -> None:
+    def test_rank_weighted_combine_custom_weights(
+        self, archive_1obj: Archive, candidates: np.ndarray
+    ) -> None:
         m1 = GlobalSurrogateManager(
             RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         m2 = GlobalSurrogateManager(
             RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
-        ensemble = EnsembleSurrogateManager([m1, m2])
-        scores, _ = ensemble.score_candidates(candidates, archive_1obj)
+        mgr = CompositeSurrogateManager(
+            [m1, m2], combine_fn=rank_weighted_combine(np.array([1.0, 3.0]))
+        )
+        scores, _ = mgr.score_candidates(candidates, archive_1obj)
         assert scores.shape == (len(candidates),)
 
     def test_predictions_from_first_manager(
         self, archive_1obj: Archive, candidates: np.ndarray
     ) -> None:
-        """EnsembleSurrogateManager returns predictions from the first sub-manager."""
+        """predictions always come from managers[0]."""
         m1 = GlobalSurrogateManager(
             RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         m2 = GlobalSurrogateManager(
             RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
-        ensemble = EnsembleSurrogateManager([m1, m2])
-        _, predictions = ensemble.score_candidates(candidates, archive_1obj)
+        mgr = CompositeSurrogateManager([m1, m2], combine_fn=product_combine)
+        _, predictions = mgr.score_candidates(candidates, archive_1obj)
         assert len(predictions) == len(candidates)
         for p in predictions:
             assert isinstance(p, SurrogatePrediction)
 
-    def test_scores_in_0_1_range(
-        self, archive_1obj: Archive, candidates: np.ndarray
-    ) -> None:
-        """Aggregated scores are rank-normalized weighted averages, so in [0, 1]."""
-        m1 = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
-        )
-        m2 = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
-        )
-        ensemble = EnsembleSurrogateManager([m1, m2])
-        scores, _ = ensemble.score_candidates(candidates, archive_1obj)
-        assert np.all(scores >= 0.0)
-        assert np.all(scores <= 1.0)
-
-    def test_single_manager_ensemble(
+    def test_single_manager(
         self,
         surrogate_1obj: RBFsurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
-        """An ensemble with one manager propagates scores correctly."""
         m = GlobalSurrogateManager(surrogate_1obj, MeanPrediction())
-        ensemble = EnsembleSurrogateManager([m])
-        scores, _ = ensemble.score_candidates(candidates, archive_1obj)
+        mgr = CompositeSurrogateManager([m], combine_fn=product_combine)
+        scores, _ = mgr.score_candidates(candidates, archive_1obj)
         assert scores.shape == (len(candidates),)
 
 
@@ -763,10 +760,10 @@ class TestNichingManager:
 
 
 # ===========================================================================
-# EnsembleSurrogateManager + ArchiveBasedManager Integration Tests
+# CompositeSurrogateManager + ArchiveBasedManager Integration Tests
 # ===========================================================================
-class TestEnsembleSurrogateManagerWithArchiveBased:
-    """Integration tests: EnsembleSurrogateManager with ArchiveBasedManager."""
+class TestCompositeSurrogateManagerWithArchiveBased:
+    """Integration tests: CompositeSurrogateManager with ArchiveBasedManager."""
 
     def test_regression_novelty_ensemble_scores_shape(
         self, archive_1obj: Archive, candidates: np.ndarray
@@ -774,10 +771,11 @@ class TestEnsembleSurrogateManagerWithArchiveBased:
         m_reg = GlobalSurrogateManager(
             RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
-        ensemble = EnsembleSurrogateManager(
-            [m_reg, NoveltyManager(k=3)], weights=np.array([0.7, 0.3])
+        mgr = CompositeSurrogateManager(
+            [m_reg, NoveltyManager(k=3)],
+            combine_fn=rank_weighted_combine(np.array([0.7, 0.3])),
         )
-        scores, _ = ensemble.score_candidates(candidates, archive_1obj)
+        scores, _ = mgr.score_candidates(candidates, archive_1obj)
         assert scores.shape == (len(candidates),)
 
     def test_regression_novelty_ensemble_scores_in_0_1(
@@ -786,8 +784,10 @@ class TestEnsembleSurrogateManagerWithArchiveBased:
         m_reg = GlobalSurrogateManager(
             RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
-        ensemble = EnsembleSurrogateManager([m_reg, NoveltyManager(k=3)])
-        scores, _ = ensemble.score_candidates(candidates, archive_1obj)
+        mgr = CompositeSurrogateManager(
+            [m_reg, NoveltyManager(k=3)], combine_fn=rank_weighted_combine()
+        )
+        scores, _ = mgr.score_candidates(candidates, archive_1obj)
         assert np.all(scores >= 0.0) and np.all(scores <= 1.0)
 
     def test_regression_first_tell_f_is_finite(
@@ -797,8 +797,10 @@ class TestEnsembleSurrogateManagerWithArchiveBased:
         m_reg = GlobalSurrogateManager(
             RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
-        ensemble = EnsembleSurrogateManager([m_reg, NoveltyManager(k=3)])
-        _, preds = ensemble.score_candidates(candidates, archive_1obj)
+        mgr = CompositeSurrogateManager(
+            [m_reg, NoveltyManager(k=3)], combine_fn=rank_weighted_combine()
+        )
+        _, preds = mgr.score_candidates(candidates, archive_1obj)
         for p in preds:
             assert np.all(np.isfinite(p.tell_f))
 
@@ -806,8 +808,10 @@ class TestEnsembleSurrogateManagerWithArchiveBased:
         self, archive_1obj: Archive, candidates: np.ndarray
     ) -> None:
         """ArchiveBasedManager alone → predictions have NaN tell_f."""
-        ensemble = EnsembleSurrogateManager([NoveltyManager(k=3)])
-        _, preds = ensemble.score_candidates(candidates, archive_1obj)
+        mgr = CompositeSurrogateManager(
+            [NoveltyManager(k=3)], combine_fn=rank_weighted_combine()
+        )
+        _, preds = mgr.score_candidates(candidates, archive_1obj)
         for p in preds:
             assert p.has_tell_f
             assert np.all(np.isnan(p.tell_f))
@@ -818,10 +822,11 @@ class TestEnsembleSurrogateManagerWithArchiveBased:
         m_reg = GlobalSurrogateManager(
             RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
-        ensemble = EnsembleSurrogateManager(
-            [m_reg, DensityManager(eps=0.5)], weights=np.array([0.6, 0.4])
+        mgr = CompositeSurrogateManager(
+            [m_reg, DensityManager(eps=0.5)],
+            combine_fn=rank_weighted_combine(np.array([0.6, 0.4])),
         )
-        scores, preds = ensemble.score_candidates(candidates, archive_1obj)
+        scores, preds = mgr.score_candidates(candidates, archive_1obj)
         assert scores.shape == (len(candidates),)
         for p in preds:
             assert np.all(np.isfinite(p.tell_f))

--- a/tests/test_training_set.py
+++ b/tests/test_training_set.py
@@ -11,7 +11,9 @@ from saealib.population import Archive, ParetoArchive, Population, PopulationAtt
 from saealib.problem import Problem
 from saealib.surrogate.training_set import (
     ArchiveObjectiveSet,
+    ConstraintObjectiveSet,
     FeasibilityClassificationSet,
+    KNNConstraintObjectiveSet,
     KNNObjectiveSet,
     LevelBasedSet,
     PairwiseComparisonSet,
@@ -25,11 +27,19 @@ from saealib.surrogate.training_set import (
 
 DIM = 2
 N_OBJ = 1
+N_CONSTRAINTS = 2
 
 _ATTRS = [
     PopulationAttribute(name="x", dtype=np.float64, shape=(DIM,)),
     PopulationAttribute(name="f", dtype=np.float64, shape=(N_OBJ,)),
     PopulationAttribute(name="g", dtype=np.float64, shape=(0,)),
+    PopulationAttribute(name="cv", dtype=np.float64, shape=()),
+]
+
+_ATTRS_G = [
+    PopulationAttribute(name="x", dtype=np.float64, shape=(DIM,)),
+    PopulationAttribute(name="f", dtype=np.float64, shape=(N_OBJ,)),
+    PopulationAttribute(name="g", dtype=np.float64, shape=(N_CONSTRAINTS,)),
     PopulationAttribute(name="cv", dtype=np.float64, shape=()),
 ]
 
@@ -54,6 +64,18 @@ def _make_archive(n: int = 10) -> Archive:
         x = rng.uniform(-2.0, 2.0, size=DIM)
         f = np.array([np.sum(x**2)])
         arc.add(x=x, f=f, cv=0.0)
+    return arc
+
+
+def _make_archive_with_g(n: int = 10) -> Archive:
+    """Archive with 2 constraint columns filled with known values."""
+    arc = Archive(_ATTRS_G, init_capacity=n + 5)
+    rng = np.random.default_rng(7)
+    for i in range(n):
+        x = rng.uniform(-2.0, 2.0, size=DIM)
+        f = np.array([np.sum(x**2)])
+        g = np.array([float(i), float(-i)])   # known values for assertion
+        arc.add(x=x, f=f, g=g, cv=0.0)
     return arc
 
 
@@ -162,6 +184,73 @@ class TestKNNObjectiveSet:
         cand = np.zeros(DIM)
         data = ts.build(arc, None, None, candidate_x=cand)
         assert data.train_x.shape[0] <= 8
+
+
+# ===========================================================================
+# ConstraintObjectiveSet
+# ===========================================================================
+class TestConstraintObjectiveSet:
+    def test_returns_all_archive_points(self) -> None:
+        arc = _make_archive_with_g(8)
+        ts = ConstraintObjectiveSet()
+        data = ts.build(arc, None, None)
+        assert data.train_x.shape == (8, DIM)
+        assert data.train_y.shape == (8, N_CONSTRAINTS)
+        np.testing.assert_array_equal(data.train_y, arc.g)
+
+    def test_train_y_is_g_not_f(self) -> None:
+        arc = _make_archive_with_g(5)
+        ts = ConstraintObjectiveSet()
+        data = ts.build(arc, None, None)
+        # train_y must differ from f (different columns)
+        assert data.train_y.shape[1] == N_CONSTRAINTS
+        assert data.train_y.shape[1] != arc.f.shape[1] or not np.allclose(
+            data.train_y, arc.f
+        )
+
+    def test_raises_on_zero_constraints(self) -> None:
+        arc = _make_archive(5)   # uses _ATTRS with shape=(0,) for g
+        ts = ConstraintObjectiveSet()
+        with pytest.raises(ValueError, match="0 columns"):
+            ts.build(arc, None, None)
+
+    def test_candidate_x_is_ignored(self) -> None:
+        arc = _make_archive_with_g(6)
+        ts = ConstraintObjectiveSet()
+        candidate = np.zeros(DIM)
+        data = ts.build(arc, None, None, candidate_x=candidate)
+        assert data.train_x.shape[0] == 6
+
+
+# ===========================================================================
+# KNNConstraintObjectiveSet
+# ===========================================================================
+class TestKNNConstraintObjectiveSet:
+    def test_returns_k_neighbours(self) -> None:
+        arc = _make_archive_with_g(10)
+        ts = KNNConstraintObjectiveSet(n_neighbors=5)
+        candidate = np.zeros(DIM)
+        data = ts.build(arc, None, None, candidate_x=candidate)
+        assert data.train_x.shape == (5, DIM)
+        assert data.train_y.shape == (5, N_CONSTRAINTS)
+
+    def test_requires_candidate_x(self) -> None:
+        arc = _make_archive_with_g(5)
+        ts = KNNConstraintObjectiveSet(n_neighbors=3)
+        with pytest.raises(ValueError, match="candidate_x"):
+            ts.build(arc, None, None, candidate_x=None)
+
+    def test_raises_on_zero_constraints(self) -> None:
+        arc = _make_archive(5)
+        ts = KNNConstraintObjectiveSet(n_neighbors=3)
+        with pytest.raises(ValueError, match="0 columns"):
+            ts.build(arc, None, None, candidate_x=np.zeros(DIM))
+
+    def test_clamped_to_archive_size(self) -> None:
+        arc = _make_archive_with_g(4)
+        ts = KNNConstraintObjectiveSet(n_neighbors=50)
+        data = ts.build(arc, None, None, candidate_x=np.zeros(DIM))
+        assert data.train_x.shape[0] == 4
 
 
 # ===========================================================================

--- a/tests/test_training_set.py
+++ b/tests/test_training_set.py
@@ -74,7 +74,7 @@ def _make_archive_with_g(n: int = 10) -> Archive:
     for i in range(n):
         x = rng.uniform(-2.0, 2.0, size=DIM)
         f = np.array([np.sum(x**2)])
-        g = np.array([float(i), float(-i)])   # known values for assertion
+        g = np.array([float(i), float(-i)])  # known values for assertion
         arc.add(x=x, f=f, g=g, cv=0.0)
     return arc
 
@@ -209,7 +209,7 @@ class TestConstraintObjectiveSet:
         )
 
     def test_raises_on_zero_constraints(self) -> None:
-        arc = _make_archive(5)   # uses _ATTRS with shape=(0,) for g
+        arc = _make_archive(5)  # uses _ATTRS with shape=(0,) for g
         ts = ConstraintObjectiveSet()
         with pytest.raises(ValueError, match="0 columns"):
             ts.build(arc, None, None)


### PR DESCRIPTION
## Related Issue
Closes #86

## Overview
Adds a surrogate-assisted constraint handling path that lets the optimizer predict raw constraint values via a GP surrogate and steer candidates toward feasible regions using Probability of Feasibility. Also replaces `EnsembleSurrogateManager` with the more general `CompositeSurrogateManager` (breaking change; pre-release).

## Changes
- **Breaking**: Remove `EnsembleSurrogateManager`; replace with `CompositeSurrogateManager(managers, combine_fn)` that accepts any injectable combine function
- Add `product_combine` and `rank_weighted_combine` as module-level combine functions
- Add `ConstraintObjectiveSet` / `KNNConstraintObjectiveSet`: return `(archive.x, archive.g)` as training data for constraint surrogates
- Add `ProductOfFeasibility`: joint PoF across all constraint columns — `∏ Φ((0 − μᵢ) / σᵢ)`
- Export new symbols from `saealib.__init__`
- Add G01 end-to-end tests (9 constraints, dim=13) and backward-compat tests
- Add `TestConstraintSurrogate2D`: directly validates that PoF scores rank feasible candidates above infeasible ones on a 2-D circle-constraint problem (ρ ≈ 12.6 %)

## Verification Steps
run pytest

## Concerns
- `CompositeSurrogateManager` is a breaking change: `EnsembleSurrogateManager` is removed. Migration: `CompositeSurrogateManager([m1, m2], rank_weighted_combine())`.
- `managers[0]` in `CompositeSurrogateManager` provides the `SurrogatePrediction` objects used for `tell_f` assignment; the objective manager must be listed first.
- The continuous [0, 1]^13 G01 formulation has ρ ≈ 64.6 % (the original problem uses binary x[10..12] which reduces ρ to 0.011 %). G01 tests are smoke tests for the EI × PoF pipeline, not surrogate-guidance validation.

## Other
