### PR TITLE
fix: [#147] GenerationBasedStrategy re-fits surrogate every surrogate generation despite unchanged archive

### DIFF
--- a/src/saealib/strategies/gb.py
+++ b/src/saealib/strategies/gb.py
@@ -40,6 +40,8 @@ class GenerationBasedStrategy(OptimizationStrategy):
             Component provider.
         """
         # --- surrogate inner loop ---
+        if self.gen_ctrl > 0:
+            provider.surrogate_manager.fit(ctx.archive, ctx)
         for _ in range(self.gen_ctrl):
             ctx.count_generation()
             offspring = provider.algorithm.ask(ctx, provider)
@@ -47,7 +49,7 @@ class GenerationBasedStrategy(OptimizationStrategy):
             provider.dispatch(SurrogateStartEvent(ctx=ctx, offspring=offspring))
 
             _, predictions = provider.surrogate_manager.score_candidates(
-                offspring.x, ctx.archive, ctx
+                offspring.x, ctx.archive, ctx, refit=False
             )
             for i, pred in enumerate(predictions):
                 assign_tell_f(offspring[i], pred, ctx)

--- a/src/saealib/surrogate/archive_manager.py
+++ b/src/saealib/surrogate/archive_manager.py
@@ -56,7 +56,7 @@ class ArchiveBasedManager(SurrogateManager):
         archive: Archive,
         ctx: OptimizationContext | None = None,
         *,
-        refit: bool = True,  # noqa: ARG002 — no surrogate to fit
+        refit: bool = True,
     ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
         """Compute scores and wrap results in SurrogatePrediction with tell_f=NaN."""
         scores = self.compute_scores(candidates_x, archive, ctx)

--- a/src/saealib/surrogate/archive_manager.py
+++ b/src/saealib/surrogate/archive_manager.py
@@ -55,6 +55,8 @@ class ArchiveBasedManager(SurrogateManager):
         candidates_x: np.ndarray,
         archive: Archive,
         ctx: OptimizationContext | None = None,
+        *,
+        refit: bool = True,  # noqa: ARG002 — no surrogate to fit
     ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
         """Compute scores and wrap results in SurrogatePrediction with tell_f=NaN."""
         scores = self.compute_scores(candidates_x, archive, ctx)

--- a/src/saealib/surrogate/manager.py
+++ b/src/saealib/surrogate/manager.py
@@ -344,7 +344,7 @@ class LocalSurrogateManager(SurrogateManager):
         archive: Archive,
         ctx: OptimizationContext | None = None,
         *,
-        refit: bool = True,  # noqa: ARG002 — per-candidate fit is always done
+        refit: bool = True,
     ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
         """Fit a local model per candidate and score each individually."""
         predictions: list[SurrogatePrediction] = []

--- a/src/saealib/surrogate/manager.py
+++ b/src/saealib/surrogate/manager.py
@@ -88,12 +88,36 @@ class SurrogateManager(ABC):
             )
         return scores, predictions
 
+    def fit(
+        self,
+        archive: Archive,
+        ctx: OptimizationContext | None = None,
+    ) -> None:
+        """
+        Pre-fit the surrogate on the archive.
+
+        Call once before a sequence of ``score_candidates(..., refit=False)``
+        calls when the archive does not change between calls (e.g. the
+        surrogate-only inner loop of ``GenerationBasedStrategy``).
+        The default implementation is a no-op; override in managers that
+        maintain a fitted surrogate model.
+
+        Parameters
+        ----------
+        archive : Archive
+            Archive of evaluated solutions used for surrogate training.
+        ctx : OptimizationContext or None, optional
+            Current optimization context.
+        """
+
     @abstractmethod
     def score_candidates(
         self,
         candidates_x: np.ndarray,
         archive: Archive,
         ctx: OptimizationContext | None = None,
+        *,
+        refit: bool = True,
     ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
         """
         Score candidate solutions using the surrogate model.
@@ -107,6 +131,10 @@ class SurrogateManager(ABC):
         ctx : OptimizationContext or None, optional
             Current optimization context. Passed to ``TrainingSet.build``
             for strategies that require comparator or population access.
+        refit : bool, optional
+            If ``True`` (default), fit the surrogate before scoring.
+            Pass ``False`` after an explicit :meth:`fit` call to skip
+            redundant re-fitting when the archive has not changed.
 
         Returns
         -------
@@ -238,17 +266,28 @@ class GlobalSurrogateManager(SurrogateManager):
             training_set if training_set is not None else ArchiveObjectiveSet()
         )
 
