### PR TITLE
refactor: [#137] Restrict callbacks to observation-only and introduce component lifecycle hooks

### DIFF
--- a/src/saealib/algorithms/ga.py
+++ b/src/saealib/algorithms/ga.py
@@ -126,6 +126,7 @@ class GA(Algorithm):
                 c = self.crossover.crossover(parent, rng=ctx.rng)
             else:
                 c = parent[:n_children].copy()
+            c = self.crossover.post_crossover(c, parent, ctx.rng, ctx)
             cand[i * n_children : (i + 1) * n_children] = c
         for i in range(len(cand)):
             cand[i] = handler.repair(cand[i], constraints, lb, ub)
@@ -134,6 +135,7 @@ class GA(Algorithm):
         cand_len = len(cand)
         for i in range(cand_len):
             cand[i] = self.mutation.mutate(cand[i], (lb, ub), rng=ctx.rng)
+            cand[i] = self.mutation.post_mutation(cand[i], (lb, ub), ctx.rng, ctx)
             cand[i] = handler.repair(cand[i], constraints, lb, ub)
         provider.dispatch(PostMutationEvent(ctx=ctx, candidates=cand))
 

--- a/src/saealib/algorithms/ga.py
+++ b/src/saealib/algorithms/ga.py
@@ -129,21 +129,15 @@ class GA(Algorithm):
             cand[i * n_children : (i + 1) * n_children] = c
         for i in range(len(cand)):
             cand[i] = handler.repair(cand[i], constraints, lb, ub)
-        post_co = PostCrossoverEvent(ctx=ctx, provider=provider, candidates=cand)
-        provider.dispatch(post_co)
-        cand = post_co.candidates
+        provider.dispatch(PostCrossoverEvent(ctx=ctx, candidates=cand))
 
         cand_len = len(cand)
         for i in range(cand_len):
             cand[i] = self.mutation.mutate(cand[i], (lb, ub), rng=ctx.rng)
             cand[i] = handler.repair(cand[i], constraints, lb, ub)
-        post_mut = PostMutationEvent(ctx=ctx, provider=provider, candidates=cand)
-        provider.dispatch(post_mut)
-        cand = post_mut.candidates
+        provider.dispatch(PostMutationEvent(ctx=ctx, candidates=cand))
 
-        post_ask = PostAskEvent(ctx=ctx, provider=provider, candidates=cand)
-        provider.dispatch(post_ask)
-        cand = post_ask.candidates
+        provider.dispatch(PostAskEvent(ctx=ctx, candidates=cand))
 
         cand_pop = ctx.population.empty_like(capacity=target)
         cand_pop.extend({"x": cand[:target]})

--- a/src/saealib/algorithms/pso.py
+++ b/src/saealib/algorithms/pso.py
@@ -180,8 +180,7 @@ class PSO(Algorithm):
             }
         )
 
-        post_ask = PostAskEvent(ctx=ctx, provider=provider, candidates=x_new)
-        provider.dispatch(post_ask)
+        provider.dispatch(PostAskEvent(ctx=ctx, candidates=x_new))
 
         return cand_pop
 

--- a/src/saealib/callback/events.py
+++ b/src/saealib/callback/events.py
@@ -9,7 +9,6 @@ import numpy as np
 
 if TYPE_CHECKING:
     from saealib.context import OptimizationContext
-    from saealib.optimizer import ComponentProvider
     from saealib.population import Population
     from saealib.surrogate.base import Surrogate
 
@@ -22,13 +21,11 @@ class Event:
     Attributes
     ----------
     ctx : OptimizationContext
-        The current optimization context.
-    provider : ComponentProvider
-        The component provider (e.g. Optimizer) that fired this event.
+        The current optimization context. Read-only by convention; handlers
+        should not mutate ctx. Use component lifecycle hooks for mutation.
     """
 
     ctx: OptimizationContext
-    provider: ComponentProvider
 
 
 # --- Optimizer.run events ---

--- a/src/saealib/execution/runner.py
+++ b/src/saealib/execution/runner.py
@@ -48,16 +48,16 @@ class Runner:
         ctx = opt.initializer.initialize(opt, opt.problem)
         ctx.comparator.eps_cv = ctx.problem.handler.feasibility_threshold
 
-        opt.dispatch(RunStartEvent(ctx=ctx, provider=opt))
+        opt.dispatch(RunStartEvent(ctx=ctx))
         yield ctx
 
         while not opt.termination.is_terminated(ctx):
-            opt.dispatch(GenerationStartEvent(ctx=ctx, provider=opt))
+            opt.dispatch(GenerationStartEvent(ctx=ctx))
             opt.strategy.step(ctx, opt)
             handler = ctx.problem.handler
             handler.on_generation_end(ctx.gen, ctx.population)
             ctx.comparator.eps_cv = handler.feasibility_threshold
-            opt.dispatch(GenerationEndEvent(ctx=ctx, provider=opt))
+            opt.dispatch(GenerationEndEvent(ctx=ctx))
             yield ctx
 
-        opt.dispatch(RunEndEvent(ctx=ctx, provider=opt))
+        opt.dispatch(RunEndEvent(ctx=ctx))

--- a/src/saealib/operators/crossover.py
+++ b/src/saealib/operators/crossover.py
@@ -1,8 +1,16 @@
 """Crossover operators for evolutionary algorithms."""
 
+from __future__ import annotations
+
+import copy
 from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from saealib.context import OptimizationContext
 
 
 class Crossover(ABC):
@@ -43,6 +51,59 @@ class Crossover(ABC):
             Offspring individuals. shape = (n_offspring, dim)
         """
         pass
+
+    def post_crossover(
+        self,
+        offspring: np.ndarray,
+        parents: np.ndarray,
+        rng: np.random.Generator,
+        ctx: OptimizationContext | None = None,
+    ) -> np.ndarray:
+        """Post-crossover lifecycle hook; override to inject custom processing.
+
+        Parameters
+        ----------
+        offspring : np.ndarray
+            Offspring produced by crossover. shape = (n_children, dim)
+        parents : np.ndarray
+            Parent individuals. shape = (n_parents, dim)
+        rng : np.random.Generator
+            Random number generator.
+        ctx : OptimizationContext or None, optional
+            Current optimization context.
+
+        Returns
+        -------
+        np.ndarray
+            Processed offspring. shape = (n_children, dim)
+        """
+        return offspring
+
+    def with_post(
+        self,
+        fn: Callable[
+            [np.ndarray, np.ndarray, np.random.Generator, OptimizationContext | None],
+            np.ndarray,
+        ],
+    ) -> Crossover:
+        """Return a copy of this operator with ``fn`` appended to the hook.
+
+        Parameters
+        ----------
+        fn : callable
+            ``fn(offspring, parents, rng, ctx) -> np.ndarray``
+
+        Returns
+        -------
+        Crossover
+            Shallow copy with the hook registered.
+        """
+        new = copy.copy(self)
+        prev = self.post_crossover
+        new.post_crossover = lambda offspring, parents, rng, ctx=None: fn(
+            prev(offspring, parents, rng, ctx), parents, rng, ctx
+        )
+        return new
 
 
 class CrossoverBLXAlpha(Crossover):

--- a/src/saealib/operators/mutation.py
+++ b/src/saealib/operators/mutation.py
@@ -1,8 +1,16 @@
 """Mutation operators for evolutionary algorithms."""
 
+from __future__ import annotations
+
+import copy
 from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from saealib.context import OptimizationContext
 
 
 class Mutation(ABC):
