### PR TITLE
feat: [#139] Introduce saealib.exceptions exception hierarchy

### DIFF
--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -22,6 +22,7 @@ from saealib.callback import (
     RunStartEvent,
 )
 from saealib.comparators import Comparator, NSGA2Comparator, SingleObjectiveComparator
+from saealib.exceptions import ConfigurationError, SaealibError, ValidationError
 from saealib.execution.evaluator import EvaluationResult, Evaluator, SerialEvaluator
 from saealib.execution.initializer import Initializer, LHSInitializer
 from saealib.operators import (
@@ -81,6 +82,7 @@ __all__ = [
     # Callbacks (core)
     "CallbackManager",
     "Comparator",
+    "ConfigurationError",
     # Problem
     "ConstraintHandler",
     "Crossover",
@@ -121,6 +123,7 @@ __all__ = [
     "Result",
     "RunEndEvent",
     "RunStartEvent",
+    "SaealibError",
     "SerialEvaluator",
     "SingleObjectiveComparator",
     "StaticToleranceHandler",
@@ -132,6 +135,7 @@ __all__ = [
     "TerminationCondition",
     "TournamentSelection",
     "TruncationSelection",
+    "ValidationError",
     "f_target",
     # Indicators
     "hypervolume",

--- a/src/saealib/api.py
+++ b/src/saealib/api.py
@@ -13,6 +13,7 @@ from saealib.algorithms.ga import GA
 from saealib.algorithms.pso import PSO
 from saealib.callback import GenerationStartEvent, logging_generation
 from saealib.context import OptimizationContext
+from saealib.exceptions import ValidationError
 from saealib.execution.initializer import LHSInitializer
 from saealib.operators.crossover import CrossoverBLXAlpha
 from saealib.operators.mutation import MutationUniform
@@ -79,7 +80,9 @@ def _resolve_direction(
     try:
         return np.array([_map[d] for d in direction])
     except KeyError as e:
-        raise ValueError(f"Unknown direction {e}. Use 'minimize' or 'maximize'.") from e
+        raise ValidationError(
+            f"Unknown direction {e}. Use 'minimize' or 'maximize'."
+        ) from e
 
 
 def _ensure_problem(
@@ -94,7 +97,7 @@ def _ensure_problem(
     if isinstance(func, Problem):
         return func
     if dim is None or lb is None or ub is None:
-        raise ValueError("dim, lb, and ub are required when func is a callable.")
+        raise ValidationError("dim, lb, and ub are required when func is a callable.")
     return Problem(func=func, dim=dim, n_obj=n_obj, direction=direction, lb=lb, ub=ub)
 
 
@@ -110,7 +113,7 @@ def _resolve_algorithm(algorithm: str | Algorithm) -> Algorithm:
             )
         if name == "PSO":
             return PSO()
-        raise ValueError(
+        raise ValidationError(
             f"Unknown algorithm: {algorithm!r}. "
             "Use 'GA', 'PSO', or an Algorithm instance."
         )
@@ -123,7 +126,7 @@ def _resolve_surrogate(
     n_neighbors: int,
 ) -> SurrogateManager:
     if surrogate is None:
-        raise ValueError(
+        raise ValidationError(
             "surrogate=None is not supported. "
             "Use 'rbf' or a Surrogate/SurrogateManager instance."
         )
@@ -139,7 +142,7 @@ def _resolve_surrogate(
                 MeanPrediction(direction=problem.direction),
                 training_set=KNNObjectiveSet(n_neighbors),
             )
-        raise ValueError(
+        raise ValidationError(
             f"Unknown surrogate: {surrogate!r}. "
             "Use 'rbf' or a Surrogate/SurrogateManager instance."
         )
@@ -165,7 +168,7 @@ def _resolve_strategy(
         if name == "ps":
             n_select = max(1, pop_size // 10)
             return PreSelectionStrategy(n_candidates=pop_size, n_select=n_select)
-        raise ValueError(
+        raise ValidationError(
             f"Unknown strategy: {strategy!r}. "
             "Use 'ib', 'gb', 'ps', or an OptimizationStrategy instance."
         )

--- a/src/saealib/exceptions.py
+++ b/src/saealib/exceptions.py
@@ -1,0 +1,15 @@
+"""Public exception hierarchy for saealib."""
+
+__all__ = ["ConfigurationError", "SaealibError", "ValidationError"]
+
+
+class SaealibError(Exception):
+    """Base class for all saealib exceptions."""
+
+
+class ValidationError(SaealibError, ValueError):
+    """Raised when user-supplied arguments fail validation at a public boundary."""
+
+
+class ConfigurationError(SaealibError, ValueError):
+    """Raised when an :class:`~saealib.Optimizer` is misconfigured at run time."""

--- a/src/saealib/optimizer.py
+++ b/src/saealib/optimizer.py
@@ -13,6 +13,7 @@ from saealib.callback import (
     logging_generation,
 )
 from saealib.context import OptimizationContext
+from saealib.exceptions import ConfigurationError
 from saealib.execution.evaluator import Evaluator, SerialEvaluator
 from saealib.execution.runner import Runner
 from saealib.surrogate.manager import LocalSurrogateManager, SurrogateManager
@@ -247,7 +248,7 @@ class Optimizer:
         """
         issues = self.validate()
         if issues:
-            raise ValueError(
+            raise ConfigurationError(
                 "Optimizer misconfigured:\n" + "\n".join(f"  - {m}" for m in issues)
             )
         return Runner(self).iterate()
@@ -263,7 +264,7 @@ class Optimizer:
         """
         issues = self.validate()
         if issues:
-            raise ValueError(
+            raise ConfigurationError(
                 "Optimizer misconfigured:\n" + "\n".join(f"  - {m}" for m in issues)
             )
         return Runner(self).run()

--- a/src/saealib/problem/problem.py
+++ b/src/saealib/problem/problem.py
@@ -10,6 +10,7 @@ from saealib.comparators import (
     NSGA2Comparator,
     SingleObjectiveComparator,
 )
+from saealib.exceptions import ValidationError
 from saealib.problem.constraint import (
     ConstraintHandler,
     InequalityConstraint,
@@ -105,7 +106,7 @@ class Problem:
             eps_cv = eps_obj = eps
         direction = np.asarray(direction, dtype=float)
         if not np.all(np.abs(direction) == 1):
-            raise ValueError("direction elements must be +1 or -1")
+            raise ValidationError("direction elements must be +1 or -1")
         self.dim = dim
         self.n_obj = n_obj
         self.direction = direction

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -40,13 +40,13 @@ class TestTopLevelExport:
         assert "ConfigurationError" in saealib.__all__
 
     def test_importable_from_top_level(self):
-        from saealib import ConfigurationError as CE
-        from saealib import SaealibError as SE
-        from saealib import ValidationError as VE
+        from saealib import ConfigurationError as CfgErr
+        from saealib import SaealibError as BaseErr
+        from saealib import ValidationError as ValErr
 
-        assert SE is SaealibError
-        assert VE is ValidationError
-        assert CE is ConfigurationError
+        assert BaseErr is SaealibError
+        assert ValErr is ValidationError
+        assert CfgErr is ConfigurationError
 
 
 class TestMinimizeBoundary:
@@ -60,21 +60,15 @@ class TestMinimizeBoundary:
 
     def test_surrogate_none(self):
         with pytest.raises(ValidationError):
-            saealib.minimize(
-                lambda x: x, dim=1, lb=[0], ub=[1], surrogate=None
-            )
+            saealib.minimize(lambda x: x, dim=1, lb=[0], ub=[1], surrogate=None)
 
     def test_unknown_surrogate(self):
         with pytest.raises(ValidationError):
-            saealib.minimize(
-                lambda x: x, dim=1, lb=[0], ub=[1], surrogate="unknown"
-            )
+            saealib.minimize(lambda x: x, dim=1, lb=[0], ub=[1], surrogate="unknown")
 
     def test_unknown_strategy(self):
         with pytest.raises(ValidationError):
-            saealib.minimize(
-                lambda x: x, dim=1, lb=[0], ub=[1], strategy="unknown"
-            )
+            saealib.minimize(lambda x: x, dim=1, lb=[0], ub=[1], strategy="unknown")
 
     def test_missing_dim(self):
         with pytest.raises(ValidationError):
@@ -82,9 +76,7 @@ class TestMinimizeBoundary:
 
     def test_unknown_direction(self):
         with pytest.raises(ValidationError):
-            saealib.minimize(
-                lambda x: x, dim=1, lb=[0], ub=[1], direction=["minimise"]
-            )
+            saealib.minimize(lambda x: x, dim=1, lb=[0], ub=[1], direction=["minimise"])
 
 
 class TestOptimizerBoundary:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,114 @@
+"""Regression tests for saealib.exceptions hierarchy and public boundary raises."""
+
+import pytest
+
+import saealib
+from saealib.exceptions import ConfigurationError, SaealibError, ValidationError
+
+
+class TestHierarchy:
+    def test_saealib_error_is_exception(self):
+        assert issubclass(SaealibError, Exception)
+
+    def test_validation_error_bases(self):
+        assert issubclass(ValidationError, SaealibError)
+        assert issubclass(ValidationError, ValueError)
+
+    def test_configuration_error_bases(self):
+        assert issubclass(ConfigurationError, SaealibError)
+        assert issubclass(ConfigurationError, ValueError)
+
+    def test_validation_error_catchable_as_value_error(self):
+        with pytest.raises(ValueError):
+            raise ValidationError("bad input")
+
+    def test_configuration_error_catchable_as_value_error(self):
+        with pytest.raises(ValueError):
+            raise ConfigurationError("misconfigured")
+
+    def test_both_catchable_as_saealib_error(self):
+        with pytest.raises(SaealibError):
+            raise ValidationError("x")
+        with pytest.raises(SaealibError):
+            raise ConfigurationError("x")
+
+
+class TestTopLevelExport:
+    def test_exported_in_all(self):
+        assert "SaealibError" in saealib.__all__
+        assert "ValidationError" in saealib.__all__
+        assert "ConfigurationError" in saealib.__all__
+
+    def test_importable_from_top_level(self):
+        from saealib import ConfigurationError as CE
+        from saealib import SaealibError as SE
+        from saealib import ValidationError as VE
+
+        assert SE is SaealibError
+        assert VE is ValidationError
+        assert CE is ConfigurationError
+
+
+class TestMinimizeBoundary:
+    def test_unknown_algorithm(self):
+        with pytest.raises(ValidationError):
+            saealib.minimize(lambda x: x, dim=1, lb=[0], ub=[1], algorithm="unknown")
+
+    def test_unknown_algorithm_still_value_error(self):
+        with pytest.raises(ValueError):
+            saealib.minimize(lambda x: x, dim=1, lb=[0], ub=[1], algorithm="unknown")
+
+    def test_surrogate_none(self):
+        with pytest.raises(ValidationError):
+            saealib.minimize(
+                lambda x: x, dim=1, lb=[0], ub=[1], surrogate=None
+            )
+
+    def test_unknown_surrogate(self):
+        with pytest.raises(ValidationError):
+            saealib.minimize(
+                lambda x: x, dim=1, lb=[0], ub=[1], surrogate="unknown"
+            )
+
+    def test_unknown_strategy(self):
+        with pytest.raises(ValidationError):
+            saealib.minimize(
+                lambda x: x, dim=1, lb=[0], ub=[1], strategy="unknown"
+            )
+
+    def test_missing_dim(self):
+        with pytest.raises(ValidationError):
+            saealib.minimize(lambda x: x, lb=[0], ub=[1])
+
+    def test_unknown_direction(self):
+        with pytest.raises(ValidationError):
+            saealib.minimize(
+                lambda x: x, dim=1, lb=[0], ub=[1], direction=["minimise"]
+            )
+
+
+class TestOptimizerBoundary:
+    def _incomplete_optimizer(self) -> saealib.Optimizer:
+        import numpy as np
+
+        problem = saealib.Problem(
+            func=lambda x: np.sum(x),
+            dim=2,
+            n_obj=1,
+            direction=np.array([-1.0]),
+            lb=[-5.0, -5.0],
+            ub=[5.0, 5.0],
+        )
+        return saealib.Optimizer(problem)  # no algorithm/strategy/termination set
+
+    def test_misconfigured_run_raises_configuration_error(self):
+        with pytest.raises(ConfigurationError, match="Optimizer misconfigured"):
+            self._incomplete_optimizer().run()
+
+    def test_misconfigured_run_still_value_error(self):
+        with pytest.raises(ValueError, match="Optimizer misconfigured"):
+            self._incomplete_optimizer().run()
+
+    def test_misconfigured_iterate_raises_configuration_error(self):
+        with pytest.raises(ConfigurationError, match="Optimizer misconfigured"):
+            next(self._incomplete_optimizer().iterate())


### PR DESCRIPTION
## Related Issue
Closes #139

## Overview
Introduce `saealib.exceptions` with a `SaealibError` base class and two derived exceptions (`ValidationError`, `ConfigurationError`). Derived classes inherit from the matching built-in (`ValueError`) for backward compatibility.

## Changes
- Add `src/saealib/exceptions.py` (`SaealibError`, `ValidationError`, `ConfigurationError`)
- Export all three from top-level `saealib` namespace (Tier 1)
- Replace `ValueError` with `ValidationError` at `minimize`/`maximize` boundaries (`api.py`, `problem/problem.py`)
- Replace `ValueError` with `ConfigurationError` at `Optimizer.run`/`iterate` (`optimizer.py`)
- Add `tests/test_exceptions.py` (18 tests covering hierarchy, exports, and boundary raises)

## Verification Steps
run pytest (tests/test_exceptions.py)

## Concerns
- `ConfigurationError` inherits `ValueError` to keep existing `pytest.raises(ValueError)` assertions in `test_optimizer_validate.py` passing without modification.
- Internal `raise` sites (acquisition, surrogate, etc.) are out of scope and left as a follow-up.

## Other