+    def fit(
+        self,
+        archive: Archive,
+        ctx: OptimizationContext | None = None,
+    ) -> None:
+        """Fit the surrogate on the full archive."""
+        population = ctx.population if ctx is not None else None
+        data = self.training_set.build(archive, population, ctx, candidate_x=None)
+        self.surrogate.fit(data.train_x, data.train_y)
+        self.surrogate.post_fit(data.train_x, data.train_y, ctx)
+
     def score_candidates(
         self,
         candidates_x: np.ndarray,
         archive: Archive,
         ctx: OptimizationContext | None = None,
+        *,
+        refit: bool = True,
     ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
         """Fit on full archive, predict and score all candidates at once."""
-        population = ctx.population if ctx is not None else None
-        data = self.training_set.build(archive, population, ctx, candidate_x=None)
-        self.surrogate.fit(data.train_x, data.train_y)
-        self.surrogate.post_fit(data.train_x, data.train_y, ctx)
+        if refit:
+            self.fit(archive, ctx)
 
         reference = self.acquisition.compute_reference(archive)
         prediction = self.surrogate.predict(candidates_x)  # mean: (n_candidates, n_obj)
@@ -304,6 +343,8 @@ class LocalSurrogateManager(SurrogateManager):
         candidates_x: np.ndarray,
         archive: Archive,
         ctx: OptimizationContext | None = None,
+        *,
+        refit: bool = True,  # noqa: ARG002 — per-candidate fit is always done
     ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
         """Fit a local model per candidate and score each individually."""
         predictions: list[SurrogatePrediction] = []
@@ -418,11 +459,22 @@ class CompositeSurrogateManager(SurrogateManager):
         self.managers = managers
         self.combine_fn = combine_fn
 
+    def fit(
+        self,
+        archive: Archive,
+        ctx: OptimizationContext | None = None,
+    ) -> None:
+        """Pre-fit all sub-managers."""
+        for manager in self.managers:
+            manager.fit(archive, ctx)
+
     def score_candidates(
         self,
         candidates_x: np.ndarray,
         archive: Archive,
         ctx: OptimizationContext | None = None,
+        *,
+        refit: bool = True,
     ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
         """Combine scores from all sub-managers using ``combine_fn``.
 
@@ -432,7 +484,9 @@ class CompositeSurrogateManager(SurrogateManager):
         first_predictions: list[SurrogatePrediction] | None = None
 
         for i, manager in enumerate(self.managers):
-            scores, preds = manager.score_candidates(candidates_x, archive, ctx)
+            scores, preds = manager.score_candidates(
+                candidates_x, archive, ctx, refit=refit
+            )
             all_scores.append(scores)
             if i == 0:
                 first_predictions = preds

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -207,7 +207,7 @@ class TestGenerationBasedStrategy:
 
         strategy.step(ctx, provider)
 
-        # refit=False passed by gb.py, but LocalSurrogateManager still fits per candidate
+        # LocalSurrogateManager always fits per candidate; refit=False is ignored
         n_offspring = len(ctx.population)
         assert fit_count[0] == n_offspring
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -6,6 +6,8 @@ Tests cover:
 - PreSelectionStrategy: fe count equals n_select, archive growth, n_select cap
 """
 
+import operator
+
 import numpy as np
 
 from saealib import (
@@ -27,6 +29,7 @@ from saealib.strategies.ps import PreSelectionStrategy
 from saealib.surrogate.archive_manager import DensityManager, NoveltyManager
 from saealib.surrogate.manager import (
     CompositeSurrogateManager,
+    GlobalSurrogateManager,
     LocalSurrogateManager,
     rank_weighted_combine,
 )
@@ -97,7 +100,10 @@ def _make_ga() -> GA:
 class _MockSurrogateManager:
     """Returns uniform scores and constant predictions."""
 
-    def score_candidates(self, candidates_x, archive, ctx=None):
+    def fit(self, archive, ctx=None):
+        pass
+
+    def score_candidates(self, candidates_x, archive, ctx=None, *, refit=True):
         n = len(candidates_x)
         scores = np.linspace(1.0, 0.0, n)
         predictions = [
@@ -170,6 +176,40 @@ class TestGenerationBasedStrategy:
         strategy.step(ctx, provider)
         assert ctx.gen == 1
         assert ctx.fe == len(ctx.population)
+
+    def test_surrogate_fit_called_once_per_step(self):
+        """fit() must be called exactly once per step(), not once per surrogate gen."""
+        fit_count = [0]
+
+        ctx = _make_ctx()
+        surrogate = RBFsurrogate(gaussian_kernel, DIM).with_post_fit(
+            lambda tx, ty, c: operator.setitem(fit_count, 0, fit_count[0] + 1)
+        )
+        manager = GlobalSurrogateManager(surrogate, MeanPrediction())
+        provider = _MockProvider(_make_ga(), manager)
+        strategy = GenerationBasedStrategy(gen_ctrl=3)
+
+        strategy.step(ctx, provider)
+
+        assert fit_count[0] == 1
+
+    def test_local_surrogate_refit_false_ignored(self):
+        """LocalSurrogateManager always fits per candidate; refit=False is a no-op."""
+        fit_count = [0]
+
+        ctx = _make_ctx()
+        surrogate = RBFsurrogate(gaussian_kernel, DIM).with_post_fit(
+            lambda tx, ty, c: operator.setitem(fit_count, 0, fit_count[0] + 1)
+        )
+        manager = LocalSurrogateManager(surrogate, MeanPrediction())
+        provider = _MockProvider(_make_ga(), manager)
+        strategy = GenerationBasedStrategy(gen_ctrl=1)
+
+        strategy.step(ctx, provider)
+
+        # refit=False passed by gb.py, but LocalSurrogateManager still fits per candidate
+        n_offspring = len(ctx.population)
+        assert fit_count[0] == n_offspring
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Related Issue
Closes #147

## Overview

`GenerationBasedStrategy` called `surrogate.fit()` once per surrogate generation inside its inner loop, even though the archive does not change between surrogate generations. For `gen_ctrl=5`, this caused 5 redundant fits with identical training data per `step()` call — a significant bottleneck for heavy surrogates (GP, SVR).

## Changes

- `SurrogateManager`: add `fit(archive, ctx)` (no-op default) and `refit: bool = True` keyword argument to `score_candidates()`
- `GlobalSurrogateManager`: override `fit()` to perform build + surrogate fit + post-fit; `score_candidates()` skips fit when `refit=False`
- `CompositeSurrogateManager`: override `fit()` to fan out to sub-managers; propagate `refit` through `score_candidates()`
- `LocalSurrogateManager` / `ArchiveBasedManager`: accept `refit` in signature (ignored — per-candidate or archive-based fit is always performed)
- `GenerationBasedStrategy`: call `surrogate_manager.fit()` once before the surrogate loop; pass `refit=False` inside the loop

## Verification Steps
run pytest

## Concerns

- `refit=False` before an explicit `fit()` call leaves the surrogate in an unfitted state. This is a caller contract, not guarded internally — consistent with how sklearn-style APIs work.
- `LocalSurrogateManager` silently ignores `refit=False`. The `refit` parameter is part of the ABC contract for uniformity; the per-candidate fit inside `score_candidates()` is intentional and cannot be skipped.

## Other

N/A