@@ -33,6 +41,59 @@ class Mutation(ABC):
             Mutated individual. shape = (dim,)
         """
         pass
+
+    def post_mutation(
+        self,
+        offspring: np.ndarray,
+        mutate_range: tuple,
+        rng: np.random.Generator,
+        ctx: OptimizationContext | None = None,
+    ) -> np.ndarray:
+        """Post-mutation lifecycle hook; override to inject custom processing.
+
+        Parameters
+        ----------
+        offspring : np.ndarray
+            Individual after mutation. shape = (dim,)
+        mutate_range : tuple
+            Tuple of (lower_bound, upper_bound) used for mutation.
+        rng : np.random.Generator
+            Random number generator.
+        ctx : OptimizationContext or None, optional
+            Current optimization context.
+
+        Returns
+        -------
+        np.ndarray
+            Processed individual. shape = (dim,)
+        """
+        return offspring
+
+    def with_post(
+        self,
+        fn: Callable[
+            [np.ndarray, tuple, np.random.Generator, OptimizationContext | None],
+            np.ndarray,
+        ],
+    ) -> Mutation:
+        """Return a copy of this operator with ``fn`` appended to the hook.
+
+        Parameters
+        ----------
+        fn : callable
+            ``fn(offspring, mutate_range, rng, ctx) -> np.ndarray``
+
+        Returns
+        -------
+        Mutation
+            Shallow copy with the hook registered.
+        """
+        new = copy.copy(self)
+        prev = self.post_mutation
+        new.post_mutation = lambda offspring, mutate_range, rng, ctx=None: fn(
+            prev(offspring, mutate_range, rng, ctx), mutate_range, rng, ctx
+        )
+        return new
 
 
 class MutationUniform(Mutation):

--- a/src/saealib/strategies/gb.py
+++ b/src/saealib/strategies/gb.py
@@ -44,9 +44,7 @@ class GenerationBasedStrategy(OptimizationStrategy):
             ctx.count_generation()
             offspring = provider.algorithm.ask(ctx, provider)
 
-            provider.dispatch(
-                SurrogateStartEvent(ctx=ctx, offspring=offspring)
-            )
+            provider.dispatch(SurrogateStartEvent(ctx=ctx, offspring=offspring))
 
             _, predictions = provider.surrogate_manager.score_candidates(
                 offspring.x, ctx.archive, ctx
@@ -54,9 +52,7 @@ class GenerationBasedStrategy(OptimizationStrategy):
             for i, pred in enumerate(predictions):
                 assign_tell_f(offspring[i], pred, ctx)
 
-            provider.dispatch(
-                SurrogateEndEvent(ctx=ctx, offspring=offspring)
-            )
+            provider.dispatch(SurrogateEndEvent(ctx=ctx, offspring=offspring))
 
             provider.algorithm.tell(ctx, provider, offspring)
 
@@ -77,8 +73,6 @@ class GenerationBasedStrategy(OptimizationStrategy):
             )
         ctx.count_fe(n_offspring)
 
-        provider.dispatch(
-            PostEvaluationEvent(ctx=ctx, offspring=offspring)
-        )
+        provider.dispatch(PostEvaluationEvent(ctx=ctx, offspring=offspring))
 
         provider.algorithm.tell(ctx, provider, offspring)

--- a/src/saealib/strategies/gb.py
+++ b/src/saealib/strategies/gb.py
@@ -45,7 +45,7 @@ class GenerationBasedStrategy(OptimizationStrategy):
             offspring = provider.algorithm.ask(ctx, provider)
 
             provider.dispatch(
-                SurrogateStartEvent(ctx=ctx, provider=provider, offspring=offspring)
+                SurrogateStartEvent(ctx=ctx, offspring=offspring)
             )
 
             _, predictions = provider.surrogate_manager.score_candidates(
@@ -55,7 +55,7 @@ class GenerationBasedStrategy(OptimizationStrategy):
                 assign_tell_f(offspring[i], pred, ctx)
 
             provider.dispatch(
-                SurrogateEndEvent(ctx=ctx, provider=provider, offspring=offspring)
+                SurrogateEndEvent(ctx=ctx, offspring=offspring)
             )
 
             provider.algorithm.tell(ctx, provider, offspring)
@@ -78,7 +78,7 @@ class GenerationBasedStrategy(OptimizationStrategy):
         ctx.count_fe(n_offspring)
 
         provider.dispatch(
-            PostEvaluationEvent(ctx=ctx, provider=provider, offspring=offspring)
+            PostEvaluationEvent(ctx=ctx, offspring=offspring)
         )
 
         provider.algorithm.tell(ctx, provider, offspring)

--- a/src/saealib/strategies/gb.py
+++ b/src/saealib/strategies/gb.py
@@ -49,7 +49,7 @@ class GenerationBasedStrategy(OptimizationStrategy):
             )
 
             _, predictions = provider.surrogate_manager.score_candidates(
-                offspring.x, ctx.archive, provider, ctx
+                offspring.x, ctx.archive, ctx
             )
             for i, pred in enumerate(predictions):
                 assign_tell_f(offspring[i], pred, ctx)

--- a/src/saealib/strategies/ib.py
+++ b/src/saealib/strategies/ib.py
@@ -52,9 +52,7 @@ class IndividualBasedStrategy(OptimizationStrategy):
         n_offspring = len(offspring)
         n_eval = max(1, int(self.evaluation_ratio * n_offspring))
 
-        provider.dispatch(
-            SurrogateStartEvent(ctx=ctx, offspring=offspring)
-        )
+        provider.dispatch(SurrogateStartEvent(ctx=ctx, offspring=offspring))
 
         # 2. score candidates via surrogate manager
         scores, predictions = provider.surrogate_manager.score_candidates(
@@ -63,9 +61,7 @@ class IndividualBasedStrategy(OptimizationStrategy):
         for i, pred in enumerate(predictions):
             assign_tell_f(offspring[i], pred, ctx)
 
-        provider.dispatch(
-            SurrogateEndEvent(ctx=ctx, offspring=offspring)
-        )
+        provider.dispatch(SurrogateEndEvent(ctx=ctx, offspring=offspring))
 
         # 3. top-k selection and true evaluation
         idx = np.argsort(-scores)
@@ -84,9 +80,7 @@ class IndividualBasedStrategy(OptimizationStrategy):
         ctx.count_fe(n_eval)
 
         evaluated = offspring.extract(list(range(n_eval)))
-        provider.dispatch(
-            PostEvaluationEvent(ctx=ctx, offspring=evaluated)
-        )
+        provider.dispatch(PostEvaluationEvent(ctx=ctx, offspring=evaluated))
 
         # 4. update algorithm with offspring (algorithm.tell)
         provider.algorithm.tell(ctx, provider, offspring)

--- a/src/saealib/strategies/ib.py
+++ b/src/saealib/strategies/ib.py
@@ -58,7 +58,7 @@ class IndividualBasedStrategy(OptimizationStrategy):
 
         # 2. score candidates via surrogate manager
         scores, predictions = provider.surrogate_manager.score_candidates(
-            offspring.x, ctx.archive, provider, ctx
+            offspring.x, ctx.archive, ctx
         )
         for i, pred in enumerate(predictions):
             assign_tell_f(offspring[i], pred, ctx)

--- a/src/saealib/strategies/ib.py
+++ b/src/saealib/strategies/ib.py
@@ -53,7 +53,7 @@ class IndividualBasedStrategy(OptimizationStrategy):
         n_eval = max(1, int(self.evaluation_ratio * n_offspring))
 
         provider.dispatch(
-            SurrogateStartEvent(ctx=ctx, provider=provider, offspring=offspring)
+            SurrogateStartEvent(ctx=ctx, offspring=offspring)
         )
 
         # 2. score candidates via surrogate manager
@@ -64,7 +64,7 @@ class IndividualBasedStrategy(OptimizationStrategy):
             assign_tell_f(offspring[i], pred, ctx)
 
         provider.dispatch(
-            SurrogateEndEvent(ctx=ctx, provider=provider, offspring=offspring)
+            SurrogateEndEvent(ctx=ctx, offspring=offspring)
         )
 
         # 3. top-k selection and true evaluation
@@ -85,7 +85,7 @@ class IndividualBasedStrategy(OptimizationStrategy):
 
         evaluated = offspring.extract(list(range(n_eval)))
         provider.dispatch(
-            PostEvaluationEvent(ctx=ctx, provider=provider, offspring=evaluated)
+            PostEvaluationEvent(ctx=ctx, offspring=evaluated)
         )
 
         # 4. update algorithm with offspring (algorithm.tell)

--- a/src/saealib/strategies/ps.py
+++ b/src/saealib/strategies/ps.py
@@ -51,7 +51,7 @@ class PreSelectionStrategy(OptimizationStrategy):
         )
 
         provider.dispatch(
-            SurrogateStartEvent(ctx=ctx, provider=provider, offspring=candidates)
+            SurrogateStartEvent(ctx=ctx, offspring=candidates)
         )
 
         scores, predictions = provider.surrogate_manager.score_candidates(
@@ -61,7 +61,7 @@ class PreSelectionStrategy(OptimizationStrategy):
             assign_tell_f(candidates[i], pred, ctx)
 
         provider.dispatch(
-            SurrogateEndEvent(ctx=ctx, provider=provider, offspring=candidates)
+            SurrogateEndEvent(ctx=ctx, offspring=candidates)
         )
 
         idx = np.argsort(-scores)
@@ -82,7 +82,7 @@ class PreSelectionStrategy(OptimizationStrategy):
 
         evaluated = candidates.extract(list(range(n_eval)))
         provider.dispatch(
-            PostEvaluationEvent(ctx=ctx, provider=provider, offspring=evaluated)
+            PostEvaluationEvent(ctx=ctx, offspring=evaluated)
         )
 
         provider.algorithm.tell(ctx, provider, candidates)

--- a/src/saealib/strategies/ps.py
+++ b/src/saealib/strategies/ps.py
@@ -50,9 +50,7 @@ class PreSelectionStrategy(OptimizationStrategy):
             ctx, provider, n_offspring=self.n_candidates
         )
 
-        provider.dispatch(
-            SurrogateStartEvent(ctx=ctx, offspring=candidates)
-        )
+        provider.dispatch(SurrogateStartEvent(ctx=ctx, offspring=candidates))
 
         scores, predictions = provider.surrogate_manager.score_candidates(
             candidates.x, ctx.archive, ctx
@@ -60,9 +58,7 @@ class PreSelectionStrategy(OptimizationStrategy):
         for i, pred in enumerate(predictions):
             assign_tell_f(candidates[i], pred, ctx)
 
-        provider.dispatch(
-            SurrogateEndEvent(ctx=ctx, offspring=candidates)
-        )
+        provider.dispatch(SurrogateEndEvent(ctx=ctx, offspring=candidates))
 
         idx = np.argsort(-scores)
         candidates = candidates.extract(idx)
@@ -81,8 +77,6 @@ class PreSelectionStrategy(OptimizationStrategy):
         ctx.count_fe(n_eval)
 
         evaluated = candidates.extract(list(range(n_eval)))
-        provider.dispatch(
-            PostEvaluationEvent(ctx=ctx, offspring=evaluated)
-        )
+        provider.dispatch(PostEvaluationEvent(ctx=ctx, offspring=evaluated))
 
         provider.algorithm.tell(ctx, provider, candidates)

--- a/src/saealib/strategies/ps.py
+++ b/src/saealib/strategies/ps.py
@@ -55,7 +55,7 @@ class PreSelectionStrategy(OptimizationStrategy):
         )
 
         scores, predictions = provider.surrogate_manager.score_candidates(
-            candidates.x, ctx.archive, provider, ctx
+            candidates.x, ctx.archive, ctx
         )
         for i, pred in enumerate(predictions):
             assign_tell_f(candidates[i], pred, ctx)

--- a/src/saealib/surrogate/archive_manager.py
+++ b/src/saealib/surrogate/archive_manager.py
@@ -16,7 +16,6 @@ from saealib.surrogate.prediction import SurrogatePrediction
 
 if TYPE_CHECKING:
     from saealib.context import OptimizationContext
-    from saealib.optimizer import ComponentProvider
     from saealib.population import Archive
 
 
@@ -55,7 +54,6 @@ class ArchiveBasedManager(SurrogateManager):
         self,
         candidates_x: np.ndarray,
         archive: Archive,
-        provider: ComponentProvider | None = None,
         ctx: OptimizationContext | None = None,
     ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
         """Compute scores and wrap results in SurrogatePrediction with tell_f=NaN."""

--- a/src/saealib/surrogate/base.py
+++ b/src/saealib/surrogate/base.py
@@ -1,10 +1,18 @@
 """Abstract base class for surrogate models."""
 
+from __future__ import annotations
+
+import copy
 from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 import numpy as np
 
 from saealib.surrogate.prediction import SurrogatePrediction
+
+if TYPE_CHECKING:
+    from saealib.context import OptimizationContext
 
 
 class Surrogate(ABC):
@@ -49,3 +57,47 @@ class Surrogate(ABC):
             prediction.std  shape: (n_samples, n_obj) or None
         """
         pass
