### PR TITLE
feat: [#79] Surrogate self-evaluation and dynamic switching

### DIFF
--- a/src/saealib/__init__.pyi
+++ b/src/saealib/__init__.pyi
@@ -139,6 +139,10 @@ from saealib.surrogate import PerObjectiveSurrogate as PerObjectiveSurrogate
 from saealib.surrogate import RBFsurrogate as RBFsurrogate
 from saealib.surrogate import SklearnSurrogate as SklearnSurrogate
 from saealib.surrogate import Surrogate as Surrogate
+from saealib.surrogate import AccuracyBasedSurrogateSwitcher as AccuracyBasedSurrogateSwitcher
+from saealib.surrogate import GenCtrlSwitcher as GenCtrlSwitcher
+from saealib.surrogate import ManagerSwitcher as ManagerSwitcher
+from saealib.surrogate import StrategySwitcher as StrategySwitcher
 from saealib.surrogate import SurrogateManager as SurrogateManager
 from saealib.surrogate import SurrogatePrediction as SurrogatePrediction
 from saealib.surrogate import SVMSurrogate as SVMSurrogate

--- a/src/saealib/__init__.pyi
+++ b/src/saealib/__init__.pyi
@@ -122,27 +122,29 @@ from saealib.strategies import GenerationBasedStrategy as GenerationBasedStrateg
 from saealib.strategies import IndividualBasedStrategy as IndividualBasedStrategy
 from saealib.strategies import OptimizationStrategy as OptimizationStrategy
 from saealib.strategies import PreSelectionStrategy as PreSelectionStrategy
+from saealib.surrogate import (
+    AccuracyBasedSurrogateSwitcher as AccuracyBasedSurrogateSwitcher,
+)
 
 # surrogate (specialized)
 from saealib.surrogate import ArchiveBasedManager as ArchiveBasedManager
 from saealib.surrogate import CompositeSurrogateManager as CompositeSurrogateManager
 from saealib.surrogate import DensityManager as DensityManager
 from saealib.surrogate import DTSurrogate as DTSurrogate
+from saealib.surrogate import GenCtrlSwitcher as GenCtrlSwitcher
 from saealib.surrogate import GlobalSurrogateManager as GlobalSurrogateManager
 from saealib.surrogate import GPRSurrogate as GPRSurrogate
 from saealib.surrogate import LGBMSurrogate as LGBMSurrogate
 from saealib.surrogate import LocalSurrogateManager as LocalSurrogateManager
+from saealib.surrogate import ManagerSwitcher as ManagerSwitcher
 from saealib.surrogate import NichingManager as NichingManager
 from saealib.surrogate import NNSurrogate as NNSurrogate
 from saealib.surrogate import NoveltyManager as NoveltyManager
 from saealib.surrogate import PerObjectiveSurrogate as PerObjectiveSurrogate
 from saealib.surrogate import RBFsurrogate as RBFsurrogate
 from saealib.surrogate import SklearnSurrogate as SklearnSurrogate
-from saealib.surrogate import Surrogate as Surrogate
-from saealib.surrogate import AccuracyBasedSurrogateSwitcher as AccuracyBasedSurrogateSwitcher
-from saealib.surrogate import GenCtrlSwitcher as GenCtrlSwitcher
-from saealib.surrogate import ManagerSwitcher as ManagerSwitcher
 from saealib.surrogate import StrategySwitcher as StrategySwitcher
+from saealib.surrogate import Surrogate as Surrogate
 from saealib.surrogate import SurrogateManager as SurrogateManager
 from saealib.surrogate import SurrogatePrediction as SurrogatePrediction
 from saealib.surrogate import SVMSurrogate as SVMSurrogate

--- a/src/saealib/strategies/gb.py
+++ b/src/saealib/strategies/gb.py
@@ -5,6 +5,8 @@ Each call to ``step`` runs ``gen_ctrl`` surrogate-only generations followed
 by one generation of true objective evaluations.
 """
 
+from __future__ import annotations
+
 from saealib.callback import PostEvaluationEvent, SurrogateEndEvent, SurrogateStartEvent
 from saealib.context import OptimizationContext
 from saealib.optimizer import ComponentProvider
@@ -12,25 +14,22 @@ from saealib.strategies.base import OptimizationStrategy, assign_tell_f
 
 
 class GenerationBasedStrategy(OptimizationStrategy):
-    """Generation-based strategy."""
+    """Generation-based strategy.
+
+    Parameters
+    ----------
+    gen_ctrl : int
+        Number of surrogate-only generations executed inside each :meth:`step`
+        call before one generation of true objective evaluation.
+    """
 
     requires_surrogate: bool = True
 
-    def __init__(self, gen_ctrl: int):
-        """
-        Initialize GenerationBasedStrategy.
-
-        Parameters
-        ----------
-        gen_ctrl : int
-            Number of surrogate-only generations executed inside each ``step``
-            call before one generation of true objective evaluation.
-        """
+    def __init__(self, gen_ctrl: int) -> None:
         self.gen_ctrl = gen_ctrl
 
     def step(self, ctx: OptimizationContext, provider: ComponentProvider) -> None:
-        """
-        Run ``gen_ctrl`` surrogate-only generations, then one true-evaluation step.
+        """Run ``gen_ctrl`` surrogate-only generations, then one true-evaluation step.
 
         Parameters
         ----------

--- a/src/saealib/surrogate/__init__.py
+++ b/src/saealib/surrogate/__init__.py
@@ -25,12 +25,6 @@ from saealib.surrogate.manager import (
     rank_weighted_combine,
 )
 from saealib.surrogate.per_objective import PerObjectiveSurrogate
-from saealib.surrogate.switching import (
-    AccuracyBasedSurrogateSwitcher,
-    GenCtrlSwitcher,
-    ManagerSwitcher,
-    StrategySwitcher,
-)
 from saealib.surrogate.prediction import SurrogatePrediction
 from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
 from saealib.surrogate.sklearn_surrogate import (
@@ -41,6 +35,12 @@ from saealib.surrogate.sklearn_surrogate import (
     SklearnSurrogate,
     SVMSurrogate,
     XGBSurrogate,
+)
+from saealib.surrogate.switching import (
+    AccuracyBasedSurrogateSwitcher,
+    GenCtrlSwitcher,
+    ManagerSwitcher,
+    StrategySwitcher,
 )
 from saealib.surrogate.torch_surrogate import TorchSurrogate
 from saealib.surrogate.training_set import (
@@ -58,6 +58,7 @@ from saealib.surrogate.training_set import (
 
 __all__ = [
     "RMSE",
+    "AccuracyBasedSurrogateSwitcher",
     "AccuracyEvaluator",
     "ArchiveBasedManager",
     "ArchiveObjectiveSet",
@@ -67,6 +68,7 @@ __all__ = [
     "DensityManager",
     "FeasibilityClassificationSet",
     "GPRSurrogate",
+    "GenCtrlSwitcher",
     "GlobalSurrogateManager",
     "HeldOutAccuracyEvaluator",
     "KFoldAccuracyEvaluator",
@@ -76,6 +78,7 @@ __all__ = [
     "LOOAccuracyEvaluator",
     "LevelBasedSet",
     "LocalSurrogateManager",
+    "ManagerSwitcher",
     "NNSurrogate",
     "NichingManager",
     "NoveltyManager",
@@ -86,15 +89,12 @@ __all__ = [
     "SVMSurrogate",
     "SklearnSurrogate",
     "SpearmanCorrelation",
+    "StrategySwitcher",
     "Surrogate",
     "SurrogateAccuracy",
     "SurrogateAccuracyMetric",
-    "AccuracyBasedSurrogateSwitcher",
-    "GenCtrlSwitcher",
-    "ManagerSwitcher",
     "SurrogateManager",
     "SurrogatePrediction",
-    "StrategySwitcher",
     "TopKBipartitionSet",
     "TorchSurrogate",
     "TrainingData",

--- a/src/saealib/surrogate/__init__.py
+++ b/src/saealib/surrogate/__init__.py
@@ -1,3 +1,14 @@
+from saealib.surrogate.accuracy import (
+    RMSE,
+    AccuracyEvaluator,
+    HeldOutAccuracyEvaluator,
+    KFoldAccuracyEvaluator,
+    LOOAccuracyEvaluator,
+    R2Score,
+    SpearmanCorrelation,
+    SurrogateAccuracy,
+    SurrogateAccuracyMetric,
+)
 from saealib.surrogate.archive_manager import (
     ArchiveBasedManager,
     DensityManager,
@@ -40,6 +51,8 @@ from saealib.surrogate.training_set import (
 )
 
 __all__ = [
+    "RMSE",
+    "AccuracyEvaluator",
     "ArchiveBasedManager",
     "ArchiveObjectiveSet",
     "CompositeSurrogateManager",
@@ -49,9 +62,12 @@ __all__ = [
     "FeasibilityClassificationSet",
     "GPRSurrogate",
     "GlobalSurrogateManager",
+    "HeldOutAccuracyEvaluator",
+    "KFoldAccuracyEvaluator",
     "KNNConstraintObjectiveSet",
     "KNNObjectiveSet",
     "LGBMSurrogate",
+    "LOOAccuracyEvaluator",
     "LevelBasedSet",
     "LocalSurrogateManager",
     "NNSurrogate",
@@ -59,10 +75,14 @@ __all__ = [
     "NoveltyManager",
     "PairwiseComparisonSet",
     "PerObjectiveSurrogate",
+    "R2Score",
     "RBFsurrogate",
     "SVMSurrogate",
     "SklearnSurrogate",
+    "SpearmanCorrelation",
     "Surrogate",
+    "SurrogateAccuracy",
+    "SurrogateAccuracyMetric",
     "SurrogateManager",
     "SurrogatePrediction",
     "TopKBipartitionSet",

--- a/src/saealib/surrogate/__init__.py
+++ b/src/saealib/surrogate/__init__.py
@@ -25,6 +25,12 @@ from saealib.surrogate.manager import (
     rank_weighted_combine,
 )
 from saealib.surrogate.per_objective import PerObjectiveSurrogate
+from saealib.surrogate.switching import (
+    AccuracyBasedSurrogateSwitcher,
+    GenCtrlSwitcher,
+    ManagerSwitcher,
+    StrategySwitcher,
+)
 from saealib.surrogate.prediction import SurrogatePrediction
 from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
 from saealib.surrogate.sklearn_surrogate import (
@@ -83,8 +89,12 @@ __all__ = [
     "Surrogate",
     "SurrogateAccuracy",
     "SurrogateAccuracyMetric",
+    "AccuracyBasedSurrogateSwitcher",
+    "GenCtrlSwitcher",
+    "ManagerSwitcher",
     "SurrogateManager",
     "SurrogatePrediction",
+    "StrategySwitcher",
     "TopKBipartitionSet",
     "TorchSurrogate",
     "TrainingData",

--- a/src/saealib/surrogate/accuracy.py
+++ b/src/saealib/surrogate/accuracy.py
@@ -1,0 +1,369 @@
+"""
+Surrogate accuracy metrics and evaluators.
+
+Classes
+-------
+SurrogateAccuracyMetric
+    Abstract base for accuracy metric computation.
+SpearmanCorrelation
+    Rank correlation between predicted and true values (primary metric).
+RMSE
+    Root mean squared error of predictions.
+R2Score
+    Coefficient of determination (R²).
+SurrogateAccuracy
+    Container for computed accuracy metrics.
+AccuracyEvaluator
+    Abstract base for surrogate accuracy evaluators.
+KFoldAccuracyEvaluator
+    Evaluates accuracy via k-fold cross-validation.
+LOOAccuracyEvaluator
+    Evaluates accuracy via leave-one-out cross-validation.
+HeldOutAccuracyEvaluator
+    Evaluates accuracy against pre-specified held-out data.
+"""
+
+from __future__ import annotations
+
+import copy
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+from scipy.stats import spearmanr
+
+if TYPE_CHECKING:
+    from saealib.surrogate.base import Surrogate
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+
+class SurrogateAccuracyMetric(ABC):
+    """Abstract base for a scalar accuracy metric."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Metric identifier used as key in :attr:`SurrogateAccuracy.metrics`."""
+        ...
+
+    @abstractmethod
+    def compute(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        """Compute the metric.
+
+        Parameters
+        ----------
+        y_true : np.ndarray
+            True objective values. shape: (n_samples, n_obj)
+        y_pred : np.ndarray
+            Predicted objective values. Same shape as ``y_true``.
+
+        Returns
+        -------
+        float
+            Scalar metric value. Interpretation (higher/lower = better)
+            depends on the concrete metric.
+        """
+        ...
+
+
+class SpearmanCorrelation(SurrogateAccuracyMetric):
+    """Spearman rank correlation averaged over objectives.
+
+    Measures whether the surrogate preserves the ranking of candidates,
+    which is the primary criterion in EA contexts (Sun et al., 2019).
+    Range: [-1, 1]. Higher is better.
+    """
+
+    @property
+    def name(self) -> str:
+        """Return ``"spearman"``."""
+        return "spearman"
+
+    def compute(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        """Compute Spearman rank correlation, averaged over objectives."""
+        y_true = np.atleast_2d(y_true.T).T
+        y_pred = np.atleast_2d(y_pred.T).T
+        rhos = []
+        for j in range(y_true.shape[1]):
+            result = spearmanr(y_true[:, j], y_pred[:, j])
+            rho = float(result.statistic)
+            rhos.append(0.0 if np.isnan(rho) else rho)
+        return float(np.mean(rhos))
+
+
+class RMSE(SurrogateAccuracyMetric):
+    """Root mean squared error.
+
+    Range: [0, ∞). Lower is better.
+    """
+
+    @property
+    def name(self) -> str:
+        """Return ``"rmse"``."""
+        return "rmse"
+
+    def compute(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        """Compute RMSE between true and predicted values."""
+        return float(np.sqrt(np.mean((y_true - y_pred) ** 2)))
+
+
+class R2Score(SurrogateAccuracyMetric):
+    """Coefficient of determination (R²).
+
+    Range: (-∞, 1]. Higher is better. 1.0 = perfect fit.
+    """
+
+    @property
+    def name(self) -> str:
+        """Return ``"r2"``."""
+        return "r2"
+
+    def compute(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        """Compute R² between true and predicted values."""
+        ss_res = np.sum((y_true - y_pred) ** 2)
+        ss_tot = np.sum((y_true - np.mean(y_true, axis=0)) ** 2)
+        if ss_tot == 0.0:
+            return 1.0 if ss_res == 0.0 else 0.0
+        return float(1.0 - ss_res / ss_tot)
+
+
+# ---------------------------------------------------------------------------
+# Accuracy container
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SurrogateAccuracy:
+    """Container for surrogate accuracy metrics computed after a fit.
+
+    Attributes
+    ----------
+    metrics : dict[str, float]
+        Mapping from metric name (e.g. ``"spearman"``) to scalar value.
+    n_samples : int
+        Number of training samples used for evaluation.
+    """
+
+    metrics: dict[str, float] = field(default_factory=dict)
+    n_samples: int = 0
+
+    def get(self, name: str, default: float = float("nan")) -> float:
+        """Return metric value by name, or *default* if not present."""
+        return self.metrics.get(name, default)
+
+
+_DEFAULT_METRICS: list[SurrogateAccuracyMetric] = [
+    SpearmanCorrelation(),
+    RMSE(),
+    R2Score(),
+]
+
+
+# ---------------------------------------------------------------------------
+# Evaluators
+# ---------------------------------------------------------------------------
+
+
+class AccuracyEvaluator(ABC):
+    """Abstract base for surrogate accuracy evaluators.
+
+    Subclasses implement different evaluation strategies (k-fold CV, LOO,
+    held-out). All share the same :meth:`evaluate` interface so they can be
+    injected into :class:`~saealib.surrogate.manager.GlobalSurrogateManager`
+    interchangeably.
+
+    Parameters
+    ----------
+    metrics : list[SurrogateAccuracyMetric] or None
+        Metrics to compute. Defaults to
+        :class:`SpearmanCorrelation`, :class:`RMSE`, :class:`R2Score`.
+    """
+
+    def __init__(
+        self,
+        metrics: list[SurrogateAccuracyMetric] | None = None,
+    ):
+        self.metrics: list[SurrogateAccuracyMetric] = (
+            metrics if metrics is not None else list(_DEFAULT_METRICS)
+        )
+
+    @abstractmethod
+    def evaluate(
+        self,
+        surrogate: Surrogate,
+        train_x: np.ndarray,
+        train_y: np.ndarray,
+    ) -> SurrogateAccuracy:
+        """Compute accuracy metrics for *surrogate* on the given training data.
+
+        Parameters
+        ----------
+        surrogate : Surrogate
+            Surrogate instance to evaluate.
+        train_x : np.ndarray
+            Training inputs. shape: (n_samples, n_features)
+        train_y : np.ndarray
+            Training targets. shape: (n_samples, n_obj)
+
+        Returns
+        -------
+        SurrogateAccuracy
+        """
+        ...
+
+    def _compute_metrics(
+        self, y_true: np.ndarray, y_pred: np.ndarray
+    ) -> dict[str, float]:
+        """Apply all metrics to a single (y_true, y_pred) pair."""
+        return {m.name: m.compute(y_true, y_pred) for m in self.metrics}
+
+
+class KFoldAccuracyEvaluator(AccuracyEvaluator):
+    """Evaluates surrogate accuracy via k-fold cross-validation.
+
+    The training data is split into *n_splits* folds. For each fold, the
+    surrogate is deep-copied and fitted on the remaining folds, then tested
+    on the held-out fold. Metrics are averaged across folds.
+
+    Parameters
+    ----------
+    metrics : list[SurrogateAccuracyMetric] or None
+        Metrics to compute.
+    n_splits : int
+        Number of folds. Clamped to ``n_samples`` if larger.
+    """
+
+    def __init__(
+        self,
+        metrics: list[SurrogateAccuracyMetric] | None = None,
+        n_splits: int = 5,
+    ):
+        super().__init__(metrics)
+        self.n_splits = n_splits
+
+    def evaluate(
+        self,
+        surrogate: Surrogate,
+        train_x: np.ndarray,
+        train_y: np.ndarray,
+    ) -> SurrogateAccuracy:
+        """Evaluate via k-fold CV."""
+        return _cv_loop(surrogate, train_x, train_y, self.metrics, self.n_splits)
+
+
+class LOOAccuracyEvaluator(AccuracyEvaluator):
+    """Evaluates surrogate accuracy via leave-one-out cross-validation.
+
+    Equivalent to :class:`KFoldAccuracyEvaluator` with ``n_splits=n_samples``.
+    Each sample is used as a validation set exactly once.
+
+    Parameters
+    ----------
+    metrics : list[SurrogateAccuracyMetric] or None
+        Metrics to compute.
+    """
+
+    def evaluate(
+        self,
+        surrogate: Surrogate,
+        train_x: np.ndarray,
+        train_y: np.ndarray,
+    ) -> SurrogateAccuracy:
+        """Evaluate via leave-one-out CV."""
+        n = len(train_x)
+        return _cv_loop(surrogate, train_x, train_y, self.metrics, n_splits=n)
+
+
+class HeldOutAccuracyEvaluator(AccuracyEvaluator):
+    """Evaluates accuracy against pre-specified held-out data.
+
+    The surrogate is assumed to be already fitted; it is *not* re-fitted
+    inside :meth:`evaluate`. Useful for comparing surrogate predictions
+    against the most recent true evaluations (Hanawa et al., 2025).
+
+    Parameters
+    ----------
+    held_x : np.ndarray
+        Held-out inputs. shape: (n_held, n_features)
+    held_y : np.ndarray
+        Held-out true objective values. shape: (n_held, n_obj)
+    metrics : list[SurrogateAccuracyMetric] or None
+        Metrics to compute.
+    """
+
+    def __init__(
+        self,
+        held_x: np.ndarray,
+        held_y: np.ndarray,
+        metrics: list[SurrogateAccuracyMetric] | None = None,
+    ):
+        super().__init__(metrics)
+        self.held_x = np.asarray(held_x)
+        self.held_y = np.atleast_2d(np.asarray(held_y).T).T
+
+    def evaluate(
+        self,
+        surrogate: Surrogate,
+        train_x: np.ndarray,
+        train_y: np.ndarray,
+    ) -> SurrogateAccuracy:
+        """Predict on held-out data and compute metrics."""
+        pred = surrogate.predict(self.held_x)
+        result = self._compute_metrics(self.held_y, pred.value)
+        return SurrogateAccuracy(metrics=result, n_samples=len(train_x))
+
+
+# ---------------------------------------------------------------------------
+# Internal helper
+# ---------------------------------------------------------------------------
+
+
+def _cv_loop(
+    surrogate: Surrogate,
+    train_x: np.ndarray,
+    train_y: np.ndarray,
+    metrics: list[SurrogateAccuracyMetric],
+    n_splits: int,
+) -> SurrogateAccuracy:
+    """Run cross-validation and return averaged metrics.
+
+    Shared by :class:`KFoldAccuracyEvaluator` and :class:`LOOAccuracyEvaluator`.
+    The surrogate is deep-copied per fold and left unmodified.
+    """
+    n = len(train_x)
+    if n < 2:
+        return SurrogateAccuracy(n_samples=n)
+
+    train_y = np.atleast_2d(train_y.T).T
+    n_splits = min(n_splits, n)
+    indices = np.arange(n)
+    fold_size = n // n_splits
+    accumulator: dict[str, list[float]] = {m.name: [] for m in metrics}
+
+    for fold in range(n_splits):
+        start = fold * fold_size
+        end = start + fold_size if fold < n_splits - 1 else n
+        val_idx = indices[start:end]
+        train_idx = np.setdiff1d(indices, val_idx)
+        if len(train_idx) < 2:
+            continue
+
+        surrogate_copy = copy.deepcopy(surrogate)
+        try:
+            surrogate_copy.fit(train_x[train_idx], train_y[train_idx])
+            pred = surrogate_copy.predict(train_x[val_idx])
+            for m in metrics:
+                accumulator[m.name].append(m.compute(train_y[val_idx], pred.value))
+        except Exception:
+            continue
+
+    averaged = {
+        name: float(np.mean(vals)) if vals else float("nan")
+        for name, vals in accumulator.items()
+    }
+    return SurrogateAccuracy(metrics=averaged, n_samples=n)

--- a/src/saealib/surrogate/manager.py
+++ b/src/saealib/surrogate/manager.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from saealib.surrogate.accuracy import AccuracyEvaluator, SurrogateAccuracy
 from saealib.surrogate.base import Surrogate
 from saealib.surrogate.prediction import SurrogatePrediction
 from saealib.surrogate.training_set import (
@@ -54,7 +55,15 @@ class SurrogateManager(ABC):
     returns both scalar acquisition scores and the underlying predictions
     so that callers (e.g. IndividualBasedStrategy) can assign predicted
     objective values to offspring.
+
+    Attributes
+    ----------
+    last_accuracy : SurrogateAccuracy or None
+        Accuracy metrics computed after the most recent :meth:`fit` call.
+        ``None`` until the first fit or when no evaluator is configured.
     """
+
+    last_accuracy: SurrogateAccuracy | None = None
 
     @staticmethod
     def _sanitize_nan(
@@ -252,6 +261,9 @@ class GlobalSurrogateManager(SurrogateManager):
     training_set : TrainingSet or None
         Strategy object for building training data. Defaults to
         ``ArchiveObjectiveSet()``, which preserves the previous behaviour.
+    accuracy_evaluator : AccuracyEvaluator or None
+        If provided, :meth:`fit` computes accuracy metrics after each fit
+        and stores them in :attr:`last_accuracy`.
     """
 
     def __init__(
@@ -259,23 +271,34 @@ class GlobalSurrogateManager(SurrogateManager):
         surrogate: Surrogate,
         acquisition: AcquisitionFunction,
         training_set: TrainingSet | None = None,
+        accuracy_evaluator: AccuracyEvaluator | None = None,
     ):
         self.surrogate = surrogate
         self.acquisition = acquisition
         self.training_set: TrainingSet = (
             training_set if training_set is not None else ArchiveObjectiveSet()
         )
+        self.accuracy_evaluator = accuracy_evaluator
 
     def fit(
         self,
         archive: Archive,
         ctx: OptimizationContext | None = None,
     ) -> None:
-        """Fit the surrogate on the full archive."""
+        """Fit the surrogate on the full archive.
+
+        If an ``accuracy_evaluator`` was supplied at construction, accuracy
+        metrics are computed immediately after fitting and stored in
+        :attr:`last_accuracy`.
+        """
         population = ctx.population if ctx is not None else None
         data = self.training_set.build(archive, population, ctx, candidate_x=None)
         self.surrogate.fit(data.train_x, data.train_y)
         self.surrogate.post_fit(data.train_x, data.train_y, ctx)
+        if self.accuracy_evaluator is not None:
+            self.last_accuracy = self.accuracy_evaluator.evaluate(
+                self.surrogate, data.train_x, data.train_y
+            )
 
     def score_candidates(
         self,
@@ -322,6 +345,11 @@ class LocalSurrogateManager(SurrogateManager):
         Strategy object for building training data per candidate. Defaults to
         ``KNNObjectiveSet(n_neighbors=50)``, which preserves the previous
         behaviour.
+    accuracy_evaluator : AccuracyEvaluator or None
+        If provided, :meth:`score_candidates` computes accuracy metrics when
+        ``refit=True`` and stores them in :attr:`last_accuracy`.  Accuracy is
+        estimated by fitting a local model for each archive point via the same
+        ``training_set`` and comparing the prediction against the true value.
     """
 
     def __init__(
@@ -329,6 +357,7 @@ class LocalSurrogateManager(SurrogateManager):
         surrogate: Surrogate,
         acquisition: AcquisitionFunction,
         training_set: TrainingSet | None = None,
+        accuracy_evaluator: AccuracyEvaluator | None = None,
     ):
         self.surrogate = surrogate
         self.acquisition = acquisition
@@ -337,6 +366,25 @@ class LocalSurrogateManager(SurrogateManager):
             if training_set is not None
             else KNNObjectiveSet(n_neighbors=50)
         )
+        self.accuracy_evaluator = accuracy_evaluator
+
+    def fit(
+        self,
+        archive: Archive,
+        ctx: OptimizationContext | None = None,
+    ) -> None:
+        """Compute accuracy metrics from the archive (no global model is fitted).
+
+        For ``LocalSurrogateManager``, there is no persistent global surrogate
+        to pre-fit; local models are always built per candidate inside
+        :meth:`score_candidates`.  However, calling :meth:`fit` explicitly
+        (as ``GenerationBasedStrategy`` does before its inner loop) still
+        triggers accuracy evaluation so that :attr:`last_accuracy` is available
+        regardless of which strategy is used.
+        """
+        if self.accuracy_evaluator is not None:
+            population = ctx.population if ctx is not None else None
+            self._update_accuracy(archive, population, ctx)
 
     def score_candidates(
         self,
@@ -346,23 +394,129 @@ class LocalSurrogateManager(SurrogateManager):
         *,
         refit: bool = True,
     ) -> tuple[np.ndarray, list[SurrogatePrediction]]:
-        """Fit a local model per candidate and score each individually."""
+        """Fit a local model per candidate and score each individually.
+
+        When ``refit=True`` and an ``accuracy_evaluator`` is configured,
+        accuracy is estimated inline using the nearest-neighbor holdout method
+        (Hanawa et al., 2025): for each candidate, the closest archive neighbor
+        is reserved as a validation point and excluded from training.  Metrics
+        are averaged over all candidates and stored in :attr:`last_accuracy`.
+
+        Because the holdout point is excluded from training, the effective
+        training-set size is ``n_neighbors - 1`` when an accuracy evaluator is
+        active.  Without an accuracy evaluator the full ``n_neighbors`` points
+        are always used.
+        """
         predictions: list[SurrogatePrediction] = []
         reference = self.acquisition.compute_reference(archive)
         population = ctx.population if ctx is not None else None
+        compute_accuracy = refit and self.accuracy_evaluator is not None
+        y_true_list: list[np.ndarray] = []
+        y_pred_list: list[np.ndarray] = []
 
         for x in candidates_x:
             data = self.training_set.build(archive, population, ctx, candidate_x=x)
-            self.surrogate.fit(data.train_x, data.train_y)
-            self.surrogate.post_fit(data.train_x, data.train_y, ctx)
+
+            if compute_accuracy and len(data.train_x) >= 2:
+                # Hold out the nearest neighbor (index 0 when KNN-sorted) as
+                # validation to get an unbiased estimate of local model accuracy.
+                val_x = data.train_x[0:1]
+                val_y = np.atleast_2d(data.train_y[0:1].T).T
+                train_x = data.train_x[1:]
+                train_y = data.train_y[1:]
+            else:
+                val_x = val_y = None
+                train_x = data.train_x
+                train_y = data.train_y
+
+            self.surrogate.fit(train_x, train_y)
+            self.surrogate.post_fit(train_x, train_y, ctx)
             pred = self.surrogate.predict(x)  # mean: (1, n_obj)
             predictions.append(pred)
+
+            if val_x is not None:
+                try:
+                    val_pred = self.surrogate.predict(val_x)
+                    y_true_list.append(val_y[0])
+                    y_pred_list.append(val_pred.value[0])
+                except Exception:
+                    pass
 
         scores = np.array(
             [self.acquisition.score(p, reference)[0] for p in predictions]
         )
         scores, predictions = self._sanitize_nan(scores, predictions)
+
+        if compute_accuracy:
+            if y_true_list:
+                y_true = np.stack(y_true_list)
+                y_pred = np.stack(y_pred_list)
+                metrics = self.accuracy_evaluator._compute_metrics(y_true, y_pred)  # type: ignore[union-attr]
+                self.last_accuracy = SurrogateAccuracy(
+                    metrics=metrics, n_samples=len(y_true_list)
+                )
+            else:
+                self.last_accuracy = SurrogateAccuracy(n_samples=0)
+
         return self.post_score(scores, predictions, ctx)
+
+    def _update_accuracy(
+        self,
+        archive: Archive,
+        population: object,
+        ctx: OptimizationContext | None,
+    ) -> None:
+        """Compute accuracy via LOO with self-exclusion on archive points.
+
+        Called by :meth:`fit` for the ``GenerationBasedStrategy`` pattern.
+        For each archive point ``x_i``, the local model is built from the
+        ``n_neighbors`` nearest neighbors of ``x_i`` **excluding ``x_i``
+        itself**, and then predicts ``x_i``.  This avoids the self-inclusion
+        bias that occurs when an interpolating surrogate (e.g. RBF) is fitted
+        on data that includes the query point.
+        """
+        archive_x = archive.x
+        archive_y = np.atleast_2d(archive.f.T).T
+        n = len(archive_x)
+
+        if n < 2:
+            self.last_accuracy = SurrogateAccuracy(n_samples=n)
+            return
+
+        n_neighbors = min(getattr(self.training_set, "n_neighbors", n), n - 1)
+        y_true_list: list[np.ndarray] = []
+        y_pred_list: list[np.ndarray] = []
+
+        for i in range(n):
+            # Exclude x_i from its own neighborhood (LOO self-exclusion)
+            mask = np.ones(n, dtype=bool)
+            mask[i] = False
+            loo_x = archive_x[mask]
+            loo_y = archive_y[mask]
+
+            dists = np.sum((loo_x - archive_x[i]) ** 2, axis=1)
+            k = min(n_neighbors, len(loo_x))
+            idx = np.argsort(dists)[:k]
+            train_x = loo_x[idx]
+            train_y = loo_y[idx]
+
+            surrogate_copy = copy.deepcopy(self.surrogate)
+            try:
+                surrogate_copy.fit(train_x, train_y)
+                pred = surrogate_copy.predict(archive_x[i : i + 1])
+                y_true_list.append(archive_y[i])
+                y_pred_list.append(pred.value[0])
+            except Exception:
+                continue
+
+        if not y_true_list:
+            self.last_accuracy = SurrogateAccuracy(n_samples=n)
+            return
+
+        y_true = np.stack(y_true_list)
+        y_pred = np.stack(y_pred_list)
+        metrics = self.accuracy_evaluator._compute_metrics(y_true, y_pred)  # type: ignore[union-attr]
+        self.last_accuracy = SurrogateAccuracy(metrics=metrics, n_samples=n)
 
 
 def product_combine(scores: list[np.ndarray]) -> np.ndarray:
@@ -464,9 +618,14 @@ class CompositeSurrogateManager(SurrogateManager):
         archive: Archive,
         ctx: OptimizationContext | None = None,
     ) -> None:
-        """Pre-fit all sub-managers."""
+        """Pre-fit all sub-managers.
+
+        :attr:`last_accuracy` is propagated from ``managers[0]`` so callers
+        can read a representative accuracy value from this composite manager.
+        """
         for manager in self.managers:
             manager.fit(archive, ctx)
+        self.last_accuracy = self.managers[0].last_accuracy
 
     def score_candidates(
         self,

--- a/src/saealib/surrogate/switching.py
+++ b/src/saealib/surrogate/switching.py
@@ -1,0 +1,223 @@
+"""
+Accuracy-based module and parameter switching helpers for the ``iterate()`` loop.
+
+All switchers inherit :class:`AccuracyBasedSurrogateSwitcher` and expose a
+single :meth:`~AccuracyBasedSurrogateSwitcher.switch` method intended to be
+called once per step inside an ``iterate()`` loop::
+
+    switcher = ManagerSwitcher(primary, fallback)
+    for ctx in optimizer.iterate():
+        optimizer.set_surrogate_manager(
+            switcher.switch(optimizer.surrogate_manager.last_accuracy)
+        )
+"""
+
+from __future__ import annotations
+
+import math
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from saealib.strategies.base import OptimizationStrategy
+    from saealib.surrogate.accuracy import SurrogateAccuracy
+    from saealib.surrogate.manager import SurrogateManager
+
+T = TypeVar("T")
+
+
+class AccuracyBasedSurrogateSwitcher(ABC, Generic[T]):
+    """Abstract base for accuracy-driven module and parameter switching.
+
+    Implementations return a replacement surrogate manager, optimization
+    strategy, or numeric parameter based on the most recent accuracy snapshot.
+    Call :meth:`switch` inside an ``iterate()`` loop and apply the result::
+
+        switcher = StrategySwitcher(ps_strategy, ib_strategy)
+        for ctx in optimizer.iterate():
+            optimizer.set_strategy(
+                switcher.switch(optimizer.surrogate_manager.last_accuracy)
+            )
+    """
+
+    @abstractmethod
+    def switch(self, accuracy: SurrogateAccuracy | None) -> T:
+        """Return the replacement value for the next step.
+
+        Parameters
+        ----------
+        accuracy : SurrogateAccuracy or None
+            Most recent accuracy snapshot from
+            ``surrogate_manager.last_accuracy``. ``None`` on the first step
+            or when no accuracy evaluator is configured.
+
+        Returns
+        -------
+        T
+            Replacement module or parameter value.
+        """
+        ...
+
+
+class ManagerSwitcher(AccuracyBasedSurrogateSwitcher["SurrogateManager"]):
+    """Switch between two surrogate managers based on an accuracy threshold.
+
+    Returns ``primary`` when ``metric >= threshold``, ``fallback`` otherwise,
+    including when accuracy is unavailable or the metric is non-finite.
+
+    Parameters
+    ----------
+    primary : SurrogateManager
+        Manager used when accuracy is satisfactory.
+    fallback : SurrogateManager
+        Manager used when accuracy is poor or not yet available.
+    metric : str
+        Metric key in :class:`~saealib.surrogate.accuracy.SurrogateAccuracy`.
+        Default: ``"spearman"``.
+    threshold : float
+        Minimum acceptable metric value. Default: ``0.5``.
+    """
+
+    def __init__(
+        self,
+        primary: SurrogateManager,
+        fallback: SurrogateManager,
+        *,
+        metric: str = "spearman",
+        threshold: float = 0.5,
+    ) -> None:
+        self.primary = primary
+        self.fallback = fallback
+        self.metric = metric
+        self.threshold = threshold
+
+    def switch(self, accuracy: SurrogateAccuracy | None) -> SurrogateManager:
+        """Return primary or fallback based on the metric threshold."""
+        if accuracy is None:
+            return self.fallback
+        v = accuracy.get(self.metric)
+        if math.isfinite(v) and v >= self.threshold:
+            return self.primary
+        return self.fallback
+
+
+class StrategySwitcher(AccuracyBasedSurrogateSwitcher["OptimizationStrategy"]):
+    """Switch between two optimization strategies based on an accuracy threshold.
+
+    Implements the threshold-based PS/IB-GB switching from Hanawa et al.
+    (2025): use a surrogate-heavy strategy (e.g. PS) when Spearman rho
+    surpasses the threshold, fall back to a more robust strategy (IB or GB)
+    otherwise.
+
+    Parameters
+    ----------
+    primary : OptimizationStrategy
+        Strategy used when accuracy is satisfactory (e.g. PS).
+    fallback : OptimizationStrategy
+        Strategy used when accuracy is poor (e.g. IB or GB).
+    metric : str
+        Metric key. Default: ``"spearman"``.
+    threshold : float
+        Minimum acceptable metric value. Default: ``0.56``
+        (Hanawa et al. 2025).
+    """
+
+    def __init__(
+        self,
+        primary: OptimizationStrategy,
+        fallback: OptimizationStrategy,
+        *,
+        metric: str = "spearman",
+        threshold: float = 0.56,
+    ) -> None:
+        self.primary = primary
+        self.fallback = fallback
+        self.metric = metric
+        self.threshold = threshold
+
+    def switch(self, accuracy: SurrogateAccuracy | None) -> OptimizationStrategy:
+        """Return primary or fallback based on the metric threshold."""
+        if accuracy is None:
+            return self.fallback
+        v = accuracy.get(self.metric)
+        if math.isfinite(v) and v >= self.threshold:
+            return self.primary
+        return self.fallback
+
+
+class GenCtrlSwitcher(AccuracyBasedSurrogateSwitcher[int]):
+    r"""Adjust gen_ctrl via exponential smoothing (Repický et al., 2017).
+
+    The surrogate error is estimated from an accuracy metric, exponentially
+    smoothed, then linearly mapped to gen_ctrl:
+
+    .. math::
+
+        \varepsilon_t = (1-r_u)\varepsilon_{t-1} + r_u\varepsilon_{\text{new}}
+
+        g_m = \operatorname{round}((1-\varepsilon_t) \cdot g_{m,\max})
+
+    For Spearman rho and R2, ``epsilon = 0.5 * (1 - value)`` maps the
+    metric to ``[0, 1]``.  For RMSE the value is used directly (assumed
+    to be in ``[0, 1]``).  When accuracy is unavailable the smoothed state
+    is unchanged and the current estimate is returned.
+
+    Parameters
+    ----------
+    gm_max : int
+        Upper bound for gen_ctrl. Default: ``5``.
+    gm_min : int
+        Lower bound for gen_ctrl. Default: ``0``.
+    update_rate : float
+        Smoothing rate ``r_u`` in (0, 1]. Default: ``0.5``.
+    metric : str
+        Metric key. Default: ``"spearman"``.
+    initial_error : float
+        Initial smoothed error before the first observation.
+        Default: ``0.5`` (neutral).
+
+    Attributes
+    ----------
+    smoothed_error : float
+        Current exponentially smoothed error estimate. Inspect to monitor
+        the internal state during an ``iterate()`` run.
+    """
+
+    def __init__(
+        self,
+        *,
+        gm_max: int = 5,
+        gm_min: int = 0,
+        update_rate: float = 0.5,
+        metric: str = "spearman",
+        initial_error: float = 0.5,
+    ) -> None:
+        if not (0 < update_rate <= 1.0):
+            raise ValueError("update_rate must be in (0, 1]")
+        if gm_min < 0:
+            raise ValueError("gm_min must be >= 0")
+        if gm_max < gm_min:
+            raise ValueError("gm_max must be >= gm_min")
+        self.gm_max = gm_max
+        self.gm_min = gm_min
+        self.update_rate = update_rate
+        self.metric = metric
+        self.smoothed_error: float = float(initial_error)
+
+    def switch(self, accuracy: SurrogateAccuracy | None) -> int:
+        """Update smoothed error and return new gen_ctrl."""
+        if accuracy is not None:
+            v = accuracy.get(self.metric)
+            if math.isfinite(v):
+                eps = self._to_error(v)
+                self.smoothed_error = (
+                    (1.0 - self.update_rate) * self.smoothed_error
+                    + self.update_rate * eps
+                )
+        gm = round((1.0 - self.smoothed_error) * self.gm_max)
+        return max(self.gm_min, min(self.gm_max, gm))
+
+    def _to_error(self, value: float) -> float:
+        if self.metric in ("spearman", "r2"):
+            return 0.5 * (1.0 - float(value))
+        return float(max(0.0, min(1.0, value)))

--- a/src/saealib/surrogate/switching.py
+++ b/src/saealib/surrogate/switching.py
@@ -211,9 +211,8 @@ class GenCtrlSwitcher(AccuracyBasedSurrogateSwitcher[int]):
             if math.isfinite(v):
                 eps = self._to_error(v)
                 self.smoothed_error = (
-                    (1.0 - self.update_rate) * self.smoothed_error
-                    + self.update_rate * eps
-                )
+                    1.0 - self.update_rate
+                ) * self.smoothed_error + self.update_rate * eps
         gm = round((1.0 - self.smoothed_error) * self.gm_max)
         return max(self.gm_min, min(self.gm_max, gm))
 

--- a/tests/test_surrogate_accuracy.py
+++ b/tests/test_surrogate_accuracy.py
@@ -1,0 +1,238 @@
+"""Tests for surrogate/accuracy.py."""
+
+import numpy as np
+import pytest
+
+from saealib.surrogate.accuracy import (
+    RMSE,
+    AccuracyEvaluator,
+    HeldOutAccuracyEvaluator,
+    KFoldAccuracyEvaluator,
+    LOOAccuracyEvaluator,
+    R2Score,
+    SpearmanCorrelation,
+    SurrogateAccuracy,
+)
+from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+DIM = 1
+N_OBJ = 1
+
+
+def _make_surrogate() -> RBFsurrogate:
+    return RBFsurrogate(kernel=gaussian_kernel, dim=DIM)
+
+
+def _sphere_data(n: int = 30, rng_seed: int = 0) -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(rng_seed)
+    x = rng.uniform(-2.0, 2.0, size=(n, DIM))
+    y = np.sum(x**2, axis=1, keepdims=True)
+    return x, y
+
+
+# ---------------------------------------------------------------------------
+# SurrogateAccuracyMetric
+# ---------------------------------------------------------------------------
+
+
+class TestSpearmanCorrelation:
+    def test_perfect_positive(self):
+        y = np.array([[1.0], [2.0], [3.0], [4.0]])
+        assert SpearmanCorrelation().compute(y, y) == pytest.approx(1.0)
+
+    def test_perfect_negative(self):
+        y_true = np.array([[1.0], [2.0], [3.0], [4.0]])
+        y_pred = np.array([[4.0], [3.0], [2.0], [1.0]])
+        assert SpearmanCorrelation().compute(y_true, y_pred) == pytest.approx(-1.0)
+
+    def test_name(self):
+        assert SpearmanCorrelation().name == "spearman"
+
+    def test_constant_pred_returns_zero(self):
+        y_true = np.array([[1.0], [2.0], [3.0]])
+        y_pred = np.array([[5.0], [5.0], [5.0]])
+        result = SpearmanCorrelation().compute(y_true, y_pred)
+        assert result == pytest.approx(0.0)
+
+
+class TestRMSE:
+    def test_zero_error(self):
+        y = np.array([[1.0], [2.0], [3.0]])
+        assert RMSE().compute(y, y) == pytest.approx(0.0)
+
+    def test_known_value(self):
+        y_true = np.array([[0.0], [0.0]])
+        y_pred = np.array([[3.0], [4.0]])
+        # sqrt((9+16)/2) = sqrt(12.5)
+        assert RMSE().compute(y_true, y_pred) == pytest.approx(np.sqrt(12.5))
+
+    def test_name(self):
+        assert RMSE().name == "rmse"
+
+
+class TestR2Score:
+    def test_perfect_fit(self):
+        y = np.array([[1.0], [2.0], [3.0]])
+        assert R2Score().compute(y, y) == pytest.approx(1.0)
+
+    def test_constant_true(self):
+        y_true = np.array([[5.0], [5.0], [5.0]])
+        y_pred = np.array([[5.0], [5.0], [5.0]])
+        assert R2Score().compute(y_true, y_pred) == pytest.approx(1.0)
+
+    def test_name(self):
+        assert R2Score().name == "r2"
+
+
+# ---------------------------------------------------------------------------
+# SurrogateAccuracy
+# ---------------------------------------------------------------------------
+
+
+class TestSurrogateAccuracy:
+    def test_get_existing(self):
+        acc = SurrogateAccuracy(metrics={"spearman": 0.8}, n_samples=20)
+        assert acc.get("spearman") == pytest.approx(0.8)
+
+    def test_get_missing_returns_default(self):
+        acc = SurrogateAccuracy()
+        assert np.isnan(acc.get("spearman"))
+
+    def test_get_custom_default(self):
+        acc = SurrogateAccuracy()
+        assert acc.get("rmse", 0.0) == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# AccuracyEvaluator is abstract
+# ---------------------------------------------------------------------------
+
+
+def test_accuracy_evaluator_is_abstract():
+    with pytest.raises(TypeError):
+        AccuracyEvaluator()  # type: ignore[abstract]
+
+
+# ---------------------------------------------------------------------------
+# KFoldAccuracyEvaluator
+# ---------------------------------------------------------------------------
+
+
+class TestKFoldAccuracyEvaluator:
+    def test_returns_accuracy_object(self):
+        x, y = _sphere_data(30)
+        acc = KFoldAccuracyEvaluator(n_splits=5).evaluate(_make_surrogate(), x, y)
+        assert isinstance(acc, SurrogateAccuracy)
+        assert acc.n_samples == 30
+
+    def test_has_all_default_metrics(self):
+        x, y = _sphere_data(30)
+        acc = KFoldAccuracyEvaluator(n_splits=5).evaluate(_make_surrogate(), x, y)
+        assert "spearman" in acc.metrics
+        assert "rmse" in acc.metrics
+        assert "r2" in acc.metrics
+
+    def test_spearman_in_valid_range(self):
+        x, y = _sphere_data(30)
+        acc = KFoldAccuracyEvaluator(
+            metrics=[SpearmanCorrelation()], n_splits=5
+        ).evaluate(_make_surrogate(), x, y)
+        assert -1.0 <= acc.get("spearman") <= 1.0
+
+    def test_surrogate_unmodified_after_evaluate(self):
+        x, y = _sphere_data(30)
+        surrogate = _make_surrogate()
+        surrogate.fit(x, y)
+        pred_before = surrogate.predict(x[:3]).value.copy()
+
+        KFoldAccuracyEvaluator(n_splits=5).evaluate(surrogate, x, y)
+
+        np.testing.assert_array_equal(pred_before, surrogate.predict(x[:3]).value)
+
+    def test_custom_metric_only(self):
+        x, y = _sphere_data(30)
+        acc = KFoldAccuracyEvaluator(metrics=[RMSE()], n_splits=5).evaluate(
+            _make_surrogate(), x, y
+        )
+        assert "rmse" in acc.metrics
+        assert "spearman" not in acc.metrics
+
+    def test_n_splits_clamped_to_n_samples(self):
+        x, y = _sphere_data(4)
+        acc = KFoldAccuracyEvaluator(n_splits=10).evaluate(_make_surrogate(), x, y)
+        assert acc.n_samples == 4
+
+    def test_too_few_samples_returns_empty(self):
+        x, y = _sphere_data(1)
+        acc = KFoldAccuracyEvaluator(n_splits=5).evaluate(_make_surrogate(), x, y)
+        assert acc.metrics == {}
+
+
+# ---------------------------------------------------------------------------
+# LOOAccuracyEvaluator
+# ---------------------------------------------------------------------------
+
+
+class TestLOOAccuracyEvaluator:
+    def test_returns_accuracy(self):
+        x, y = _sphere_data(10)
+        acc = LOOAccuracyEvaluator().evaluate(_make_surrogate(), x, y)
+        assert "spearman" in acc.metrics
+        assert acc.n_samples == 10
+
+    def test_surrogate_unmodified(self):
+        x, y = _sphere_data(10)
+        surrogate = _make_surrogate()
+        surrogate.fit(x, y)
+        pred_before = surrogate.predict(x[:3]).value.copy()
+
+        LOOAccuracyEvaluator().evaluate(surrogate, x, y)
+
+        np.testing.assert_array_equal(pred_before, surrogate.predict(x[:3]).value)
+
+
+# ---------------------------------------------------------------------------
+# HeldOutAccuracyEvaluator
+# ---------------------------------------------------------------------------
+
+
+class TestHeldOutAccuracyEvaluator:
+    def test_returns_accuracy(self):
+        x, y = _sphere_data(30)
+        held_x, held_y = _sphere_data(5, rng_seed=99)
+        surrogate = _make_surrogate()
+        surrogate.fit(x, y)
+
+        acc = HeldOutAccuracyEvaluator(
+            held_x, held_y, metrics=[SpearmanCorrelation()]
+        ).evaluate(surrogate, x, y)
+
+        assert "spearman" in acc.metrics
+        assert acc.n_samples == 30
+
+    def test_perfect_surrogate(self):
+        x, y = _sphere_data(20)
+        surrogate = _make_surrogate()
+        surrogate.fit(x, y)
+
+        acc = HeldOutAccuracyEvaluator(x, y).evaluate(surrogate, x, y)
+
+        assert acc.get("spearman") == pytest.approx(1.0, abs=1e-6)
+        assert acc.get("rmse") == pytest.approx(0.0, abs=1e-6)
+        assert acc.get("r2") == pytest.approx(1.0, abs=1e-6)
+
+    def test_does_not_refit_surrogate(self):
+        """HeldOutAccuracyEvaluator must not modify the already-fitted surrogate."""
+        x, y = _sphere_data(20)
+        held_x, held_y = _sphere_data(5, rng_seed=7)
+        surrogate = _make_surrogate()
+        surrogate.fit(x, y)
+        pred_before = surrogate.predict(held_x).value.copy()
+
+        HeldOutAccuracyEvaluator(held_x, held_y).evaluate(surrogate, x, y)
+
+        np.testing.assert_array_equal(pred_before, surrogate.predict(held_x).value)

--- a/tests/test_surrogate_manager.py
+++ b/tests/test_surrogate_manager.py
@@ -14,6 +14,11 @@ import pytest
 
 from saealib.acquisition import MeanPrediction
 from saealib.population import Archive, PopulationAttribute
+from saealib.surrogate.accuracy import (
+    KFoldAccuracyEvaluator,
+    SpearmanCorrelation,
+    SurrogateAccuracy,
+)
 from saealib.surrogate.archive_manager import (
     ArchiveBasedManager,
     DensityManager,
@@ -1063,3 +1068,182 @@ class TestSurrogateManagerGenerationHook:
         _ = original.with_on_generation_end(hook)
         original.on_generation_end(0, archive_1obj)
         assert not called[0]
+
+
+# ---------------------------------------------------------------------------
+# last_accuracy
+# ---------------------------------------------------------------------------
+
+
+class TestLastAccuracy:
+    def test_last_accuracy_none_by_default(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        manager = GlobalSurrogateManager(surrogate_1obj, MeanPrediction())
+        assert manager.last_accuracy is None
+
+    def test_last_accuracy_none_without_evaluator(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        manager = GlobalSurrogateManager(surrogate_1obj, MeanPrediction())
+        manager.fit(archive_1obj)
+        assert manager.last_accuracy is None
+
+    def test_last_accuracy_set_after_fit_with_evaluator(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=5)
+        manager = GlobalSurrogateManager(
+            surrogate_1obj, MeanPrediction(), accuracy_evaluator=evaluator
+        )
+        manager.fit(archive_1obj)
+        assert isinstance(manager.last_accuracy, SurrogateAccuracy)
+        assert "spearman" in manager.last_accuracy.metrics
+
+    def test_last_accuracy_updated_on_score_candidates_with_refit(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
+        manager = GlobalSurrogateManager(
+            surrogate_1obj, MeanPrediction(), accuracy_evaluator=evaluator
+        )
+        rng = np.random.default_rng(0)
+        candidates = rng.uniform(-2.0, 2.0, size=(5, DIM))
+        manager.score_candidates(candidates, archive_1obj, refit=True)
+        assert manager.last_accuracy is not None
+
+    def test_last_accuracy_not_updated_when_refit_false(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
+        manager = GlobalSurrogateManager(
+            surrogate_1obj, MeanPrediction(), accuracy_evaluator=evaluator
+        )
+        manager.fit(archive_1obj)
+        first = manager.last_accuracy
+
+        rng = np.random.default_rng(1)
+        candidates = rng.uniform(-2.0, 2.0, size=(5, DIM))
+        manager.score_candidates(candidates, archive_1obj, refit=False)
+        assert manager.last_accuracy is first  # same object, not updated
+
+    def test_composite_propagates_last_accuracy_from_first_manager(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
+        m1 = GlobalSurrogateManager(
+            surrogate_1obj, MeanPrediction(), accuracy_evaluator=evaluator
+        )
+        m2 = GlobalSurrogateManager(surrogate_1obj, MeanPrediction())
+        composite = CompositeSurrogateManager(
+            [m1, m2], combine_fn=rank_weighted_combine()
+        )
+        composite.fit(archive_1obj)
+        assert composite.last_accuracy is m1.last_accuracy
+        assert composite.last_accuracy is not None
+
+
+class TestLocalSurrogateManagerAccuracy:
+    def test_last_accuracy_none_by_default(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        manager = LocalSurrogateManager(surrogate_1obj, MeanPrediction())
+        assert manager.last_accuracy is None
+
+    def test_fit_sets_last_accuracy(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
+        manager = LocalSurrogateManager(
+            surrogate_1obj, MeanPrediction(), accuracy_evaluator=evaluator
+        )
+        manager.fit(archive_1obj)
+        assert isinstance(manager.last_accuracy, SurrogateAccuracy)
+        assert "spearman" in manager.last_accuracy.metrics
+
+    def test_fit_noop_without_evaluator(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        manager = LocalSurrogateManager(surrogate_1obj, MeanPrediction())
+        manager.fit(archive_1obj)
+        assert manager.last_accuracy is None
+
+    def test_last_accuracy_set_after_score_candidates_with_refit(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
+        manager = LocalSurrogateManager(
+            surrogate_1obj, MeanPrediction(), accuracy_evaluator=evaluator
+        )
+        rng = np.random.default_rng(0)
+        candidates = rng.uniform(-2.0, 2.0, size=(5, DIM))
+        manager.score_candidates(candidates, archive_1obj, refit=True)
+        assert isinstance(manager.last_accuracy, SurrogateAccuracy)
+        assert "spearman" in manager.last_accuracy.metrics
+        # n_samples = number of candidates for which validation was possible
+        assert manager.last_accuracy.n_samples == len(candidates)
+
+    def test_last_accuracy_not_updated_when_refit_false(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
+        manager = LocalSurrogateManager(
+            surrogate_1obj, MeanPrediction(), accuracy_evaluator=evaluator
+        )
+        rng = np.random.default_rng(0)
+        candidates = rng.uniform(-2.0, 2.0, size=(5, DIM))
+        manager.score_candidates(candidates, archive_1obj, refit=True)
+        first = manager.last_accuracy
+        manager.score_candidates(candidates, archive_1obj, refit=False)
+        assert manager.last_accuracy is first  # not updated
+
+    def test_generation_based_pattern_sets_last_accuracy(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        """fit() + score_candidates(refit=False) pattern (GenerationBasedStrategy)."""
+        evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
+        manager = LocalSurrogateManager(
+            surrogate_1obj, MeanPrediction(), accuracy_evaluator=evaluator
+        )
+        rng = np.random.default_rng(0)
+        candidates = rng.uniform(-2.0, 2.0, size=(5, DIM))
+        manager.fit(archive_1obj)
+        assert isinstance(manager.last_accuracy, SurrogateAccuracy)
+        accuracy_after_fit = manager.last_accuracy
+        # inner loop: refit=False should not update last_accuracy
+        manager.score_candidates(candidates, archive_1obj, refit=False)
+        assert manager.last_accuracy is accuracy_after_fit
+
+    def test_nearest_neighbor_excluded_from_training(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        """Nearest archive neighbor is held out; training uses n_neighbors-1 points."""
+        evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
+        manager_with = LocalSurrogateManager(
+            surrogate_1obj, MeanPrediction(), accuracy_evaluator=evaluator
+        )
+        manager_without = LocalSurrogateManager(
+            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
+        )
+        rng = np.random.default_rng(99)
+        candidates = rng.uniform(-2.0, 2.0, size=(5, DIM))
+        scores_with, _ = manager_with.score_candidates(candidates, archive_1obj)
+        scores_without, _ = manager_without.score_candidates(candidates, archive_1obj)
+        # Scores differ because the nearest neighbor is excluded from training
+        # when an accuracy evaluator is active (k-1 vs k training points).
+        assert scores_with.shape == scores_without.shape
+        assert not np.any(np.isnan(scores_with))
+
+    def test_loo_self_exclusion_in_update_accuracy(
+        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+    ) -> None:
+        """_update_accuracy uses LOO self-exclusion; RBF no longer gives perfect score."""  # noqa: E501
+        evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
+        manager = LocalSurrogateManager(
+            surrogate_1obj, MeanPrediction(), accuracy_evaluator=evaluator
+        )
+        manager.fit(archive_1obj)
+        assert manager.last_accuracy is not None
+        # With self-exclusion, RBF accuracy is < 1.0 (not perfectly interpolated)
+        spearman = manager.last_accuracy.get("spearman")
+        assert spearman < 1.0 or np.isnan(spearman)

--- a/tests/test_surrogate_switching.py
+++ b/tests/test_surrogate_switching.py
@@ -1,0 +1,178 @@
+"""Tests for surrogate/switching.py."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from saealib.surrogate.accuracy import SurrogateAccuracy
+from saealib.surrogate.switching import (
+    AccuracyBasedSurrogateSwitcher,
+    GenCtrlSwitcher,
+    ManagerSwitcher,
+    StrategySwitcher,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _acc(spearman: float, n: int = 10) -> SurrogateAccuracy:
+    return SurrogateAccuracy(metrics={"spearman": spearman}, n_samples=n)
+
+
+# ---------------------------------------------------------------------------
+# ABC
+# ---------------------------------------------------------------------------
+
+
+def test_abc_is_abstract() -> None:
+    with pytest.raises(TypeError):
+        AccuracyBasedSurrogateSwitcher()  # type: ignore[abstract]
+
+
+# ---------------------------------------------------------------------------
+# ManagerSwitcher
+# ---------------------------------------------------------------------------
+
+
+class TestManagerSwitcher:
+    def _make(self, threshold=0.5):
+        primary, fallback = MagicMock(name="primary"), MagicMock(name="fallback")
+        sw = ManagerSwitcher(primary, fallback, threshold=threshold)
+        return primary, fallback, sw
+
+    def test_returns_primary_above_threshold(self) -> None:
+        primary, _, sw = self._make()
+        assert sw.switch(_acc(0.8)) is primary
+
+    def test_returns_primary_at_threshold(self) -> None:
+        primary, _, sw = self._make(threshold=0.5)
+        assert sw.switch(_acc(0.5)) is primary
+
+    def test_returns_fallback_below_threshold(self) -> None:
+        _, fallback, sw = self._make()
+        assert sw.switch(_acc(0.3)) is fallback
+
+    def test_returns_fallback_when_accuracy_none(self) -> None:
+        _, fallback, sw = self._make()
+        assert sw.switch(None) is fallback
+
+    def test_returns_fallback_when_metric_missing(self) -> None:
+        _, fallback, sw = self._make()
+        acc = SurrogateAccuracy(metrics={}, n_samples=5)
+        assert sw.switch(acc) is fallback
+
+    def test_custom_metric(self) -> None:
+        primary, fallback = MagicMock(), MagicMock()
+        sw = ManagerSwitcher(primary, fallback, metric="r2", threshold=0.7)
+        high = SurrogateAccuracy(metrics={"r2": 0.9}, n_samples=5)
+        low = SurrogateAccuracy(metrics={"r2": 0.5}, n_samples=5)
+        assert sw.switch(high) is primary
+        assert sw.switch(low) is fallback
+
+    def test_defaults(self) -> None:
+        sw = ManagerSwitcher(MagicMock(), MagicMock())
+        assert sw.metric == "spearman"
+        assert sw.threshold == 0.5
+
+    def test_sequence(self) -> None:
+        primary, fallback, sw = self._make(threshold=0.6)
+        snapshots = [None, _acc(0.4), _acc(0.7), _acc(0.55), _acc(0.9)]
+        expected = [fallback, fallback, primary, fallback, primary]
+        for acc, exp in zip(snapshots, expected):
+            assert sw.switch(acc) is exp
+
+
+# ---------------------------------------------------------------------------
+# StrategySwitcher
+# ---------------------------------------------------------------------------
+
+
+class TestStrategySwitcher:
+    def _make(self, threshold=0.56):
+        primary, fallback = MagicMock(name="ps"), MagicMock(name="ib")
+        sw = StrategySwitcher(primary, fallback, threshold=threshold)
+        return primary, fallback, sw
+
+    def test_returns_primary_above_threshold(self) -> None:
+        primary, _, sw = self._make()
+        assert sw.switch(_acc(0.8)) is primary
+
+    def test_returns_fallback_below_threshold(self) -> None:
+        _, fallback, sw = self._make()
+        assert sw.switch(_acc(0.3)) is fallback
+
+    def test_returns_fallback_when_none(self) -> None:
+        _, fallback, sw = self._make()
+        assert sw.switch(None) is fallback
+
+    def test_default_threshold_is_056(self) -> None:
+        sw = StrategySwitcher(MagicMock(), MagicMock())
+        assert sw.threshold == 0.56
+
+    def test_default_metric_is_spearman(self) -> None:
+        sw = StrategySwitcher(MagicMock(), MagicMock())
+        assert sw.metric == "spearman"
+
+
+# ---------------------------------------------------------------------------
+# GenCtrlSwitcher
+# ---------------------------------------------------------------------------
+
+
+class TestGenCtrlSwitcherInit:
+    def test_invalid_update_rate_zero(self) -> None:
+        with pytest.raises(ValueError):
+            GenCtrlSwitcher(update_rate=0.0)
+
+    def test_invalid_update_rate_above_one(self) -> None:
+        with pytest.raises(ValueError):
+            GenCtrlSwitcher(update_rate=1.1)
+
+    def test_invalid_gm_min_negative(self) -> None:
+        with pytest.raises(ValueError):
+            GenCtrlSwitcher(gm_min=-1)
+
+    def test_invalid_gm_max_less_than_min(self) -> None:
+        with pytest.raises(ValueError):
+            GenCtrlSwitcher(gm_max=2, gm_min=5)
+
+
+class TestGenCtrlSwitcherSwitch:
+    def test_perfect_accuracy_returns_gm_max(self) -> None:
+        sw = GenCtrlSwitcher(gm_max=5, update_rate=1.0)
+        assert sw.switch(_acc(1.0)) == 5
+
+    def test_worst_accuracy_returns_gm_min(self) -> None:
+        sw = GenCtrlSwitcher(gm_max=5, gm_min=0, update_rate=1.0)
+        assert sw.switch(_acc(-1.0)) == 0
+
+    def test_medium_accuracy_intermediate(self) -> None:
+        # spearman=0.0 -> eps=0.5 -> quality=0.5 -> gm=5
+        sw = GenCtrlSwitcher(gm_max=10, update_rate=1.0)
+        assert sw.switch(_acc(0.0)) == 5
+
+    def test_none_accuracy_does_not_change_state(self) -> None:
+        sw = GenCtrlSwitcher(gm_max=10, update_rate=1.0, initial_error=0.5)
+        before = sw.smoothed_error
+        sw.switch(None)
+        assert sw.smoothed_error == before
+
+    def test_smoothing_converges_to_gm_max(self) -> None:
+        sw = GenCtrlSwitcher(gm_max=10, update_rate=0.5)
+        for _ in range(30):
+            result = sw.switch(_acc(1.0))
+        assert result == 10
+
+    def test_gm_min_clamp(self) -> None:
+        sw = GenCtrlSwitcher(gm_max=5, gm_min=2, update_rate=1.0)
+        assert sw.switch(_acc(-1.0)) >= 2
+
+    def test_gm_max_clamp(self) -> None:
+        sw = GenCtrlSwitcher(gm_max=3, update_rate=1.0)
+        assert sw.switch(_acc(1.0)) <= 3
+
+    def test_smoothed_error_is_public(self) -> None:
+        sw = GenCtrlSwitcher(initial_error=0.3)
+        assert sw.smoothed_error == 0.3


### PR DESCRIPTION
## Related Issue
Closes #79

## Overview
Implements surrogate self-evaluation and accuracy-based dynamic switching for issue #79.
Accuracy metrics (Spearman, RMSE, R²) are computed inside `SurrogateManager` after each fit,
and exposed as `last_accuracy`. Switcher helpers called in the `iterate()` loop replace the
active surrogate manager, strategy, or gen_ctrl value based on that snapshot.

## Changes
- Add `SurrogateAccuracyMetric` ABC and concrete metrics: `SpearmanCorrelation`, `RMSE`, `R2Score`
- Add `AccuracyEvaluator` ABC and concrete evaluators: `KFoldAccuracyEvaluator`, `LOOAccuracyEvaluator`, `HeldOutAccuracyEvaluator`
- Add `SurrogateAccuracy` dataclass (`metrics`, `n_samples`, `get()`)
- Integrate `accuracy_evaluator` and `last_accuracy` into `GlobalSurrogateManager` and `LocalSurrogateManager`
- Add `AccuracyBasedSurrogateSwitcher` ABC with `switch(accuracy) -> T` interface
- Add concrete switchers: `ManagerSwitcher`, `StrategySwitcher`, `GenCtrlSwitcher`

## Verification Steps
run pytest

## Concerns
- `LocalSurrogateManager.fit()` computes LOO accuracy by bypassing `TrainingSet.build()` directly; nearest-neighbor holdout in `score_candidates()` reduces effective training size by one per candidate