### PR TITLE
feat: [#143] Add on_generation_end lifecycle hook to SurrogateManager

### DIFF
--- a/src/saealib/execution/runner.py
+++ b/src/saealib/execution/runner.py
@@ -57,6 +57,9 @@ class Runner:
             handler = ctx.problem.handler
             handler.on_generation_end(ctx.gen, ctx.population)
             ctx.comparator.eps_cv = handler.feasibility_threshold
+            sm = getattr(opt, "surrogate_manager", None)
+            if sm is not None:
+                sm.on_generation_end(ctx.gen, ctx.archive, ctx)
             opt.dispatch(GenerationEndEvent(ctx=ctx))
             yield ctx
 

--- a/src/saealib/surrogate/manager.py
+++ b/src/saealib/surrogate/manager.py
@@ -168,6 +168,44 @@ class SurrogateManager(ABC):
         )
         return new
 
+    def on_generation_end(
+        self,
+        gen: int,
+        archive: Archive,
+        ctx: OptimizationContext | None = None,
+    ) -> None:
+        """End-of-generation hook; override to update internal state."""
+
+    def with_on_generation_end(
+        self,
+        fn: Callable[[int, Archive, OptimizationContext | None], None],
+    ) -> SurrogateManager:
+        """Return a copy of this manager with ``fn`` appended to the hook.
+
+        Parameters
+        ----------
+        fn : callable
+            ``fn(gen, archive, ctx) -> None``
+
+        Returns
+        -------
+        SurrogateManager
+            Shallow copy with the hook registered.
+        """
+        new = copy.copy(self)
+        prev = self.on_generation_end
+
+        def _chained(
+            gen: int,
+            archive: Archive,
+            ctx: OptimizationContext | None = None,
+        ) -> None:
+            prev(gen, archive, ctx)
+            fn(gen, archive, ctx)
+
+        new.on_generation_end = _chained
+        return new
+
 
 class GlobalSurrogateManager(SurrogateManager):
     """

--- a/tests/test_surrogate_manager.py
+++ b/tests/test_surrogate_manager.py
@@ -999,3 +999,67 @@ class TestSurrogateManagerHooks:
         )
         manager.score_candidates(candidates, archive_1obj)
         assert call_count[0] == len(candidates)
+
+
+# ===========================================================================
+# SurrogateManager.on_generation_end / with_on_generation_end
+# ===========================================================================
+
+
+class TestSurrogateManagerGenerationHook:
+    """Tests for SurrogateManager.on_generation_end and with_on_generation_end."""
+
+    def test_on_generation_end_default_is_noop(
+        self,
+        surrogate_1obj: RBFsurrogate,
+        archive_1obj: Archive,
+    ) -> None:
+        manager = GlobalSurrogateManager(surrogate_1obj, MeanPrediction())
+        assert manager.on_generation_end(0, archive_1obj, ctx=None) is None
+
+    def test_with_on_generation_end_fn_is_called(
+        self,
+        surrogate_1obj: RBFsurrogate,
+        archive_1obj: Archive,
+    ) -> None:
+        calls: list[tuple] = []
+
+        def hook(gen, archive, ctx):
+            calls.append((gen, archive, ctx))
+
+        manager = GlobalSurrogateManager(
+            surrogate_1obj, MeanPrediction()
+        ).with_on_generation_end(hook)
+        manager.on_generation_end(3, archive_1obj, ctx=None)
+
+        assert len(calls) == 1
+        assert calls[0] == (3, archive_1obj, None)
+
+    def test_with_on_generation_end_chains_in_order(
+        self,
+        surrogate_1obj: RBFsurrogate,
+        archive_1obj: Archive,
+    ) -> None:
+        order: list[int] = []
+        manager = (
+            GlobalSurrogateManager(surrogate_1obj, MeanPrediction())
+            .with_on_generation_end(lambda g, a, ctx: order.append(1))
+            .with_on_generation_end(lambda g, a, ctx: order.append(2))
+        )
+        manager.on_generation_end(0, archive_1obj)
+        assert order == [1, 2]
+
+    def test_with_on_generation_end_does_not_mutate_original(
+        self,
+        surrogate_1obj: RBFsurrogate,
+        archive_1obj: Archive,
+    ) -> None:
+        called = [False]
+
+        def hook(g, a, ctx):
+            called[0] = True
+
+        original = GlobalSurrogateManager(surrogate_1obj, MeanPrediction())
+        _ = original.with_on_generation_end(hook)
+        original.on_generation_end(0, archive_1obj)
+        assert not called[0]


### PR DESCRIPTION
## Related Issue
Closes #143

## Overview
Adds `on_generation_end(gen, archive, ctx=None)` lifecycle hook to `SurrogateManager`, following the same pattern as `ConstraintHandler.on_generation_end`. This enables surrogate implementations (e.g. Augmented Lagrangian) to update internal state per generation after `tell()`.

## Changes
- `SurrogateManager`: add `on_generation_end` as a no-op default and `with_on_generation_end(fn)` utility mirroring `with_post_score`
- `Runner.iterate()`: call `surrogate_manager.on_generation_end(gen, archive, ctx)` each generation, guarded for absent surrogate manager
- Tests: cover default no-op, hook invocation, chaining order, and immutability of original

## Verification Steps
run pytest

## Concerns
- `surrogate_manager` is optional on `Optimizer`; the runner guard (`getattr` + `None` check) is intentional and mirrors `Optimizer.validate()`.