+
+    def post_fit(
+        self,
+        train_x: np.ndarray,
+        train_y: np.ndarray,
+        ctx: OptimizationContext | None = None,
+    ) -> None:
+        """Post-fit lifecycle hook; override to inject custom processing.
+
+        Parameters
+        ----------
+        train_x : np.ndarray
+            Training input data used for this fit. shape: (n_samples, n_features)
+        train_y : np.ndarray
+            Training output data used for this fit. shape: (n_samples, n_obj)
+        ctx : OptimizationContext or None, optional
+            Current optimization context.
+        """
+
+    def with_post_fit(
+        self,
+        fn: Callable[[np.ndarray, np.ndarray, OptimizationContext | None], None],
+    ) -> Surrogate:
+        """Return a copy of this surrogate with ``fn`` appended to the post-fit hook.
+
+        Parameters
+        ----------
+        fn : callable
+            ``fn(train_x, train_y, ctx) -> None``
+
+        Returns
+        -------
+        Surrogate
+            Shallow copy with the hook registered.
+        """
+        new = copy.copy(self)
+        prev = self.post_fit
+
+        def _hook(train_x: np.ndarray, train_y: np.ndarray, ctx=None) -> None:
+            prev(train_x, train_y, ctx)
+            fn(train_x, train_y, ctx)
+
+        new.post_fit = _hook
+        return new

