### PR TITLE
feat: [#80] Parallel execution support (joblib, multiprocessing)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
+parallel = ["joblib>=1.0.0"]
 sklearn = ["scikit-learn>=1.0.0"]
 xgboost = ["xgboost>=1.7.0"]
 lightgbm = ["lightgbm>=3.0.0"]

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -180,6 +180,8 @@ _TIER2_MAP: dict[str, str] = {
     "dda_non_dominated_sort": "saealib.comparators",
     "non_dominated_sort": "saealib.comparators",
     "spea2_fitness": "saealib.comparators",
+    # execution (parallel)
+    "JoblibEvaluator": "saealib.execution.evaluator",
     # decomposition
     "Decomposition": "saealib.decomposition",
     "DecompositionComparator": "saealib.decomposition",

--- a/src/saealib/execution/evaluator.py
+++ b/src/saealib/execution/evaluator.py
@@ -102,3 +102,120 @@ class SerialEvaluator(Evaluator):
             cv[i] = cv_i
 
         return EvaluationResult(f=f, g=g, cv=cv)
+
+
+class JoblibEvaluator(Evaluator):
+    """
+    Parallel evaluator backed by `joblib <https://joblib.readthedocs.io>`_.
+
+    Candidates in each batch are evaluated in parallel using joblib's
+    ``Parallel`` / ``delayed`` interface.  The default backend ``"loky"``
+    uses cloudpickle, so problem functions defined as lambdas or closures
+    are handled without extra serialisation work.
+
+    Switching to Dask or Ray is a single-parameter change::
+
+        JoblibEvaluator(n_jobs=-1, backend="dask")   # Dask cluster
+        JoblibEvaluator(n_jobs=-1, backend="ray")    # Ray cluster
+
+    Parameters
+    ----------
+    n_jobs : int
+        Number of parallel workers.  ``-1`` uses all available CPU cores
+        (joblib convention).  ``1`` disables parallelism (equivalent to
+        :class:`SerialEvaluator` but with joblib overhead).
+    backend : str
+        joblib backend name.  ``"loky"`` (default) launches fresh worker
+        processes with cloudpickle serialisation.  Other built-in options:
+        ``"threading"``, ``"multiprocessing"``.  Third-party backends
+        ``"dask"`` and ``"ray"`` require the corresponding packages and a
+        running cluster.
+    **joblib_kwargs
+        Additional keyword arguments forwarded verbatim to
+        ``joblib.Parallel``.  Useful for ``verbose``, ``prefer``,
+        ``require``, ``timeout``, etc.
+
+    Raises
+    ------
+    ImportError
+        If joblib is not installed.
+
+    Notes
+    -----
+    **Island-model nested parallelism**: when multiple islands each own a
+    ``JoblibEvaluator``, CPU cores may be over-subscribed.  Set
+    ``n_jobs=1`` per island evaluator and let the island-level parallelism
+    control concurrency, or use ``joblib.parallel_backend`` as a context
+    manager to limit inner workers.
+
+    Async evaluation is out of scope for this class.  Asynchronous
+    candidate dispatch would require changes to the ``Algorithm.ask`` /
+    ``Algorithm.tell`` interface and is tracked separately.
+    """
+
+    def __init__(
+        self,
+        n_jobs: int = -1,
+        backend: str = "loky",
+        **joblib_kwargs: object,
+    ) -> None:
+        try:
+            import joblib as _joblib  # noqa: F401
+        except ImportError as exc:
+            raise ImportError(
+                "JoblibEvaluator requires joblib. "
+                "Install it with: pip install saealib[parallel]"
+            ) from exc
+        self._n_jobs = n_jobs
+        self._backend = backend
+        self._joblib_kwargs = joblib_kwargs
+
+    @property
+    def n_jobs(self) -> int:
+        """Number of parallel workers (joblib convention; ``-1`` = all cores)."""
+        return self._n_jobs
+
+    @property
+    def backend(self) -> str:
+        """Joblib backend name."""
+        return self._backend
+
+    def evaluate_batch(self, x: np.ndarray, problem: Problem) -> EvaluationResult:
+        """
+        Evaluate candidates in parallel using joblib.
+
+        Parameters
+        ----------
+        x : np.ndarray
+            Design vectors to evaluate.  shape = (n, dim)
+        problem : Problem
+            The optimization problem providing the objective and constraints.
+
+        Returns
+        -------
+        EvaluationResult
+            Batched objective values, raw constraint values, and violations.
+        """
+        from joblib import Parallel, delayed
+
+        x = np.atleast_2d(np.asarray(x, dtype=float))
+        n = len(x)
+
+        def _eval_one(xi: np.ndarray) -> tuple[np.ndarray, np.ndarray, float]:
+            g_i, cv_i = problem.evaluate_constraints(xi)
+            f_i = problem.evaluate(xi, g_i)
+            return f_i, g_i, cv_i
+
+        results = Parallel(
+            n_jobs=self._n_jobs,
+            backend=self._backend,
+            **self._joblib_kwargs,
+        )(delayed(_eval_one)(x[i]) for i in range(n))
+
+        f = np.array([r[0] for r in results], dtype=float).reshape(n, problem.n_obj)
+        g = np.array([r[1] for r in results], dtype=float).reshape(
+            n, problem.n_constraints
+        )
+        cv = np.array([r[2] for r in results], dtype=float)
+
+        return EvaluationResult(f=f, g=g, cv=cv)

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -13,6 +13,7 @@ import numpy as np
 import pytest
 
 from saealib import EvaluationResult, Evaluator, Optimizer, SerialEvaluator
+from saealib.execution.evaluator import JoblibEvaluator
 from saealib.problem import InequalityConstraint, Problem
 
 
@@ -69,6 +70,74 @@ class TestSerialEvaluator:
         result = SerialEvaluator().evaluate_batch(np.array([[3.0, 4.0]]), p)
         assert result.f.shape == (1, 1)
         assert result.f[0, 0] == pytest.approx(25.0)
+
+
+joblib = pytest.importorskip("joblib", reason="joblib not installed")
+
+
+class TestJoblibEvaluator:
+    def test_import_error_raised_at_init(self, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "joblib":
+                raise ImportError("joblib not found")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        with pytest.raises(ImportError, match="saealib\\[parallel\\]"):
+            JoblibEvaluator()
+
+    def test_is_evaluator_subclass(self):
+        assert issubclass(JoblibEvaluator, Evaluator)
+
+    def test_default_properties(self):
+        ev = JoblibEvaluator()
+        assert ev.n_jobs == -1
+        assert ev.backend == "loky"
+
+    def test_custom_properties(self):
+        ev = JoblibEvaluator(n_jobs=2, backend="threading")
+        assert ev.n_jobs == 2
+        assert ev.backend == "threading"
+
+    def test_results_match_serial(self):
+        p = _sphere_problem(constraints=[InequalityConstraint(lambda x: x[0] - 1.0)])
+        x = np.array([[0.0, 0.0], [2.0, 0.0], [-3.0, 1.0]])
+        serial = SerialEvaluator().evaluate_batch(x, p)
+        parallel = JoblibEvaluator(n_jobs=2, backend="loky").evaluate_batch(x, p)
+        assert parallel.f == pytest.approx(serial.f)
+        assert parallel.g == pytest.approx(serial.g)
+        assert parallel.cv == pytest.approx(serial.cv)
+
+    def test_no_constraints_shape(self):
+        p = _sphere_problem()
+        x = np.array([[1.0, 2.0], [3.0, 4.0]])
+        result = JoblibEvaluator(n_jobs=2, backend="loky").evaluate_batch(x, p)
+        assert result.f.shape == (2, 1)
+        assert result.g.shape == (2, 0)
+        assert result.cv.shape == (2,)
+        assert np.all(result.cv == 0.0)
+
+    def test_threading_backend(self):
+        p = _sphere_problem()
+        x = np.array([[1.0, 0.0], [0.0, 1.0]])
+        serial = SerialEvaluator().evaluate_batch(x, p)
+        parallel = JoblibEvaluator(n_jobs=2, backend="threading").evaluate_batch(x, p)
+        assert parallel.f == pytest.approx(serial.f)
+
+    def test_result_is_evaluation_result(self):
+        p = _sphere_problem()
+        x = np.array([[1.0, 1.0]])
+        result = JoblibEvaluator(n_jobs=1, backend="loky").evaluate_batch(x, p)
+        assert isinstance(result, EvaluationResult)
+
+    def test_lazy_import_accessible_via_saealib(self):
+        import saealib
+
+        assert saealib.JoblibEvaluator is JoblibEvaluator
 
 
 class TestOptimizerWiring:

--- a/uv.lock
+++ b/uv.lock
@@ -1588,6 +1588,9 @@ dependencies = [
 lightgbm = [
     { name = "lightgbm" },
 ]
+parallel = [
+    { name = "joblib" },
+]
 sklearn = [
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1627,6 +1630,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "joblib", marker = "extra == 'parallel'", specifier = ">=1.0.0" },
     { name = "lightgbm", marker = "extra == 'lightgbm'", specifier = ">=3.0.0" },
     { name = "numpy", specifier = ">=1.22.1" },
     { name = "scikit-learn", marker = "extra == 'sklearn'", specifier = ">=1.0.0" },
@@ -1635,7 +1639,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.15.0" },
     { name = "xgboost", marker = "extra == 'xgboost'", specifier = ">=1.7.0" },
 ]
-provides-extras = ["lightgbm", "sklearn", "torch", "xgboost"]
+provides-extras = ["lightgbm", "parallel", "sklearn", "torch", "xgboost"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Related Issue
Closes #80

## Overview
Add `JoblibEvaluator`, a parallel batch evaluator backed by joblib. The `Evaluator` abstraction (#85) was already in place; this PR adds the parallel concrete implementation on top of it.

## Changes
- Add `JoblibEvaluator(n_jobs=-1, backend="loky", **joblib_kwargs)` to `src/saealib/execution/evaluator.py`
- Raise `ImportError` at construction time (not mid-run) when joblib is absent
- Add `saealib[parallel]` optional dependency group (`joblib>=1.0.0`)
- Export `JoblibEvaluator` via `saealib.__init__` (Tier 2 lazy import)
- Add `TestJoblibEvaluator` to `tests/test_evaluator.py` (7 tests)

## Verification Steps
run pytest

## Concerns
- `"threading"` backend is GIL-bound; effective only when the objective function releases the GIL (e.g. numpy-heavy or Cython code).
- Island-model nested parallelism: when each island owns a `JoblibEvaluator`, CPU cores may be over-subscribed. Use `n_jobs=1` per island evaluator in that case.
- `multiprocessing` backend is not added as a separate class; `backend="multiprocessing"` via `JoblibEvaluator` covers the use case.

## Other
Dask / Ray escalation requires only a backend parameter change and the respective package installed — no saealib API changes needed.