### PR TITLE
refactor: [#128] Centralize deprecation management with utility decorators

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,67 @@ We adhere to strict coding standards to ensure maintainability.
 * **Type Hinting**: Type hints are strongly encouraged for all public APIs.
 * **Docstrings**: We follow the **NumPy style** docstrings.
 
-### 3. Testing Policy
+### 3. Deprecation Policy
+
+When renaming or removing a public API, add a backward-compatible fallback using the utilities in `src/saealib/_deprecated.py`. Always use `FutureWarning` (visible to users by default).
+
+#### Renamed keyword argument
+
+```python
+from saealib._deprecated import deprecated_param
+
+class MyComparator(Comparator):
+    @deprecated_param("old_name", "new_name", "0.2.0")
+    def __init__(self, new_name=None, ...):
+        ...
+```
+
+The decorator intercepts `old_name` from `**kwargs`, emits a `FutureWarning`, and forwards the value to `new_name`. Remove `old_name` from the signature entirely.
+
+#### One old argument mapping to multiple new arguments
+
+Use `warn_deprecated` inline when a single old parameter maps to more than one new parameter:
+
+```python
+from saealib._deprecated import warn_deprecated
+
+def __init__(self, ..., eps=None, *, eps_cv=1e-6, eps_obj=1e-6):
+    if eps is not None:
+        warn_deprecated("eps", "eps_cv and eps_obj", "0.2.0")
+        eps_cv = eps_obj = eps
+```
+
+#### Deprecated class alias
+
+```python
+from saealib._deprecated import deprecated_class
+
+@deprecated_class("NewClassName")
+class OldClassName(NewClassName):
+    """Deprecated alias of :class:`NewClassName`."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+```
+
+#### Testing
+
+Assert the warning category is `FutureWarning`:
+
+```python
+def test_old_name_warns():
+    with pytest.warns(FutureWarning):
+        MyComparator(old_name=1.0)
+```
+
+If a test class exercises a deprecated API without testing the warning itself, suppress it at the class level:
+
+```python
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+class TestLegacyBehavior:
+    ...
+```
+
+### 4. Testing Policy
 
 We use `pytest` for testing. Since this library involves stochastic evolutionary algorithms, we have a specific testing strategy to distinguish between "expected random variations" and "regressions."
 
@@ -78,7 +138,7 @@ If `test_integration` fails, check the following:
         4. Commit the updated snapshot file along with your code changes.
 
 
-### 4. Pull Request Guidelines
+### 5. Pull Request Guidelines
 
 1. Ensure all tests pass locally.
 2. If you updated the regression snapshots, please include a summary of the changes in the PR description:

--- a/src/saealib/_deprecated.py
+++ b/src/saealib/_deprecated.py
@@ -1,0 +1,57 @@
+"""Deprecation utilities for backward-compatible API changes."""
+
+from __future__ import annotations
+
+import functools
+import warnings
+from collections.abc import Callable
+from typing import TypeVar
+
+F = TypeVar("F", bound=Callable)
+
+
+def warn_deprecated(old: str, replacement: str, version: str, stacklevel: int = 2) -> None:
+    """Emit a FutureWarning for a deprecated name."""
+    warnings.warn(
+        f"'{old}' is deprecated and will be removed in {version}. "
+        f"Use {replacement!r} instead.",
+        FutureWarning,
+        stacklevel=stacklevel + 1,
+    )
+
+
+def deprecated_param(old: str, new: str, version: str) -> Callable[[F], F]:
+    """Decorator: transparently rename a kwarg with a FutureWarning."""
+
+    def decorator(func: F) -> F:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            if old in kwargs:
+                warn_deprecated(old, new, version, stacklevel=2)
+                kwargs.setdefault(new, kwargs.pop(old))
+            return func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def deprecated_class(replacement: str) -> Callable[[type], type]:
+    """Decorator: emit FutureWarning when a deprecated class is instantiated."""
+
+    def decorator(cls: type) -> type:
+        original_init = cls.__init__
+
+        @functools.wraps(original_init)
+        def new_init(self, *args, **kwargs):
+            warnings.warn(
+                f"{cls.__name__} is deprecated. Use {replacement} instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            original_init(self, *args, **kwargs)
+
+        cls.__init__ = new_init
+        return cls
+
+    return decorator

--- a/src/saealib/_deprecated.py
+++ b/src/saealib/_deprecated.py
@@ -10,7 +10,9 @@ from typing import TypeVar
 F = TypeVar("F", bound=Callable)
 
 
-def warn_deprecated(old: str, replacement: str, version: str, stacklevel: int = 2) -> None:
+def warn_deprecated(
+    old: str, replacement: str, version: str, stacklevel: int = 2
+) -> None:
     """Emit a FutureWarning for a deprecated name."""
     warnings.warn(
         f"'{old}' is deprecated and will be removed in {version}. "
@@ -21,7 +23,7 @@ def warn_deprecated(old: str, replacement: str, version: str, stacklevel: int = 
 
 
 def deprecated_param(old: str, new: str, version: str) -> Callable[[F], F]:
-    """Decorator: transparently rename a kwarg with a FutureWarning."""
+    """Transparently rename a kwarg with a FutureWarning."""
 
     def decorator(func: F) -> F:
         @functools.wraps(func)
@@ -37,7 +39,7 @@ def deprecated_param(old: str, new: str, version: str) -> Callable[[F], F]:
 
 
 def deprecated_class(replacement: str) -> Callable[[type], type]:
-    """Decorator: emit FutureWarning when a deprecated class is instantiated."""
+    """Emit FutureWarning when a deprecated class is instantiated."""
 
     def decorator(cls: type) -> type:
         original_init = cls.__init__

--- a/src/saealib/comparators.py
+++ b/src/saealib/comparators.py
@@ -7,9 +7,10 @@ for ranking and comparing solutions in single- and multi-objective optimization.
 
 from __future__ import annotations
 
-import warnings
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Protocol
+
+from saealib._deprecated import deprecated_param, warn_deprecated
 
 import numpy as np
 
@@ -345,12 +346,7 @@ class Comparator(ABC):
     @property
     def eps(self) -> float:
         """Deprecated. Use eps_cv or eps_obj."""
-        warnings.warn(
-            "Comparator.eps is deprecated and will be removed in 0.1.0. "
-            "Use eps_cv or eps_obj.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        warn_deprecated("Comparator.eps", "eps_cv or eps_obj", "0.1.0")
         return self.eps_cv
 
     @abstractmethod
@@ -424,30 +420,17 @@ class Comparator(ABC):
 class SingleObjectiveComparator(Comparator):
     """Comparator for single-objective optimization."""
 
+    @deprecated_param("weight", "direction", "0.1.0")
     def __init__(
         self,
         direction: float = 1.0,
         eps: float | None = None,
         *,
-        weight: float | None = None,
         eps_cv: float = 1e-6,
         eps_obj: float = 1e-6,
     ):
-        if weight is not None:
-            warnings.warn(
-                "SingleObjectiveComparator(weight=...) is deprecated"
-                " and will be removed in 0.1.0. Use direction=.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            direction = weight
         if eps is not None:
-            warnings.warn(
-                "SingleObjectiveComparator(eps=...) is deprecated"
-                " and will be removed in 0.1.0. Use eps_cv and eps_obj.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            warn_deprecated("eps", "eps_cv and eps_obj", "0.1.0")
             eps_cv = eps_obj = eps
         super().__init__(
             np.array([direction]), eps_cv, eps_obj, direction=np.array([direction])
@@ -544,34 +527,21 @@ class WeightedSumComparator(Comparator):
         Epsilon tolerance for constraint violation and fitness comparison.
     """
 
+    @deprecated_param("weights", "direction", "0.1.0")
     def __init__(
         self,
         direction: np.ndarray | None = None,
         eps: float | None = None,
         *,
-        weights: np.ndarray | None = None,
         eps_cv: float = 1e-6,
         eps_obj: float = 1e-6,
     ):
-        if weights is not None:
-            warnings.warn(
-                "WeightedSumComparator(weights=...) is deprecated"
-                " and will be removed in 0.1.0. Use direction=.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            direction = weights
         if direction is None:
             raise TypeError(
                 "WeightedSumComparator() missing required argument: 'direction'"
             )
         if eps is not None:
-            warnings.warn(
-                "WeightedSumComparator(eps=...) is deprecated"
-                " and will be removed in 0.1.0. Use eps_cv and eps_obj.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            warn_deprecated("eps", "eps_cv and eps_obj", "0.1.0")
             eps_cv = eps_obj = eps
         _dir = np.asarray(direction, dtype=float)
         super().__init__(_dir, eps_cv, eps_obj, direction=_dir)
@@ -1103,12 +1073,7 @@ class ParetoComparator(Comparator):
         dominator: Dominator | None = None,
     ):
         if eps is not None:
-            warnings.warn(
-                "ParetoComparator(eps=...) is deprecated and will be removed in 0.1.0. "
-                "Use eps_cv.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            warn_deprecated("eps", "eps_cv", "0.1.0")
             eps_cv = eps
         direction_arr = (
             np.asarray(direction, dtype=float) if direction is not None else None
@@ -1211,12 +1176,7 @@ class NSGA2Comparator(ParetoComparator):
         dominator: Dominator | None = None,
     ):
         if eps is not None:
-            warnings.warn(
-                "NSGA2Comparator(eps=...) is deprecated and will be removed in 0.1.0. "
-                "Use eps_cv.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            warn_deprecated("eps", "eps_cv", "0.1.0")
             eps_cv = eps
         super().__init__(
             direction,

--- a/src/saealib/comparators.py
+++ b/src/saealib/comparators.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Protocol
 
-from saealib._deprecated import deprecated_param, warn_deprecated
-
 import numpy as np
+
+from saealib._deprecated import deprecated_param, warn_deprecated
 
 if TYPE_CHECKING:
     from saealib.population import Population

--- a/src/saealib/problem.py
+++ b/src/saealib/problem.py
@@ -11,10 +11,9 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
-from saealib._deprecated import deprecated_class, warn_deprecated
-
 import numpy as np
 
+from saealib._deprecated import deprecated_class, warn_deprecated
 from saealib.comparators import (
     Comparator,
     NSGA2Comparator,

--- a/src/saealib/problem.py
+++ b/src/saealib/problem.py
@@ -7,10 +7,11 @@ Comparator classes and Pareto-related utilities are in saealib.comparators.
 
 from __future__ import annotations
 
-import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import TYPE_CHECKING
+
+from saealib._deprecated import deprecated_class, warn_deprecated
 
 import numpy as np
 
@@ -106,6 +107,7 @@ class InequalityConstraint:
         return None
 
 
+@deprecated_class("InequalityConstraint")
 class Constraint(InequalityConstraint):
     """
     Deprecated alias of :class:`InequalityConstraint`.
@@ -116,12 +118,6 @@ class Constraint(InequalityConstraint):
     """
 
     def __init__(self, func: callable, threshold: float = 0.0):
-        warnings.warn(
-            "Constraint is deprecated and will be removed in a future release. "
-            "Use InequalityConstraint instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         super().__init__(func, threshold)
 
 
@@ -614,12 +610,7 @@ class Problem:
             behavior.
         """
         if eps is not None:
-            warnings.warn(
-                "Problem(eps=...) is deprecated and will be removed in 0.1.0. "
-                "Use eps_cv and eps_obj.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            warn_deprecated("eps", "eps_cv and eps_obj", "0.1.0")
             eps_cv = eps_obj = eps
         direction = np.asarray(direction, dtype=float)
         if not np.all(np.abs(direction) == 1):
@@ -651,12 +642,7 @@ class Problem:
     @property
     def eps(self) -> float:
         """Deprecated. Use eps_cv or eps_obj."""
-        warnings.warn(
-            "Problem.eps is deprecated and will be removed in 0.1.0. "
-            "Use eps_cv or eps_obj.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        warn_deprecated("Problem.eps", "eps_cv or eps_obj", "0.1.0")
         return self.eps_cv
 
     @property

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -24,6 +24,7 @@ from saealib.problem import (
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 class TestConstraint:
     def test_evaluate_returns_func_value(self):
         c = Constraint(lambda x: x[0] ** 2 - 1.0)

--- a/tests/test_constraint_handler.py
+++ b/tests/test_constraint_handler.py
@@ -55,7 +55,7 @@ class TestInequalityConstraint:
         assert issubclass(Constraint, InequalityConstraint)
 
     def test_constraint_alias_warns(self):
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(FutureWarning):
             Constraint(lambda x: float(x[0]))
 
     def test_inequality_constraint_does_not_warn(self):

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -13,7 +13,7 @@ import numpy as np
 import pytest
 
 from saealib import EvaluationResult, Evaluator, Optimizer, SerialEvaluator
-from saealib.problem import Constraint, Problem
+from saealib.problem import InequalityConstraint, Problem
 
 
 def _sphere_problem(constraints=None):
@@ -33,7 +33,7 @@ class TestSerialEvaluator:
         assert issubclass(SerialEvaluator, Evaluator)
 
     def test_batch_shapes_with_constraints(self):
-        p = _sphere_problem(constraints=[Constraint(lambda x: x[0] - 1.0)])
+        p = _sphere_problem(constraints=[InequalityConstraint(lambda x: x[0] - 1.0)])
         x = np.array([[0.0, 0.0], [2.0, 0.0]])
         result = SerialEvaluator().evaluate_batch(x, p)
         assert isinstance(result, EvaluationResult)
@@ -42,7 +42,7 @@ class TestSerialEvaluator:
         assert result.cv.shape == (2,)
 
     def test_values_match_per_candidate(self):
-        p = _sphere_problem(constraints=[Constraint(lambda x: x[0] - 1.0)])
+        p = _sphere_problem(constraints=[InequalityConstraint(lambda x: x[0] - 1.0)])
         x = np.array([[0.0, 0.0], [2.0, 0.0], [-3.0, 1.0]])
         result = SerialEvaluator().evaluate_batch(x, p)
         for i, xi in enumerate(x):
@@ -52,7 +52,7 @@ class TestSerialEvaluator:
             assert result.cv[i] == pytest.approx(cv_i)
 
     def test_cv_aggregation(self):
-        p = _sphere_problem(constraints=[Constraint(lambda x: x[0] - 1.0)])
+        p = _sphere_problem(constraints=[InequalityConstraint(lambda x: x[0] - 1.0)])
         x = np.array([[0.0, 0.0], [2.0, 0.0]])
         result = SerialEvaluator().evaluate_batch(x, p)
         assert result.cv == pytest.approx([0.0, 1.0])


### PR DESCRIPTION
## Related Issue
Closes #128 

## Overview
Deprecated kwargs, properties, and class aliases are managed with repetitive inline `warnings.warn` blocks scattered across multiple files, making it hard to add new deprecations consistently. Also, all current usages use `DeprecationWarning`, which is suppressed by default outside `__main__`.

## Changes
- Add `src/saealib/_deprecated.py` with `warn_deprecated`, `deprecated_param`, and `deprecated_class` utilities
- Replace all inline `warnings.warn(DeprecationWarning)` blocks in `comparators.py` and `problem.py` with these utilities
- Unify warning category to `FutureWarning` (visible to users by default)
- Update tests

## Verification Steps
run pytest