### PR TITLE
refactor: [#126] Unify remaining weight → direction in Comparator layer

### DIFF
--- a/src/saealib/comparators.py
+++ b/src/saealib/comparators.py
@@ -536,20 +536,31 @@ class WeightedSumComparator(Comparator):
 
     Parameters
     ----------
-    weights : np.ndarray
-        Weights for objectives. shape = (n_obj,)
+    direction : np.ndarray
+        Per-objective optimization directions (±1). shape = (n_obj,)
     eps : float
         Epsilon tolerance for constraint violation and fitness comparison.
     """
 
     def __init__(
         self,
-        weights: np.ndarray,
+        direction: np.ndarray | None = None,
         eps: float | None = None,
         *,
+        weights: np.ndarray | None = None,
         eps_cv: float = 1e-6,
         eps_obj: float = 1e-6,
     ):
+        if weights is not None:
+            warnings.warn(
+                "WeightedSumComparator(weights=...) is deprecated"
+                " and will be removed in 0.1.0. Use direction=.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            direction = weights
+        if direction is None:
+            raise TypeError("WeightedSumComparator() missing required argument: 'direction'")
         if eps is not None:
             warnings.warn(
                 "WeightedSumComparator(eps=...) is deprecated"
@@ -558,13 +569,14 @@ class WeightedSumComparator(Comparator):
                 stacklevel=2,
             )
             eps_cv = eps_obj = eps
-        super().__init__(np.asarray(weights, dtype=float), eps_cv, eps_obj)
+        _dir = np.asarray(direction, dtype=float)
+        super().__init__(_dir, eps_cv, eps_obj, direction=_dir)
 
     def sort_population(self, population: Population) -> np.ndarray:
         """Sort population by weighted sum of objectives, with feasibility first."""
         f = population.get("f")  # (n_ind, n_obj)
         cv = population.get("cv")  # (n_ind,)
-        scalar = f @ self.weights  # (n_ind,) weighted sum per individual
+        scalar = f @ self.direction  # (n_ind,) weighted sum per individual
         cv_key = np.where(cv > self.eps_cv, cv, 0)
         return np.lexsort((-scalar, cv_key))
 
@@ -590,8 +602,8 @@ class WeightedSumComparator(Comparator):
             return 1
         elif cv_b > self.eps_cv:
             return -1
-        sa = float(np.dot(fa, self.weights))
-        sb = float(np.dot(fb, self.weights))
+        sa = float(np.dot(fa, self.direction))
+        sb = float(np.dot(fb, self.direction))
         if sa > sb + self.eps_obj:
             return -1
         elif sa < sb - self.eps_obj:

--- a/src/saealib/comparators.py
+++ b/src/saealib/comparators.py
@@ -426,12 +426,21 @@ class SingleObjectiveComparator(Comparator):
 
     def __init__(
         self,
-        weight: float = 1.0,
+        direction: float = 1.0,
         eps: float | None = None,
         *,
+        weight: float | None = None,
         eps_cv: float = 1e-6,
         eps_obj: float = 1e-6,
     ):
+        if weight is not None:
+            warnings.warn(
+                "SingleObjectiveComparator(weight=...) is deprecated"
+                " and will be removed in 0.1.0. Use direction=.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            direction = weight
         if eps is not None:
             warnings.warn(
                 "SingleObjectiveComparator(eps=...) is deprecated"
@@ -440,7 +449,7 @@ class SingleObjectiveComparator(Comparator):
                 stacklevel=2,
             )
             eps_cv = eps_obj = eps
-        super().__init__(np.array([weight]), eps_cv, eps_obj)
+        super().__init__(np.array([direction]), eps_cv, eps_obj, direction=np.array([direction]))
 
     def sort_population(self, population: Population) -> np.ndarray:
         """
@@ -510,7 +519,7 @@ class SingleObjectiveComparator(Comparator):
             Sorted indices of the solutions.
         """
         cv_key = np.where(cv > self.eps_cv, cv, 0)
-        obj_key = fitness.flatten() * self.weights[0]
+        obj_key = fitness.flatten() * self.direction[0]
         return np.lexsort((-obj_key, cv_key))
 
 

--- a/src/saealib/comparators.py
+++ b/src/saealib/comparators.py
@@ -449,7 +449,9 @@ class SingleObjectiveComparator(Comparator):
                 stacklevel=2,
             )
             eps_cv = eps_obj = eps
-        super().__init__(np.array([direction]), eps_cv, eps_obj, direction=np.array([direction]))
+        super().__init__(
+            np.array([direction]), eps_cv, eps_obj, direction=np.array([direction])
+        )
 
     def sort_population(self, population: Population) -> np.ndarray:
         """
@@ -560,7 +562,9 @@ class WeightedSumComparator(Comparator):
             )
             direction = weights
         if direction is None:
-            raise TypeError("WeightedSumComparator() missing required argument: 'direction'")
+            raise TypeError(
+                "WeightedSumComparator() missing required argument: 'direction'"
+            )
         if eps is not None:
             warnings.warn(
                 "WeightedSumComparator(eps=...) is deprecated"

--- a/src/saealib/optimizer.py
+++ b/src/saealib/optimizer.py
@@ -208,8 +208,6 @@ class Optimizer:
             )
 
         _dim = getattr(self.problem.comparator, "direction", None)
-        if _dim is None:
-            _dim = getattr(self.problem.comparator, "weights", None)
         if (
             _dim is not None
             and hasattr(_dim, "__len__")
@@ -217,7 +215,7 @@ class Optimizer:
             and len(_dim) != self.problem.n_obj
         ):
             issues.append(
-                f"comparator direction/weights length ({len(_dim)}) does not match "
+                f"comparator direction length ({len(_dim)}) does not match "
                 f"problem.n_obj ({self.problem.n_obj})"
             )
 

--- a/src/saealib/problem.py
+++ b/src/saealib/problem.py
@@ -641,7 +641,7 @@ class Problem:
             self.comparator = comparator
         elif n_obj == 1:
             self.comparator = SingleObjectiveComparator(
-                weight=direction[0], eps_cv=eps_cv, eps_obj=eps_obj
+                direction=direction[0], eps_cv=eps_cv, eps_obj=eps_obj
             )
         else:
             self.comparator = NSGA2Comparator(

--- a/tests/test_moo.py
+++ b/tests/test_moo.py
@@ -376,7 +376,7 @@ class TestWeightedSumComparator:
         # weights = [-1, -1] → score = -(f1+f2); lower sum → higher score
         f = np.array([[1.0, 1.0], [0.5, 0.5], [2.0, 2.0]])
         pop = _make_pop(f)
-        comp = WeightedSumComparator(weights=np.array([-1.0, -1.0]))
+        comp = WeightedSumComparator(direction=np.array([-1.0, -1.0]))
         order = comp.sort_population(pop)
         # sorted by weighted sum descending: idx=1 (sum=1), idx=0 (sum=2), idx=2 (sum=4)
         assert order[0] == 1
@@ -387,7 +387,7 @@ class TestWeightedSumComparator:
         f = np.array([[1.0, 1.0], [0.1, 0.1], [0.5, 0.5]])
         cv = np.array([0.0, 0.5, 0.0])  # idx=1 is infeasible
         pop = _make_pop(f, cv)
-        comp = WeightedSumComparator(weights=np.array([-1.0, -1.0]))
+        comp = WeightedSumComparator(direction=np.array([-1.0, -1.0]))
         order = comp.sort_population(pop)
         # idx=1 (infeasible) should appear last
         assert order[-1] == 1
@@ -395,21 +395,21 @@ class TestWeightedSumComparator:
     def test_compare_population_a_better(self) -> None:
         f = np.array([[0.5, 0.5], [1.0, 1.0]])
         pop = _make_pop(f)
-        comp = WeightedSumComparator(weights=np.array([-1.0, -1.0]))
+        comp = WeightedSumComparator(direction=np.array([-1.0, -1.0]))
         result = comp.compare_population(pop, 0, 1)
         assert result == -1  # a has lower sum → better
 
     def test_compare_population_b_better(self) -> None:
         f = np.array([[2.0, 2.0], [1.0, 1.0]])
         pop = _make_pop(f)
-        comp = WeightedSumComparator(weights=np.array([-1.0, -1.0]))
+        comp = WeightedSumComparator(direction=np.array([-1.0, -1.0]))
         result = comp.compare_population(pop, 0, 1)
         assert result == 1  # b has lower sum → better
 
     def test_compare_population_equal(self) -> None:
         f = np.array([[1.0, 1.0], [1.0, 1.0]])
         pop = _make_pop(f)
-        comp = WeightedSumComparator(weights=np.array([-1.0, -1.0]))
+        comp = WeightedSumComparator(direction=np.array([-1.0, -1.0]))
         result = comp.compare_population(pop, 0, 1)
         assert result == 0
 
@@ -418,7 +418,7 @@ class TestWeightedSumComparator:
         f = np.array([[100.0, 100.0], [0.0, 0.0]])
         cv = np.array([0.5, 0.0])  # idx=0 infeasible, idx=1 feasible
         pop = _make_pop(f, cv)
-        comp = WeightedSumComparator(weights=np.array([-1.0, -1.0]))
+        comp = WeightedSumComparator(direction=np.array([-1.0, -1.0]))
         result = comp.compare_population(pop, 0, 1)
         assert result == 1  # b (feasible) is better
 
@@ -426,7 +426,7 @@ class TestWeightedSumComparator:
         """WeightedSumComparator with n_obj=1 behaves like SingleObjectiveComparator."""
         f = np.array([[2.0], [1.0], [3.0]])
         pop = _make_pop(f)
-        comp = WeightedSumComparator(weights=np.array([-1.0]))
+        comp = WeightedSumComparator(direction=np.array([-1.0]))
         order = comp.sort_population(pop)
         # ascending order of f: idx=1(1.0), idx=0(2.0), idx=2(3.0)
         assert order[0] == 1
@@ -677,7 +677,7 @@ class TestProblemComparatorAutoSelection:
         assert isinstance(p.comparator, NSGA2Comparator)
 
     def test_custom_comparator_overrides_auto_selection(self) -> None:
-        custom = WeightedSumComparator(weights=np.array([-1.0, -1.0]))
+        custom = WeightedSumComparator(direction=np.array([-1.0, -1.0]))
         p = Problem(
             func=lambda x: np.array([np.sum(x**2), np.sum((x - 1) ** 2)]),
             dim=2,

--- a/tests/test_optimizer_validate.py
+++ b/tests/test_optimizer_validate.py
@@ -123,8 +123,8 @@ def test_strategy_requires_surrogate_present():
 
 def test_comparator_weight_mismatch():
     opt = _fully_configured()
-    opt.problem.comparator.weights = np.array([1.0, 1.0])  # len 2 != n_obj=1
-    assert any("weights" in m for m in opt.validate())
+    opt.problem.comparator.direction = np.array([1.0, 1.0])  # len 2 != n_obj=1
+    assert any("direction" in m for m in opt.validate())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pso.py
+++ b/tests/test_pso.py
@@ -52,7 +52,7 @@ def _make_problem() -> Problem:
         direction=np.array([-1.0]),
         lb=[-5.0] * DIM,
         ub=[5.0] * DIM,
-        comparator=SingleObjectiveComparator(weight=-1.0),
+        comparator=SingleObjectiveComparator(direction=-1.0),
     )
 
 


### PR DESCRIPTION
## Related Issue
Closes #126

## Overview
Rename `weight`/`weights` parameters to `direction` in `SingleObjectiveComparator` and `WeightedSumComparator`, with `DeprecationWarning` for old keyword arguments.

## Changes
- `comparators.py`: Rename params; replace internal `self.weights` with `self.direction`
- `problem.py`: `weight=direction[0]` → `direction=direction[0]`
- `optimizer.py`: Remove `weights` fallback in `validate()`; update error message
- `tests/`: Update call sites (`test_pso.py`, `test_moo.py`, `test_optimizer_validate.py`)

## Verification Steps
run pytest

## Concerns
- `WeightedSumComparator(weights=...)` as keyword arg now emits `DeprecationWarning`; positional usage (`WeightedSumComparator(np.array([...]))`) works unchanged via renamed `direction` param.
