### PR TITLE
refactor: [#130] Rename GPSurrogate to GPRSurrogate (explicit Regressor distinction)

### DIFF
--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -138,7 +138,7 @@ from saealib.surrogate.prediction import SurrogatePrediction
 from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
 from saealib.surrogate.sklearn_surrogate import (
     DTSurrogate,
-    GPSurrogate,
+    GPRSurrogate,
     LGBMSurrogate,
     NNSurrogate,
     SklearnSurrogate,
@@ -191,7 +191,7 @@ __all__ = [
     "Evaluator",
     "Event",
     "ExpectedImprovement",
-    "GPSurrogate",
+    "GPRSurrogate",
     "GenerationBasedStrategy",
     "GenerationEndEvent",
     "GenerationStartEvent",
@@ -289,3 +289,11 @@ __all__ = [
     "stalled",
     "uniform_weight_vectors",
 ]
+
+
+def __getattr__(name: str) -> object:
+    if name == "GPSurrogate":
+        from saealib.surrogate._deprecated import GPSurrogate
+
+        return GPSurrogate
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/saealib/surrogate/__init__.py
+++ b/src/saealib/surrogate/__init__.py
@@ -1,0 +1,6 @@
+def __getattr__(name: str) -> object:
+    if name == "GPSurrogate":
+        from saealib.surrogate._deprecated import GPSurrogate
+
+        return GPSurrogate
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/saealib/surrogate/_deprecated.py
+++ b/src/saealib/surrogate/_deprecated.py
@@ -1,0 +1,9 @@
+"""Deprecated surrogate aliases."""
+
+from saealib._deprecated import deprecated_class
+from saealib.surrogate.sklearn_surrogate import GPRSurrogate as _GPRSurrogate
+
+
+@deprecated_class("GPRSurrogate")
+class GPSurrogate(_GPRSurrogate):
+    pass

--- a/src/saealib/surrogate/sklearn_surrogate.py
+++ b/src/saealib/surrogate/sklearn_surrogate.py
@@ -146,7 +146,7 @@ class DTSurrogate(SklearnSurrogate):
         super().__init__(RandomForestRegressor(**kwargs))
 
 
-class GPSurrogate(SklearnSurrogate):
+class GPRSurrogate(SklearnSurrogate):
     """
     Gaussian Process Regressor surrogate.
 

--- a/tests/test_constraint_surrogate.py
+++ b/tests/test_constraint_surrogate.py
@@ -16,7 +16,7 @@ from saealib import (
     CrossoverBLXAlpha,
     ExpectedImprovement,
     GlobalSurrogateManager,
-    GPSurrogate,
+    GPRSurrogate,
     InequalityConstraint,
     LHSInitializer,
     MutationUniform,
@@ -94,12 +94,12 @@ class TestConstraintSurrogateG01:
         problem = _make_g01_problem()
 
         ei_mgr = GlobalSurrogateManager(
-            GPSurrogate(),
+            GPRSurrogate(),
             ExpectedImprovement(),
             training_set=ArchiveObjectiveSet(),
         )
         pof_mgr = GlobalSurrogateManager(
-            PerObjectiveSurrogate([GPSurrogate() for _ in range(_N_CONSTRAINTS)]),
+            PerObjectiveSurrogate([GPRSurrogate() for _ in range(_N_CONSTRAINTS)]),
             ProductOfFeasibility(),
             training_set=ConstraintObjectiveSet(),
         )
@@ -132,7 +132,7 @@ class TestConstraintSurrogateG01:
             .set_algorithm(_make_ga())
             .set_strategy(PreSelectionStrategy(n_candidates=20, n_select=3))
             .set_surrogate_manager(
-                GlobalSurrogateManager(GPSurrogate(), ExpectedImprovement())
+                GlobalSurrogateManager(GPRSurrogate(), ExpectedImprovement())
             )
             .set_termination(Termination(max_fe(15)))
         )
@@ -155,12 +155,12 @@ class TestConstraintSurrogateG01:
         problem = _make_g01_problem()
 
         ei_mgr = GlobalSurrogateManager(
-            GPSurrogate(),
+            GPRSurrogate(),
             ExpectedImprovement(),
             training_set=ArchiveObjectiveSet(),
         )
         pof_mgr = GlobalSurrogateManager(
-            PerObjectiveSurrogate([GPSurrogate() for _ in range(_N_CONSTRAINTS)]),
+            PerObjectiveSurrogate([GPRSurrogate() for _ in range(_N_CONSTRAINTS)]),
             ProductOfFeasibility(),
             training_set=ConstraintObjectiveSet(),
         )
@@ -233,7 +233,7 @@ class TestConstraintSurrogate2D:
             .set_algorithm(_make_ga())
             .set_strategy(PreSelectionStrategy(n_candidates=20, n_select=3))
             .set_surrogate_manager(
-                GlobalSurrogateManager(GPSurrogate(), ExpectedImprovement())
+                GlobalSurrogateManager(GPRSurrogate(), ExpectedImprovement())
             )
             .set_termination(Termination(max_fe(50)))
         )
@@ -241,7 +241,7 @@ class TestConstraintSurrogate2D:
         archive = ctx.archive
 
         pof_mgr = GlobalSurrogateManager(
-            PerObjectiveSurrogate([GPSurrogate()]),
+            PerObjectiveSurrogate([GPRSurrogate()]),
             ProductOfFeasibility(),
             training_set=ConstraintObjectiveSet(),
         )
@@ -305,7 +305,7 @@ class TestConstraintSurrogateBackwardCompat:
             .set_algorithm(_make_ga())
             .set_strategy(PreSelectionStrategy(n_candidates=10, n_select=2))
             .set_surrogate_manager(
-                GlobalSurrogateManager(GPSurrogate(), ExpectedImprovement())
+                GlobalSurrogateManager(GPRSurrogate(), ExpectedImprovement())
             )
             .set_termination(Termination(max_fe(20)))
         )

--- a/tests/test_gp_surrogate.py
+++ b/tests/test_gp_surrogate.py
@@ -1,8 +1,8 @@
 """
-Tests for GPSurrogate.
+Tests for GPRSurrogate.
 
 Covers:
-- GPSurrogate: fit/predict, single/multi-objective, std population
+- GPRSurrogate: fit/predict, single/multi-objective, std population
 - provides_uncertainty flag
 - Custom kernel
 - Integration with EI, LCB, MaxUncertainty, PoF acquisition functions
@@ -21,7 +21,7 @@ from saealib.acquisition import (
 from saealib.population import Archive, PopulationAttribute
 from saealib.surrogate.manager import GlobalSurrogateManager
 from saealib.surrogate.prediction import SurrogatePrediction
-from saealib.surrogate.sklearn_surrogate import GPSurrogate
+from saealib.surrogate.sklearn_surrogate import GPRSurrogate
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -55,7 +55,7 @@ def test_x():
 @pytest.fixture
 def fitted_gp(train_data_1obj):
     X, y = train_data_1obj
-    gp = GPSurrogate()
+    gp = GPRSurrogate()
     gp.fit(X, y)
     return gp
 
@@ -82,12 +82,12 @@ def candidates():
 
 
 # ===========================================================================
-# GPSurrogate Tests
+# GPRSurrogate Tests
 # ===========================================================================
-class TestGPSurrogate:
+class TestGPRSurrogate:
     def test_fit_predict_1obj(self, train_data_1obj, test_x) -> None:
         X, y = train_data_1obj
-        gp = GPSurrogate()
+        gp = GPRSurrogate()
         gp.fit(X, y)
         pred = gp.predict(test_x)
         assert isinstance(pred, SurrogatePrediction)
@@ -95,7 +95,7 @@ class TestGPSurrogate:
 
     def test_fit_predict_2obj(self, train_data_2obj, test_x) -> None:
         X, y = train_data_2obj
-        gp = GPSurrogate()
+        gp = GPRSurrogate()
         gp.fit(X, y)
         pred = gp.predict(test_x)
         assert pred.value.shape == (5, 2)
@@ -115,7 +115,7 @@ class TestGPSurrogate:
 
     def test_std_shape_2obj(self, train_data_2obj, test_x) -> None:
         X, y = train_data_2obj
-        gp = GPSurrogate()
+        gp = GPRSurrogate()
         gp.fit(X, y)
         pred = gp.predict(test_x)
         assert pred.std.shape == (5, 2)
@@ -125,7 +125,7 @@ class TestGPSurrogate:
         assert np.all(pred.std >= 0.0)
 
     def test_provides_uncertainty_class_attribute(self) -> None:
-        assert GPSurrogate.provides_uncertainty is True
+        assert GPRSurrogate.provides_uncertainty is True
 
     def test_has_uncertainty_true(self, fitted_gp, test_x) -> None:
         pred = fitted_gp.predict(test_x)
@@ -135,7 +135,7 @@ class TestGPSurrogate:
         from sklearn.gaussian_process.kernels import Matern
 
         X, y = train_data_1obj
-        gp = GPSurrogate(kernel=Matern(nu=2.5))
+        gp = GPRSurrogate(kernel=Matern(nu=2.5))
         gp.fit(X, y)
         pred = gp.predict(test_x)
         assert pred.value.shape == (5, 1)
@@ -146,7 +146,7 @@ class TestGPSurrogate:
     ) -> None:
         X1, y1 = train_data_1obj
         X2, y2 = train_data_2obj
-        gp = GPSurrogate()
+        gp = GPRSurrogate()
         gp.fit(X1, y1)
         gp.fit(X2, y2)
         pred = gp.predict(test_x)
@@ -155,15 +155,15 @@ class TestGPSurrogate:
 
     def test_models_are_cloned_per_objective(self, train_data_2obj) -> None:
         X, y = train_data_2obj
-        gp = GPSurrogate()
+        gp = GPRSurrogate()
         gp.fit(X, y)
         assert gp._models[0] is not gp._models[1]
 
 
 # ===========================================================================
-# GPSurrogate + Acquisition Function Integration Tests
+# GPRSurrogate + Acquisition Function Integration Tests
 # ===========================================================================
-class TestGPSurrogateWithAcquisition:
+class TestGPRSurrogateWithAcquisition:
     def test_ei_integration(self, fitted_gp, test_x) -> None:
         pred = fitted_gp.predict(test_x)
         scores = ExpectedImprovement().score(pred, reference=1.0)
@@ -192,9 +192,9 @@ class TestGPSurrogateWithAcquisition:
 # ===========================================================================
 # Integration: GlobalSurrogateManager
 # ===========================================================================
-class TestGPSurrogateManager:
+class TestGPRSurrogateManager:
     def test_global_manager_ei(self, archive_1obj, candidates) -> None:
-        manager = GlobalSurrogateManager(GPSurrogate(), ExpectedImprovement())
+        manager = GlobalSurrogateManager(GPRSurrogate(), ExpectedImprovement())
         scores, preds = manager.score_candidates(candidates, archive_1obj)
         assert scores.shape == (len(candidates),)
         assert np.all(scores >= 0.0)
@@ -203,11 +203,11 @@ class TestGPSurrogateManager:
             assert p.std is not None
 
     def test_global_manager_lcb(self, archive_1obj, candidates) -> None:
-        manager = GlobalSurrogateManager(GPSurrogate(), LowerConfidenceBound())
+        manager = GlobalSurrogateManager(GPRSurrogate(), LowerConfidenceBound())
         scores, _ = manager.score_candidates(candidates, archive_1obj)
         assert scores.shape == (len(candidates),)
 
     def test_global_manager_max_uncertainty(self, archive_1obj, candidates) -> None:
-        manager = GlobalSurrogateManager(GPSurrogate(), MaxUncertainty())
+        manager = GlobalSurrogateManager(GPRSurrogate(), MaxUncertainty())
         scores, _ = manager.score_candidates(candidates, archive_1obj)
         assert scores.shape == (len(candidates),)


### PR DESCRIPTION
## Related Issue
Closes #130

## Overview
Rename `GPSurrogate` → `GPRSurrogate` to make the Regressor role explicit and avoid future naming collisions with other GP variants (e.g. GPC, variational GP). A deprecated alias is provided via `surrogate/_deprecated.py` using the existing `deprecated_class` decorator, emitting `FutureWarning` on instantiation. The alias will be removed at v0.1.0.

## Changes
- Rename `class GPSurrogate` → `class GPRSurrogate` in `surrogate/sklearn_surrogate.py`
- Add `src/saealib/surrogate/_deprecated.py` with `GPSurrogate` alias (`@deprecated_class("GPRSurrogate")`)
- Add `__getattr__` to `src/saealib/surrogate/__init__.py` for lazy alias resolution
- Update `src/saealib/__init__.py`: import, `__all__`, and `__getattr__` alias
- Update `tests/test_gp_surrogate.py` and `tests/test_constraint_surrogate.py`

## Verification Steps
run pytest

## Concerns
- **Breaking change**: `GPSurrogate` import still works but emits `FutureWarning`. Will be removed at v0.1.0 (to be noted in CHANGELOG at release).

## Other