--- a/src/saealib/surrogate/manager.py
+++ b/src/saealib/surrogate/manager.py
@@ -169,7 +169,6 @@ class GlobalSurrogateManager(SurrogateManager):
             provider.dispatch(
                 PostSurrogateFitEvent(
                     ctx=ctx,
-                    provider=provider,
                     surrogate=self.surrogate,
                     train_x=data.train_x,
                     train_f=data.train_y,
@@ -244,7 +243,6 @@ class LocalSurrogateManager(SurrogateManager):
                 provider.dispatch(
                     PostSurrogateFitEvent(
                         ctx=ctx,
-                        provider=provider,
                         surrogate=self.surrogate,
                         train_x=data.train_x,
                         train_f=data.train_y,

--- a/src/saealib/surrogate/manager.py
+++ b/src/saealib/surrogate/manager.py
@@ -31,7 +31,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from saealib.callback import PostSurrogateFitEvent
 from saealib.surrogate.base import Surrogate
 from saealib.surrogate.prediction import SurrogatePrediction
 from saealib.surrogate.training_set import (
@@ -43,7 +42,6 @@ from saealib.surrogate.training_set import (
 if TYPE_CHECKING:
     from saealib.acquisition.base import AcquisitionFunction
     from saealib.context import OptimizationContext
-    from saealib.optimizer import ComponentProvider
     from saealib.population import Archive
 
 
@@ -94,7 +92,6 @@ class SurrogateManager(ABC):
         self,
         candidates_x: np.ndarray,
         archive: Archive,
-        provider: ComponentProvider | None = None,
         ctx: OptimizationContext | None = None,
     ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
         """
@@ -106,11 +103,9 @@ class SurrogateManager(ABC):
             Candidate design variable matrix. shape: (n_candidates, dim)
         archive : Archive
             Archive of evaluated solutions used for surrogate training.
-        provider : ComponentProvider or None, optional
-            Component provider used to dispatch ``PostSurrogateFitEvent``
-            after each surrogate fit. If ``None``, no event is dispatched.
         ctx : OptimizationContext or None, optional
-            Current optimization context. Required when ``provider`` is given.
+            Current optimization context. Passed to ``TrainingSet.build``
+            for strategies that require comparator or population access.
 
         Returns
         -------
@@ -158,22 +153,12 @@ class GlobalSurrogateManager(SurrogateManager):
         self,
         candidates_x: np.ndarray,
         archive: Archive,
-        provider: ComponentProvider | None = None,
         ctx: OptimizationContext | None = None,
     ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
         """Fit on full archive, predict and score all candidates at once."""
         population = ctx.population if ctx is not None else None
         data = self.training_set.build(archive, population, ctx, candidate_x=None)
         self.surrogate.fit(data.train_x, data.train_y)
-        if provider is not None and ctx is not None:
-            provider.dispatch(
-                PostSurrogateFitEvent(
-                    ctx=ctx,
-                    surrogate=self.surrogate,
-                    train_x=data.train_x,
-                    train_f=data.train_y,
-                )
-            )
 
         reference = self.acquisition.compute_reference(archive)
         prediction = self.surrogate.predict(candidates_x)  # mean: (n_candidates, n_obj)
@@ -227,27 +212,16 @@ class LocalSurrogateManager(SurrogateManager):
         self,
         candidates_x: np.ndarray,
         archive: Archive,
-        provider: ComponentProvider | None = None,
         ctx: OptimizationContext | None = None,
     ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
         """Fit a local model per candidate and score each individually."""
         predictions: list[SurrogatePrediction] = []
-        _dispatch = provider is not None and ctx is not None
         reference = self.acquisition.compute_reference(archive)
         population = ctx.population if ctx is not None else None
 
         for x in candidates_x:
             data = self.training_set.build(archive, population, ctx, candidate_x=x)
             self.surrogate.fit(data.train_x, data.train_y)
-            if _dispatch:
-                provider.dispatch(
-                    PostSurrogateFitEvent(
-                        ctx=ctx,
-                        surrogate=self.surrogate,
-                        train_x=data.train_x,
-                        train_f=data.train_y,
-                    )
-                )
             pred = self.surrogate.predict(x)  # mean: (1, n_obj)
             predictions.append(pred)
 
@@ -355,7 +329,6 @@ class CompositeSurrogateManager(SurrogateManager):
         self,
         candidates_x: np.ndarray,
         archive: Archive,
-        provider: ComponentProvider | None = None,
         ctx: OptimizationContext | None = None,
     ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
         """Combine scores from all sub-managers using ``combine_fn``.
@@ -366,9 +339,7 @@ class CompositeSurrogateManager(SurrogateManager):
         first_predictions: list[SurrogatePrediction] | None = None
 
         for i, manager in enumerate(self.managers):
-            scores, preds = manager.score_candidates(
-                candidates_x, archive, provider, ctx
-            )
+            scores, preds = manager.score_candidates(candidates_x, archive, ctx)
             all_scores.append(scores)
             if i == 0:
                 first_predictions = preds

--- a/src/saealib/surrogate/manager.py
+++ b/src/saealib/surrogate/manager.py
@@ -25,6 +25,7 @@ rank_weighted_combine
 
 from __future__ import annotations
 
+import copy
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -117,6 +118,56 @@ class SurrogateManager(ABC):
         """
         ...
 
+    def post_score(
+        self,
+        scores: np.ndarray,
+        predictions: list[SurrogatePrediction],
+        ctx: OptimizationContext | None = None,
+    ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
+        """Post-score lifecycle hook; override to inject custom processing.
+
+        Parameters
+        ----------
+        scores : np.ndarray
+            Acquisition scores. shape: (n_candidates,)
+        predictions : list[SurrogatePrediction]
+            Surrogate predictions for each candidate.
+        ctx : OptimizationContext or None, optional
+            Current optimization context.
+
+        Returns
+        -------
+        tuple[np.ndarray, list[SurrogatePrediction]]
+            Processed scores and predictions.
+        """
+        return scores, predictions
+
+    def with_post_score(
+        self,
+        fn: Callable[
+            [np.ndarray, list[SurrogatePrediction], OptimizationContext | None],
+            tuple[np.ndarray, list[SurrogatePrediction]],
+        ],
+    ) -> SurrogateManager:
+        """Return a copy of this manager with ``fn`` appended to the hook.
+
+        Parameters
+        ----------
+        fn : callable
+            ``fn(scores, predictions, ctx) -> (scores, predictions)``
+
+        Returns
+        -------
+        SurrogateManager
+            Shallow copy with the hook registered.
+        """
+        new = copy.copy(self)
+        prev = self.post_score
+        new.post_score = lambda scores, predictions, ctx=None: fn(
+            *prev(scores, predictions, ctx), ctx
+        )
+        return new
+
 
 class GlobalSurrogateManager(SurrogateManager):
     """
@@ -159,6 +210,7 @@ class GlobalSurrogateManager(SurrogateManager):
         population = ctx.population if ctx is not None else None
         data = self.training_set.build(archive, population, ctx, candidate_x=None)
         self.surrogate.fit(data.train_x, data.train_y)
+        self.surrogate.post_fit(data.train_x, data.train_y, ctx)
 
         reference = self.acquisition.compute_reference(archive)
         prediction = self.surrogate.predict(candidates_x)  # mean: (n_candidates, n_obj)
@@ -166,7 +218,8 @@ class GlobalSurrogateManager(SurrogateManager):
 
         # Split batch prediction into per-candidate SurrogatePrediction objects
         predictions = _split_prediction(prediction)
-        return self._sanitize_nan(scores, predictions)
+        scores, predictions = self._sanitize_nan(scores, predictions)
+        return self.post_score(scores, predictions, ctx)
 
 
 class LocalSurrogateManager(SurrogateManager):
@@ -222,13 +275,15 @@ class LocalSurrogateManager(SurrogateManager):
         for x in candidates_x:
             data = self.training_set.build(archive, population, ctx, candidate_x=x)
             self.surrogate.fit(data.train_x, data.train_y)
+            self.surrogate.post_fit(data.train_x, data.train_y, ctx)
             pred = self.surrogate.predict(x)  # mean: (1, n_obj)
             predictions.append(pred)
 
         scores = np.array(
             [self.acquisition.score(p, reference)[0] for p in predictions]
         )
-        return self._sanitize_nan(scores, predictions)
+        scores, predictions = self._sanitize_nan(scores, predictions)
+        return self.post_score(scores, predictions, ctx)
 
 
 def product_combine(scores: list[np.ndarray]) -> np.ndarray:
@@ -345,7 +400,8 @@ class CompositeSurrogateManager(SurrogateManager):
                 first_predictions = preds
 
         combined = self.combine_fn(all_scores)
-        return self._sanitize_nan(combined, first_predictions)  # type: ignore[arg-type]
+        scores, predictions = self._sanitize_nan(combined, first_predictions)  # type: ignore[arg-type]
+        return self.post_score(scores, predictions, ctx)
 
 
 def _split_prediction(prediction: SurrogatePrediction) -> list[SurrogatePrediction]:

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -5,7 +5,6 @@ Tests cover:
 - CallbackManager: register, dispatch, unregister, replace
 - Event hierarchy: base class and subclass field definitions
 - Built-in handlers: logging_generation, logging_generation_hv
-- PostSurrogateFitEvent dispatch from SurrogateManager implementations
 - PostEvaluationEvent dispatch from IndividualBasedStrategy
 """
 
@@ -17,7 +16,6 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
-from saealib.acquisition import MeanPrediction
 from saealib.callback import (
     CallbackManager,
     Event,
@@ -39,14 +37,7 @@ from saealib.comparators import SingleObjectiveComparator
 from saealib.context import OptimizationContext
 from saealib.population import Archive, ParetoArchive, Population, PopulationAttribute
 from saealib.problem import Problem
-from saealib.surrogate.manager import (
-    CompositeSurrogateManager,
-    GlobalSurrogateManager,
-    LocalSurrogateManager,
-    product_combine,
-)
 from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
-from saealib.surrogate.training_set import KNNObjectiveSet
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -136,35 +127,11 @@ def cbmanager() -> CallbackManager:
     return CallbackManager()
 
 
-@pytest.fixture
-def provider() -> _MockProvider:
-    return _MockProvider()
-
-
-@pytest.fixture
-def archive() -> Archive:
-    return _make_archive()
-
-
-@pytest.fixture
-def candidates() -> np.ndarray:
-    rng = np.random.default_rng(7)
-    return rng.uniform(-1.0, 1.0, size=(5, DIM))
-
-
-@pytest.fixture
-def ctx(archive: Archive) -> OptimizationContext:
-    return _make_ctx(archive=archive)
-
-
 # ===========================================================================
 # CallbackManager Tests
 # ===========================================================================
 class TestCallbackManager:
     """Tests for CallbackManager: register, dispatch, unregister, replace."""
-
-    def _event(self, ctx, provider) -> RunStartEvent:
-        return RunStartEvent(ctx=ctx, provider=provider)
 
     def test_register_stores_handler(self, cbmanager: CallbackManager) -> None:
         handler = MagicMock()
@@ -174,9 +141,8 @@ class TestCallbackManager:
     def test_dispatch_calls_handler(self, cbmanager: CallbackManager) -> None:
         handler = MagicMock()
         cbmanager.register(RunStartEvent, handler)
-        prov = _MockProvider()
         ctx = _make_ctx()
-        event = RunStartEvent(ctx=ctx, provider=prov)
+        event = RunStartEvent(ctx=ctx)
         cbmanager.dispatch(event)
         handler.assert_called_once_with(event)
 
@@ -185,9 +151,8 @@ class TestCallbackManager:
     ) -> None:
         received = []
         cbmanager.register(RunStartEvent, received.append)
-        prov = _MockProvider()
         ctx = _make_ctx()
-        event = RunStartEvent(ctx=ctx, provider=prov)
+        event = RunStartEvent(ctx=ctx)
         cbmanager.dispatch(event)
         assert received[0] is event
 
@@ -198,9 +163,8 @@ class TestCallbackManager:
         cbmanager.register(RunStartEvent, lambda _: order.append(1))
         cbmanager.register(RunStartEvent, lambda _: order.append(2))
         cbmanager.register(RunStartEvent, lambda _: order.append(3))
-        prov = _MockProvider()
         ctx = _make_ctx()
-        cbmanager.dispatch(RunStartEvent(ctx=ctx, provider=prov))
+        cbmanager.dispatch(RunStartEvent(ctx=ctx))
         assert order == [1, 2, 3]
 
     def test_dispatch_ignores_other_event_types(
@@ -208,25 +172,22 @@ class TestCallbackManager:
     ) -> None:
         handler = MagicMock()
         cbmanager.register(RunEndEvent, handler)
-        prov = _MockProvider()
         ctx = _make_ctx()
-        cbmanager.dispatch(RunStartEvent(ctx=ctx, provider=prov))
+        cbmanager.dispatch(RunStartEvent(ctx=ctx))
         handler.assert_not_called()
 
     def test_dispatch_with_no_handlers_does_not_raise(
         self, cbmanager: CallbackManager
     ) -> None:
-        prov = _MockProvider()
         ctx = _make_ctx()
-        cbmanager.dispatch(RunStartEvent(ctx=ctx, provider=prov))  # should not raise
+        cbmanager.dispatch(RunStartEvent(ctx=ctx))  # should not raise
 
     def test_unregister_removes_handler(self, cbmanager: CallbackManager) -> None:
         handler = MagicMock()
         cbmanager.register(RunStartEvent, handler)
         cbmanager.unregister(RunStartEvent, handler)
-        prov = _MockProvider()
         ctx = _make_ctx()
-        cbmanager.dispatch(RunStartEvent(ctx=ctx, provider=prov))
+        cbmanager.dispatch(RunStartEvent(ctx=ctx))
         handler.assert_not_called()
 
     def test_unregister_unknown_raises_value_error(
@@ -241,9 +202,8 @@ class TestCallbackManager:
         new = MagicMock()
         cbmanager.register(RunStartEvent, old)
         cbmanager.replace(RunStartEvent, old, new)
-        prov = _MockProvider()
         ctx = _make_ctx()
-        cbmanager.dispatch(RunStartEvent(ctx=ctx, provider=prov))
+        cbmanager.dispatch(RunStartEvent(ctx=ctx))
         old.assert_not_called()
         new.assert_called_once()
 
@@ -267,9 +227,8 @@ class TestCallbackManager:
             order.append("new")
 
         cbmanager.replace(RunStartEvent, h2, new)
-        prov = _MockProvider()
         ctx = _make_ctx()
-        cbmanager.dispatch(RunStartEvent(ctx=ctx, provider=prov))
+        cbmanager.dispatch(RunStartEvent(ctx=ctx))
         assert order == ["h1", "new", "h3"]
 
     def test_replace_unknown_old_raises_value_error(
@@ -289,9 +248,8 @@ class TestCallbackManager:
 
         cbmanager.register(RunStartEvent, handler)
         cbmanager.register(RunStartEvent, handler)
-        prov = _MockProvider()
         ctx = _make_ctx()
-        cbmanager.dispatch(RunStartEvent(ctx=ctx, provider=prov))
+        cbmanager.dispatch(RunStartEvent(ctx=ctx))
         assert counter[0] == 2
 
 
@@ -301,15 +259,10 @@ class TestCallbackManager:
 class TestEventClasses:
     """Tests that event dataclasses expose the expected fields."""
 
-    def _prov(self) -> _MockProvider:
-        return _MockProvider()
-
-    def test_event_requires_ctx_and_provider(self) -> None:
-        prov = self._prov()
+    def test_event_has_ctx(self) -> None:
         ctx = _make_ctx()
-        e = RunStartEvent(ctx=ctx, provider=prov)
+        e = RunStartEvent(ctx=ctx)
         assert e.ctx is ctx
-        assert e.provider is prov
 
     @pytest.mark.parametrize(
         "cls",
@@ -321,55 +274,47 @@ class TestEventClasses:
         ],
     )
     def test_lifecycle_events_are_event_subclasses(self, cls) -> None:
-        prov = self._prov()
         ctx = _make_ctx()
-        e = cls(ctx=ctx, provider=prov)
+        e = cls(ctx=ctx)
         assert isinstance(e, Event)
 
     def test_post_crossover_event_has_candidates(self) -> None:
-        prov = self._prov()
         ctx = _make_ctx()
         cand = np.zeros((3, DIM))
-        e = PostCrossoverEvent(ctx=ctx, provider=prov, candidates=cand)
+        e = PostCrossoverEvent(ctx=ctx, candidates=cand)
         np.testing.assert_array_equal(e.candidates, cand)
 
     def test_post_mutation_event_has_candidates(self) -> None:
-        prov = self._prov()
         ctx = _make_ctx()
         cand = np.ones((4, DIM))
-        e = PostMutationEvent(ctx=ctx, provider=prov, candidates=cand)
+        e = PostMutationEvent(ctx=ctx, candidates=cand)
         np.testing.assert_array_equal(e.candidates, cand)
 
     def test_post_ask_event_has_candidates(self) -> None:
-        prov = self._prov()
         ctx = _make_ctx()
         cand = np.eye(DIM)
-        e = PostAskEvent(ctx=ctx, provider=prov, candidates=cand)
+        e = PostAskEvent(ctx=ctx, candidates=cand)
         np.testing.assert_array_equal(e.candidates, cand)
 
     def test_surrogate_start_event_has_offspring(self) -> None:
-        prov = self._prov()
         ctx = _make_ctx()
         pop = _make_population(3)
-        e = SurrogateStartEvent(ctx=ctx, provider=prov, offspring=pop)
+        e = SurrogateStartEvent(ctx=ctx, offspring=pop)
         assert e.offspring is pop
 
     def test_surrogate_end_event_has_offspring(self) -> None:
-        prov = self._prov()
         ctx = _make_ctx()
         pop = _make_population(3)
-        e = SurrogateEndEvent(ctx=ctx, provider=prov, offspring=pop)
+        e = SurrogateEndEvent(ctx=ctx, offspring=pop)
         assert e.offspring is pop
 
     def test_post_surrogate_fit_event_fields(self) -> None:
-        prov = self._prov()
         ctx = _make_ctx()
         surrogate = RBFsurrogate(gaussian_kernel, DIM)
         train_x = np.zeros((10, DIM))
         train_f = np.zeros((10, N_OBJ))
         e = PostSurrogateFitEvent(
             ctx=ctx,
-            provider=prov,
             surrogate=surrogate,
             train_x=train_x,
             train_f=train_f,
@@ -379,24 +324,21 @@ class TestEventClasses:
         np.testing.assert_array_equal(e.train_f, train_f)
 
     def test_post_surrogate_fit_event_defaults_none(self) -> None:
-        prov = self._prov()
         ctx = _make_ctx()
-        e = PostSurrogateFitEvent(ctx=ctx, provider=prov)
+        e = PostSurrogateFitEvent(ctx=ctx)
         assert e.surrogate is None
         assert e.train_x is None
         assert e.train_f is None
 
     def test_post_evaluation_event_has_offspring(self) -> None:
-        prov = self._prov()
         ctx = _make_ctx()
         pop = _make_population(2)
-        e = PostEvaluationEvent(ctx=ctx, provider=prov, offspring=pop)
+        e = PostEvaluationEvent(ctx=ctx, offspring=pop)
         assert e.offspring is pop
 
     def test_post_evaluation_event_default_offspring_none(self) -> None:
-        prov = self._prov()
         ctx = _make_ctx()
-        e = PostEvaluationEvent(ctx=ctx, provider=prov)
+        e = PostEvaluationEvent(ctx=ctx)
         assert e.offspring is None
 
 
@@ -447,24 +389,21 @@ class TestLoggingGenerationHandler:
 
     def test_logging_generation_single_obj_does_not_raise(self, caplog) -> None:
         ctx = self._make_1obj_ctx()
-        prov = _MockProvider()
-        event = GenerationStartEvent(ctx=ctx, provider=prov)
+        event = GenerationStartEvent(ctx=ctx)
         with caplog.at_level(logging.INFO, logger="saealib.callback"):
             logging_generation(event)
         assert "Generation" in caplog.text
 
     def test_logging_generation_single_obj_logs_best_f(self, caplog) -> None:
         ctx = self._make_1obj_ctx()
-        prov = _MockProvider()
-        event = GenerationStartEvent(ctx=ctx, provider=prov)
+        event = GenerationStartEvent(ctx=ctx)
         with caplog.at_level(logging.INFO, logger="saealib.callback"):
             logging_generation(event)
         assert "Best f" in caplog.text
 
     def test_logging_generation_multi_obj_does_not_raise(self, caplog) -> None:
         ctx = self._make_2obj_ctx()
-        prov = _MockProvider()
-        event = GenerationStartEvent(ctx=ctx, provider=prov)
+        event = GenerationStartEvent(ctx=ctx)
         with caplog.at_level(logging.INFO, logger="saealib.callback"):
             logging_generation(event)
         assert "Front1" in caplog.text
@@ -476,10 +415,9 @@ class TestLoggingGenerationHandler:
 
     def test_logging_generation_hv_does_not_raise(self, caplog) -> None:
         ctx = self._make_2obj_ctx()
-        prov = _MockProvider()
         ref = np.array([10.0, 10.0])
         handler = logging_generation_hv(ref)
-        event = GenerationStartEvent(ctx=ctx, provider=prov)
+        event = GenerationStartEvent(ctx=ctx)
         with caplog.at_level(logging.INFO, logger="saealib.callback"):
             handler(event)
 
@@ -490,166 +428,8 @@ class TestLoggingGenerationHandler:
         ctx = self._make_1obj_ctx()
         prov = _MockProvider()
         prov.cbmanager = cbm
-        event = GenerationStartEvent(ctx=ctx, provider=prov)
+        event = GenerationStartEvent(ctx=ctx)
         cbm.dispatch(event)  # should not raise
-
-
-# ===========================================================================
-# PostSurrogateFitEvent dispatch Tests
-# ===========================================================================
-class TestPostSurrogateFitDispatch:
-    """Tests that SurrogateManager implementations dispatch PostSurrogateFitEvent."""
-
-    def test_global_dispatches_once_with_provider(
-        self,
-        archive: Archive,
-        candidates: np.ndarray,
-        ctx: OptimizationContext,
-    ) -> None:
-        prov = _MockProvider()
-        manager = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
-        )
-        manager.score_candidates(candidates, archive, provider=prov, ctx=ctx)
-        fit_events = [
-            e for e in prov.dispatched if isinstance(e, PostSurrogateFitEvent)
-        ]
-        assert len(fit_events) == 1
-
-    def test_global_no_dispatch_without_provider(
-        self,
-        archive: Archive,
-        candidates: np.ndarray,
-    ) -> None:
-        manager = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
-        )
-        # provider=None (default) — should not raise and fire no events
-        scores, _predictions = manager.score_candidates(candidates, archive)
-        assert scores.shape == (len(candidates),)
-
-    def test_global_event_carries_surrogate_and_training_data(
-        self,
-        archive: Archive,
-        candidates: np.ndarray,
-        ctx: OptimizationContext,
-    ) -> None:
-        prov = _MockProvider()
-        surrogate = RBFsurrogate(gaussian_kernel, DIM)
-        manager = GlobalSurrogateManager(surrogate, MeanPrediction())
-        manager.score_candidates(candidates, archive, provider=prov, ctx=ctx)
-        event: PostSurrogateFitEvent = prov.dispatched[0]
-        assert event.surrogate is surrogate
-        assert event.train_x is not None
-        assert event.train_f is not None
-        assert event.train_x.shape == (len(archive), DIM)
-        assert event.train_f.shape == (len(archive), N_OBJ)
-
-    def test_global_event_has_correct_ctx_and_provider(
-        self,
-        archive: Archive,
-        candidates: np.ndarray,
-        ctx: OptimizationContext,
-    ) -> None:
-        prov = _MockProvider()
-        manager = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
-        )
-        manager.score_candidates(candidates, archive, provider=prov, ctx=ctx)
-        event: PostSurrogateFitEvent = prov.dispatched[0]
-        assert event.ctx is ctx
-        assert event.provider is prov
-
-    def test_local_dispatches_once_per_candidate(
-        self,
-        archive: Archive,
-        candidates: np.ndarray,
-        ctx: OptimizationContext,
-    ) -> None:
-        prov = _MockProvider()
-        manager = LocalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM),
-            MeanPrediction(),
-            training_set=KNNObjectiveSet(10),
-        )
-        manager.score_candidates(candidates, archive, provider=prov, ctx=ctx)
-        fit_events = [
-            e for e in prov.dispatched if isinstance(e, PostSurrogateFitEvent)
-        ]
-        assert len(fit_events) == len(candidates)
-
-    def test_local_no_dispatch_without_provider(
-        self,
-        archive: Archive,
-        candidates: np.ndarray,
-    ) -> None:
-        manager = LocalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM),
-            MeanPrediction(),
-            training_set=KNNObjectiveSet(10),
-        )
-        scores, _ = manager.score_candidates(candidates, archive)
-        assert scores.shape == (len(candidates),)
-
-    def test_local_each_event_carries_local_training_data(
-        self,
-        archive: Archive,
-        candidates: np.ndarray,
-        ctx: OptimizationContext,
-    ) -> None:
-        n_neighbors = 10
-        prov = _MockProvider()
-        manager = LocalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM),
-            MeanPrediction(),
-            training_set=KNNObjectiveSet(n_neighbors),
-        )
-        manager.score_candidates(candidates, archive, provider=prov, ctx=ctx)
-        fit_events = [
-            e for e in prov.dispatched if isinstance(e, PostSurrogateFitEvent)
-        ]
-        for event in fit_events:
-            assert event.train_x is not None
-            assert event.train_f is not None
-            assert event.train_x.shape == (n_neighbors, DIM)
-            assert event.train_f.shape == (n_neighbors, N_OBJ)
-
-    def test_ensemble_propagates_to_sub_managers(
-        self,
-        archive: Archive,
-        candidates: np.ndarray,
-        ctx: OptimizationContext,
-    ) -> None:
-        """CompositeSurrogateManager passes provider through to each sub-manager."""
-        prov = _MockProvider()
-        m1 = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
-        )
-        m2 = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
-        )
-        ensemble = CompositeSurrogateManager([m1, m2], combine_fn=product_combine)
-        ensemble.score_candidates(candidates, archive, provider=prov, ctx=ctx)
-        fit_events = [
-            e for e in prov.dispatched if isinstance(e, PostSurrogateFitEvent)
-        ]
-        # One PostSurrogateFitEvent per sub-manager (each fits once on full archive)
-        assert len(fit_events) == 2
-
-    def test_no_dispatch_when_only_ctx_given(
-        self,
-        archive: Archive,
-        candidates: np.ndarray,
-        ctx: OptimizationContext,
-    ) -> None:
-        """provider=None with ctx given: no dispatch (both required)."""
-        manager = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
-        )
-        scores, _ = manager.score_candidates(
-            candidates, archive, provider=None, ctx=ctx
-        )
-        assert scores.shape == (len(candidates),)
 
 
 # ===========================================================================
@@ -695,7 +475,6 @@ class TestPostEvaluationDispatch:
             .set_strategy(IndividualBasedStrategy(evaluation_ratio=evaluation_ratio))
             .set_termination(Termination(max_fe(100)))
         )
-        # Initialize the context
         ctx = opt.initializer.initialize(opt, problem)
         return ctx, opt
 
@@ -740,7 +519,6 @@ class TestPostEvaluationDispatch:
 
         event = received[0]
         offspring = event.offspring
-        # Each evaluated individual's f should equal sphere(x)
         for i in range(len(offspring)):
             x = offspring[i].x
             f = offspring[i].f

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -16,6 +16,7 @@ Tests cover:
 import numpy as np
 import pytest
 
+from saealib import GA, SequentialSelection, TruncationSelection
 from saealib.comparators import SingleObjectiveComparator
 from saealib.context import OptimizationContext
 from saealib.operators.crossover import (
@@ -28,6 +29,7 @@ from saealib.operators.crossover import (
 from saealib.operators.mutation import (
     MutationGaussian,
     MutationPolynomial,
+    MutationUniform,
 )
 from saealib.operators.selection import RouletteWheelSelection
 from saealib.population import Archive, ParetoArchive, Population, PopulationAttribute
@@ -356,3 +358,201 @@ class TestRouletteWheelSelection:
                 counts[i] += 1
 
         assert counts[best_idx] > counts[worst_idx]
+
+
+# ---------------------------------------------------------------------------
+# Crossover lifecycle hooks
+# ---------------------------------------------------------------------------
+
+
+class TestCrossoverHooks:
+    def _op(self):
+        return CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4)
+
+    def _parents(self, rng=None):
+        rng = rng if rng is not None else np.random.default_rng(0)
+        return rng.uniform(-1.0, 1.0, size=(2, DIM))
+
+    def test_post_crossover_default_is_noop(self):
+        op = self._op()
+        rng = np.random.default_rng(0)
+        parents = self._parents(rng)
+        offspring = op.crossover(parents, rng=rng)
+        result = op.post_crossover(offspring.copy(), parents, rng)
+        np.testing.assert_array_equal(result, offspring)
+
+    def test_with_post_transforms_offspring(self):
+        op = self._op().with_post(lambda o, p, rng, ctx: np.zeros_like(o))
+        rng = np.random.default_rng(0)
+        parents = self._parents(rng)
+        offspring = op.crossover(parents, rng=rng)
+        result = op.post_crossover(offspring, parents, rng)
+        np.testing.assert_array_equal(result, np.zeros_like(offspring))
+
+    def test_with_post_fn_receives_correct_args(self):
+        received = {}
+
+        def hook(offspring, parents, rng, ctx):
+            received["offspring_shape"] = offspring.shape
+            received["parents_shape"] = parents.shape
+            received["ctx"] = ctx
+            return offspring
+
+        ctx = _make_ctx()
+        op = self._op().with_post(hook)
+        rng = np.random.default_rng(0)
+        parents = self._parents(rng)
+        offspring = op.crossover(parents, rng=rng)
+        op.post_crossover(offspring, parents, rng, ctx)
+        assert received["offspring_shape"] == (2, DIM)
+        assert received["parents_shape"] == (2, DIM)
+        assert received["ctx"] is ctx
+
+    def test_with_post_chains_in_order(self):
+        log = []
+        op = (
+            self._op()
+            .with_post(lambda o, p, rng, ctx: (log.append(1), o)[1])
+            .with_post(lambda o, p, rng, ctx: (log.append(2), o)[1])
+        )
+        rng = np.random.default_rng(0)
+        parents = self._parents(rng)
+        offspring = op.crossover(parents, rng=rng)
+        op.post_crossover(offspring, parents, rng)
+        assert log == [1, 2]
+
+    def test_with_post_does_not_mutate_original(self):
+        op = self._op()
+        _ = op.with_post(lambda o, p, rng, ctx: np.zeros_like(o))
+        rng = np.random.default_rng(0)
+        parents = self._parents(rng)
+        offspring = op.crossover(parents, rng=rng)
+        result = op.post_crossover(offspring.copy(), parents, rng)
+        np.testing.assert_array_equal(result, offspring)
+
+
+# ---------------------------------------------------------------------------
+# Mutation lifecycle hooks
+# ---------------------------------------------------------------------------
+
+
+class TestMutationHooks:
+    def _op(self):
+        return MutationPolynomial(mutation_rate=1.0, eta=20.0)
+
+    def _individual(self, rng=None):
+        rng = rng if rng is not None else np.random.default_rng(0)
+        return rng.uniform(-3.0, 3.0, size=DIM)
+
+    def _range(self):
+        return np.full(DIM, -5.0), np.full(DIM, 5.0)
+
+    def test_post_mutation_default_is_noop(self):
+        op = self._op()
+        rng = np.random.default_rng(0)
+        p = self._individual(rng)
+        mutated = op.mutate(p, self._range(), rng=rng)
+        result = op.post_mutation(mutated.copy(), self._range(), rng)
+        np.testing.assert_array_equal(result, mutated)
+
+    def test_with_post_transforms_individual(self):
+        op = self._op().with_post(lambda o, mr, rng, ctx: np.zeros_like(o))
+        rng = np.random.default_rng(0)
+        p = self._individual(rng)
+        mutated = op.mutate(p, self._range(), rng=rng)
+        result = op.post_mutation(mutated, self._range(), rng)
+        np.testing.assert_array_equal(result, np.zeros(DIM))
+
+    def test_with_post_fn_receives_correct_args(self):
+        received = {}
+
+        def hook(offspring, mutate_range, rng, ctx):
+            received["shape"] = offspring.shape
+            received["ctx"] = ctx
+            return offspring
+
+        ctx = _make_ctx()
+        op = self._op().with_post(hook)
+        rng = np.random.default_rng(0)
+        p = self._individual(rng)
+        mutated = op.mutate(p, self._range(), rng=rng)
+        op.post_mutation(mutated, self._range(), rng, ctx)
+        assert received["shape"] == (DIM,)
+        assert received["ctx"] is ctx
+
+    def test_with_post_chains_in_order(self):
+        log = []
+        op = (
+            self._op()
+            .with_post(lambda o, mr, rng, ctx: (log.append(1), o)[1])
+            .with_post(lambda o, mr, rng, ctx: (log.append(2), o)[1])
+        )
+        rng = np.random.default_rng(0)
+        p = self._individual(rng)
+        mutated = op.mutate(p, self._range(), rng=rng)
+        op.post_mutation(mutated, self._range(), rng)
+        assert log == [1, 2]
+
+    def test_with_post_does_not_mutate_original(self):
+        op = self._op()
+        _ = op.with_post(lambda o, mr, rng, ctx: np.zeros_like(o))
+        rng = np.random.default_rng(0)
+        p = self._individual(rng)
+        mutated = op.mutate(p, self._range(), rng=rng)
+        result = op.post_mutation(mutated.copy(), self._range(), rng)
+        np.testing.assert_array_equal(result, mutated)
+
+
+# ---------------------------------------------------------------------------
+# GA hook invocation (integration)
+# ---------------------------------------------------------------------------
+
+
+class _DispatchOnlyProvider:
+    def dispatch(self, event):
+        pass
+
+
+class TestGAHookInvocation:
+    """Verify that GA.ask() calls post_crossover and post_mutation hooks."""
+
+    def _make_ctx(self):
+        return _make_ctx()
+
+    def test_post_crossover_called_during_ask(self):
+        call_count = [0]
+
+        def hook(offspring, parents, rng, ctx):
+            call_count[0] += 1
+            return offspring
+
+        crossover = CrossoverBLXAlpha(crossover_rate=1.0, alpha=0.4).with_post(hook)
+        ga = GA(
+            crossover=crossover,
+            mutation=MutationUniform(mutation_rate=0.0),
+            parent_selection=SequentialSelection(),
+            survivor_selection=TruncationSelection(),
+        )
+        provider = _DispatchOnlyProvider()
+        ctx = _make_ctx()
+        ga.ask(ctx, provider)
+        assert call_count[0] > 0
+
+    def test_post_mutation_called_once_per_offspring(self):
+        call_count = [0]
+
+        def hook(offspring, mutate_range, rng, ctx):
+            call_count[0] += 1
+            return offspring
+
+        mutation = MutationUniform(mutation_rate=0.0).with_post(hook)
+        ga = GA(
+            crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4),
+            mutation=mutation,
+            parent_selection=SequentialSelection(),
+            survivor_selection=TruncationSelection(),
+        )
+        provider = _DispatchOnlyProvider()
+        ctx = _make_ctx()
+        candidates = ga.ask(ctx, provider)
+        assert call_count[0] == len(candidates)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -97,7 +97,7 @@ def _make_ga() -> GA:
 class _MockSurrogateManager:
     """Returns uniform scores and constant predictions."""
 
-    def score_candidates(self, candidates_x, archive, provider, ctx):
+    def score_candidates(self, candidates_x, archive, ctx=None):
         n = len(candidates_x)
         scores = np.linspace(1.0, 0.0, n)
         predictions = [

--- a/tests/test_surrogate_manager.py
+++ b/tests/test_surrogate_manager.py
@@ -830,3 +830,176 @@ class TestCompositeSurrogateManagerWithArchiveBased:
         assert scores.shape == (len(candidates),)
         for p in preds:
             assert np.all(np.isfinite(p.tell_f))
+
+
+# ===========================================================================
+# Surrogate lifecycle hooks (post_fit / with_post_fit)
+# ===========================================================================
+
+
+class TestSurrogateHooks:
+    """Tests for Surrogate.post_fit and with_post_fit."""
+
+    def test_post_fit_default_is_noop(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        train_x, train_y = archive_1obj.x, archive_1obj.f
+        surrogate_1obj.fit(train_x, train_y)
+        result = surrogate_1obj.post_fit(train_x, train_y, ctx=None)
+        assert result is None
+
+    def test_with_post_fit_fn_is_called(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        called = [False]
+
+        def hook(train_x, train_y, ctx):
+            called[0] = True
+
+        surrogate = surrogate_1obj.with_post_fit(hook)
+        train_x, train_y = archive_1obj.x, archive_1obj.f
+        surrogate.fit(train_x, train_y)
+        surrogate.post_fit(train_x, train_y, ctx=None)
+        assert called[0]
+
+    def test_with_post_fit_fn_receives_correct_args(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        received = {}
+
+        def hook(train_x, train_y, ctx):
+            received["train_x_shape"] = train_x.shape
+            received["train_y_shape"] = train_y.shape
+
+        surrogate = surrogate_1obj.with_post_fit(hook)
+        train_x, train_y = archive_1obj.x, archive_1obj.f
+        surrogate.post_fit(train_x, train_y, ctx=None)
+        assert received["train_x_shape"] == train_x.shape
+        assert received["train_y_shape"] == train_y.shape
+
+    def test_with_post_fit_chains_in_order(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        log: list[int] = []
+        surrogate = (
+            surrogate_1obj
+            .with_post_fit(lambda tx, ty, ctx: log.append(1))
+            .with_post_fit(lambda tx, ty, ctx: log.append(2))
+        )
+        train_x, train_y = archive_1obj.x, archive_1obj.f
+        surrogate.post_fit(train_x, train_y, ctx=None)
+        assert log == [1, 2]
+
+    def test_with_post_fit_does_not_mutate_original(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        called = [False]
+
+        def hook(tx, ty, ctx):
+            called[0] = True
+
+        _ = surrogate_1obj.with_post_fit(hook)
+        train_x, train_y = archive_1obj.x, archive_1obj.f
+        surrogate_1obj.post_fit(train_x, train_y, ctx=None)
+        assert not called[0]
+
+
+# ===========================================================================
+# SurrogateManager lifecycle hooks (post_score / with_post_score)
+# ===========================================================================
+
+
+class TestSurrogateManagerHooks:
+    """Tests for SurrogateManager.post_score and with_post_score."""
+
+    def test_post_score_default_is_noop(
+        self,
+        surrogate_1obj: RBFsurrogate,
+        archive_1obj: Archive,
+        candidates: np.ndarray,
+    ) -> None:
+        manager = GlobalSurrogateManager(surrogate_1obj, MeanPrediction())
+        scores, predictions = manager.score_candidates(candidates, archive_1obj)
+        result_s, result_p = manager.post_score(scores, predictions, ctx=None)
+        np.testing.assert_array_equal(result_s, scores)
+        assert result_p is predictions
+
+    def test_with_post_score_transforms_scores(
+        self,
+        surrogate_1obj: RBFsurrogate,
+        archive_1obj: Archive,
+        candidates: np.ndarray,
+    ) -> None:
+        def zero_scores(scores, predictions, ctx):
+            return np.zeros_like(scores), predictions
+
+        manager = GlobalSurrogateManager(
+            surrogate_1obj, MeanPrediction()
+        ).with_post_score(zero_scores)
+        scores, _ = manager.score_candidates(candidates, archive_1obj)
+        np.testing.assert_array_equal(scores, np.zeros(len(candidates)))
+
+    def test_with_post_score_called_once_per_score_candidates(
+        self,
+        surrogate_1obj: RBFsurrogate,
+        archive_1obj: Archive,
+        candidates: np.ndarray,
+    ) -> None:
+        call_count = [0]
+
+        def hook(scores, predictions, ctx):
+            call_count[0] += 1
+            return scores, predictions
+
+        manager = LocalSurrogateManager(
+            surrogate_1obj, MeanPrediction(), training_set=KNNObjectiveSet(10)
+        ).with_post_score(hook)
+        manager.score_candidates(candidates, archive_1obj)
+        assert call_count[0] == 1
+
+    def test_with_post_score_does_not_mutate_original(
+        self,
+        surrogate_1obj: RBFsurrogate,
+        archive_1obj: Archive,
+        candidates: np.ndarray,
+    ) -> None:
+        manager = GlobalSurrogateManager(surrogate_1obj, MeanPrediction())
+        _ = manager.with_post_score(
+            lambda s, p, ctx: (np.zeros_like(s), p)
+        )
+        scores, _ = manager.score_candidates(candidates, archive_1obj)
+        assert not np.all(scores == 0.0)
+
+    def test_post_fit_called_in_global_manager(
+        self,
+        surrogate_1obj: RBFsurrogate,
+        archive_1obj: Archive,
+        candidates: np.ndarray,
+    ) -> None:
+        called = [False]
+
+        def hook(tx, ty, ctx):
+            called[0] = True
+
+        surrogate = surrogate_1obj.with_post_fit(hook)
+        manager = GlobalSurrogateManager(surrogate, MeanPrediction())
+        manager.score_candidates(candidates, archive_1obj)
+        assert called[0]
+
+    def test_post_fit_called_per_candidate_in_local_manager(
+        self,
+        surrogate_1obj: RBFsurrogate,
+        archive_1obj: Archive,
+        candidates: np.ndarray,
+    ) -> None:
+        call_count = [0]
+
+        def hook(tx, ty, ctx):
+            call_count[0] += 1
+
+        surrogate = surrogate_1obj.with_post_fit(hook)
+        manager = LocalSurrogateManager(
+            surrogate, MeanPrediction(), training_set=KNNObjectiveSet(10)
+        )
+        manager.score_candidates(candidates, archive_1obj)
+        assert call_count[0] == len(candidates)

--- a/tests/test_surrogate_manager.py
+++ b/tests/test_surrogate_manager.py
@@ -881,11 +881,9 @@ class TestSurrogateHooks:
         self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
     ) -> None:
         log: list[int] = []
-        surrogate = (
-            surrogate_1obj
-            .with_post_fit(lambda tx, ty, ctx: log.append(1))
-            .with_post_fit(lambda tx, ty, ctx: log.append(2))
-        )
+        surrogate = surrogate_1obj.with_post_fit(
+            lambda tx, ty, ctx: log.append(1)
+        ).with_post_fit(lambda tx, ty, ctx: log.append(2))
         train_x, train_y = archive_1obj.x, archive_1obj.f
         surrogate.post_fit(train_x, train_y, ctx=None)
         assert log == [1, 2]
@@ -964,9 +962,7 @@ class TestSurrogateManagerHooks:
         candidates: np.ndarray,
     ) -> None:
         manager = GlobalSurrogateManager(surrogate_1obj, MeanPrediction())
-        _ = manager.with_post_score(
-            lambda s, p, ctx: (np.zeros_like(s), p)
-        )
+        _ = manager.with_post_score(lambda s, p, ctx: (np.zeros_like(s), p))
         scores, _ = manager.score_candidates(candidates, archive_1obj)
         assert not np.all(scores == 0.0)
 


### PR DESCRIPTION
## Related Issue
Closes #137

## Overview
Restricts callbacks to read-only observation and introduces per-component lifecycle hooks for processing injection. This decouples `ComponentProvider` from internal component signatures and gives users a clean extension point without subclassing.

## Changes
- Remove `provider: ComponentProvider` from `Event` base class; all event constructions updated accordingly
- Remove `provider` parameter from `SurrogateManager.score_candidates()`
- Add `post_crossover` / `post_mutation` hooks to `Crossover` / `Mutation` base classes; `GA.ask()` calls both hooks per offspring
- Add `post_fit` / `post_score` hooks to `Surrogate` / `SurrogateManager` base classes; all three concrete managers call both hooks
- Add `with_post` / `with_post_fit` / `with_post_score` functional wrappers on each base class for hook composition without subclassing

## Verification Steps
run pytest

## Concerns
- `PostCrossoverEvent.candidates` / `PostMutationEvent.candidates` remain for observation, but GA no longer reads them back after dispatch. Candidate mutation via callbacks is removed; use `with_post(fn)` on the operator instead.
- `PostSurrogateFitEvent` dispatch removed from `SurrogateManager`; observe fit events via `Surrogate.with_post_fit` instead.
