### PR TITLE
feat: [#95] Add top-level seed and checkpoint/resume to Optimizer

### DIFF
--- a/docs/tutorials/checkpoint.md
+++ b/docs/tutorials/checkpoint.md
@@ -1,0 +1,171 @@
+# 再現性とチェックポイント
+
+このチュートリアルでは，乱数シードによる再現性の確保と，長時間最適化の中断・再開（チェックポイント）の方法を説明します．
+
+## シードによる再現性
+
+`Optimizer` にシードを渡すと，初期個体生成から各世代のランダム操作まで，すべての乱数を一元管理します．
+
+```python
+import numpy as np
+from saealib import (
+    GA, CrossoverBLXAlpha, IndividualBasedStrategy, LHSInitializer,
+    MutationUniform, Optimizer, RBFsurrogate, SequentialSelection,
+    Termination, TruncationSelection, gaussian_kernel, max_fe,
+)
+from saealib.comparators import SingleObjectiveComparator
+from saealib.problem import Problem
+
+def sphere(x):
+    return np.array([np.sum(x ** 2)])
+
+problem = Problem(
+    func=sphere,
+    dim=5,
+    n_obj=1,
+    direction=np.array([-1.0]),
+    lb=[-5.0] * 5,
+    ub=[5.0] * 5,
+    comparator=SingleObjectiveComparator(),
+)
+
+def make_optimizer(seed=None):
+    return (
+        Optimizer(problem, seed=seed)         # seed を Optimizer に渡す
+        .set_initializer(LHSInitializer(20, 10))
+        .set_algorithm(GA(
+            crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.5),
+            mutation=MutationUniform(mutation_rate=0.1),
+            parent_selection=SequentialSelection(),
+            survivor_selection=TruncationSelection(),
+        ))
+        .set_surrogate(RBFsurrogate(gaussian_kernel, 5), n_neighbors=10)
+        .set_strategy(IndividualBasedStrategy(evaluation_ratio=0.5))
+        .set_termination(Termination(max_fe(200)))
+    )
+
+# 同じシードで2回実行 → 結果は完全一致
+ctx1 = make_optimizer(seed=42).run()
+ctx2 = make_optimizer(seed=42).run()
+
+assert np.array_equal(ctx1.archive.x, ctx2.archive.x)  # 一致
+```
+
+`seed=None`（デフォルト）では非決定的に動作します．
+
+---
+
+## チェックポイントの保存と再開
+
+### npz 形式（ポータブル）
+
+`ctx.save(path)` でアーカイブ・個体群・乱数状態を npz ファイルに保存します．再開は `OptimizationContext.load` でコンテキストを復元し，`optimizer.run_from` に渡します．
+
+```python
+from saealib.context import OptimizationContext
+
+# 前半を実行
+opt_first = make_optimizer(seed=42)
+opt_first.set_termination(Termination(max_fe(100)))  # 100 FE まで
+ctx_mid = opt_first.run()
+
+# チェックポイントを保存
+ctx_mid.save("checkpoint.npz")
+print(f"saved: gen={ctx_mid.gen}, fe={ctx_mid.fe}")
+
+# ─────── ここで中断・再起動 ───────
+
+# コンテキストを復元
+ctx_loaded = OptimizationContext.load("checkpoint.npz", problem)
+print(f"resumed={ctx_loaded.resumed}")  # True
+
+# 最終目標まで再開
+opt_resume = make_optimizer(seed=42)   # 同じ構成で再作成
+opt_resume.set_termination(Termination(max_fe(200)))  # 最終目標を設定
+ctx_final = opt_resume.run_from(ctx_loaded)
+
+print(f"final: gen={ctx_final.gen}, fe={ctx_final.fe}")
+```
+
+> **再現性について**  
+> `ctx.rng` の内部状態ごと保存するため，同一バージョン・同一環境では中断なし実行と完全一致します．バージョンをまたぐ場合の一致は保証されません．
+
+---
+
+### pickle 形式（より完全な復元）
+
+pickle を使うと，サロゲートの学習済みパラメータなど，Optimizer の全コンポーネントをそのまま保存・復元できます．
+
+```python
+import warnings
+
+# Optimizer ごと保存
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")          # バージョン依存の警告を抑制
+    opt_mid.save_pickle(ctx_mid, "checkpoint.pkl")
+
+# Optimizer ごと復元
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    opt_resume, ctx_loaded = Optimizer.load_pickle("checkpoint.pkl")
+
+opt_resume.set_termination(Termination(max_fe(200)))
+ctx_final = opt_resume.run_from(ctx_loaded)
+```
+
+> **制約**  
+> pickle ファイルは Python・ライブラリのバージョンに依存します．lambda 関数を `Problem.func` に使用している場合は pickle できません（モジュールレベルの関数を使用してください）．
+
+---
+
+## 自動チェックポイント
+
+`run()` / `iterate()` の `checkpoint_path` パラメータで，N 世代ごとに自動保存できます．
+
+```python
+ctx = opt.run(
+    checkpoint_path="checkpoints/",   # 保存先ディレクトリ
+    checkpoint_interval=5,             # 5 世代ごとに保存
+    checkpoint_format="npz",           # "npz" | "pickle" | "both"
+    checkpoint_delete_on_success=True, # 正常終了後に削除
+)
+```
+
+ファイルは `checkpoints/checkpoint_000005.npz`, `checkpoints/checkpoint_000010.npz`, … のように命名されます．
+
+### CheckpointCallback を直接使う
+
+より細かい制御が必要な場合は `CheckpointCallback` を直接登録します．
+
+```python
+from saealib import CheckpointCallback
+
+cb = CheckpointCallback(
+    path="checkpoints/",
+    interval=5,
+    format="both",             # npz と pkl を両方保存
+    delete_on_success=False,
+    optimizer=opt,             # pickle 形式に必要
+)
+cb.register(opt.cbmanager)
+
+ctx = opt.run()
+```
+
+---
+
+## resumed フラグ
+
+チェックポイントから復元したコンテキストには `resumed=True` がセットされます．コールバックや戦略でこのフラグを参照できます．
+
+```python
+from saealib.callback import RunStartEvent
+
+def on_start(event):
+    if event.ctx.resumed:
+        print("チェックポイントから再開しました")
+    else:
+        print("新規実行を開始します")
+
+opt.cbmanager.register(RunStartEvent, on_start)
+```

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -11,4 +11,5 @@ constraints
 acquisition_functions
 callbacks
 custom_components
+checkpoint
 ```

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -10,6 +10,7 @@ __version__ = version("saealib")
 # ---------------------------------------------------------------------------
 
 from saealib.acquisition import AcquisitionFunction, ExpectedImprovement
+from saealib.checkpoint import CheckpointCallback
 from saealib.algorithms import GA, PSO, Algorithm
 from saealib.api import Result, maximize, minimize
 from saealib.callback import (
@@ -84,6 +85,8 @@ __all__ = [
     "PSO",
     # Core abstractions
     "AcquisitionFunction",
+    # Checkpoint
+    "CheckpointCallback",
     "Algorithm",
     # Population & data
     "Archive",

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -10,7 +10,6 @@ __version__ = version("saealib")
 # ---------------------------------------------------------------------------
 
 from saealib.acquisition import AcquisitionFunction, ExpectedImprovement
-from saealib.checkpoint import CheckpointCallback
 from saealib.algorithms import GA, PSO, Algorithm
 from saealib.api import Result, maximize, minimize
 from saealib.callback import (
@@ -24,6 +23,7 @@ from saealib.callback import (
     RunEndEvent,
     RunStartEvent,
 )
+from saealib.checkpoint import CheckpointCallback
 from saealib.comparators import Comparator, NSGA2Comparator, SingleObjectiveComparator
 from saealib.exceptions import ConfigurationError, SaealibError, ValidationError
 from saealib.execution.evaluator import EvaluationResult, Evaluator, SerialEvaluator
@@ -80,38 +80,27 @@ from saealib.variables import (
 logger = logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 __all__ = [
-    # Algorithms
     "GA",
     "PSO",
-    # Core abstractions
     "AcquisitionFunction",
-    # Checkpoint
-    "CheckpointCallback",
     "Algorithm",
-    # Population & data
     "Archive",
-    # Callbacks (core)
     "CallbackManager",
     "CategoricalVariable",
+    "CheckpointCallback",
     "Comparator",
     "ConfigurationError",
-    # Problem
     "ConstraintHandler",
     "ContinuousVariable",
     "Crossover",
-    # Operators (common)
     "CrossoverSBX",
     "EpsilonConstraintHandler",
     "EqualityConstraint",
     "EvaluationResult",
-    # Execution
     "Evaluator",
     "Event",
-    # Acquisition (core)
     "ExpectedImprovement",
-    # Surrogate (core)
     "GPRSurrogate",
-    # Strategies
     "GenerationBasedStrategy",
     "GenerationEndEvent",
     "GenerationStartEvent",
@@ -125,7 +114,6 @@ __all__ = [
     "LHSInitializer",
     "Mutation",
     "MutationPolynomial",
-    # Comparators (common)
     "NSGA2Comparator",
     "OptimizationStrategy",
     "Optimizer",
@@ -146,7 +134,6 @@ __all__ = [
     "Surrogate",
     "SurrogateManager",
     "SurvivorSelection",
-    # Termination
     "Termination",
     "TerminationCondition",
     "TournamentSelection",
@@ -154,12 +141,10 @@ __all__ = [
     "ValidationError",
     "Variable",
     "f_target",
-    # Indicators
     "hypervolume",
     "hypervolume_contributions",
     "max_fe",
     "max_gen",
-    # API entry points
     "maximize",
     "minimize",
     "stalled",

--- a/src/saealib/acquisition/base.py
+++ b/src/saealib/acquisition/base.py
@@ -32,7 +32,11 @@ class AcquisitionFunction(ABC):
     requires_uncertainty: bool = False
 
     @abstractmethod
-    def compute_reference(self, archive: Archive) -> Any:
+    def compute_reference(
+        self,
+        archive: Archive,
+        rng: np.random.Generator | None = None,
+    ) -> Any:
         """
         Compute the reference value required by this acquisition function.
 
@@ -46,6 +50,10 @@ class AcquisitionFunction(ABC):
         ----------
         archive : Archive
             Archive of evaluated solutions.
+        rng : np.random.Generator or None, optional
+            Random number generator from ``ctx.rng``.  Implementations that
+            require randomness should prefer this over a stored ``_rng`` so
+            that all randomness flows through the single master RNG.
 
         Returns
         -------
@@ -60,6 +68,7 @@ class AcquisitionFunction(ABC):
         self,
         prediction: SurrogatePrediction,
         reference: Any,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         """
         Compute acquisition scores for a set of candidates.
@@ -70,6 +79,8 @@ class AcquisitionFunction(ABC):
             Predictions from a surrogate model.
         reference : Any
             Reference value produced by ``compute_reference``.
+        rng : np.random.Generator or None, optional
+            Random number generator from ``ctx.rng``.
 
         Returns
         -------

--- a/src/saealib/acquisition/ehvi.py
+++ b/src/saealib/acquisition/ehvi.py
@@ -54,7 +54,9 @@ class EHVIAcquisition(AcquisitionFunction):
         self._rng = rng if rng is not None else np.random.default_rng()
 
     def compute_reference(
-        self, archive: Archive
+        self,
+        archive: Archive,
+        rng: np.random.Generator | None = None,
     ) -> tuple[np.ndarray, np.ndarray, float]:
         """
         Extract the Pareto front and (if needed) compute the reference point.
@@ -87,6 +89,7 @@ class EHVIAcquisition(AcquisitionFunction):
         self,
         prediction: SurrogatePrediction,
         reference: Any,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         """
         Estimate EHVI via Monte Carlo sampling.
@@ -97,6 +100,10 @@ class EHVIAcquisition(AcquisitionFunction):
             Surrogate predictions.  Must have std (has_uncertainty == True).
         reference : tuple
             ``(pareto_f, ref_point, base_hv)`` from ``compute_reference``.
+        rng : np.random.Generator or None, optional
+            Random number generator.  When provided (e.g. ``ctx.rng``), it is
+            used instead of the instance-level ``_rng`` so all randomness flows
+            through the master RNG.
 
         Returns
         -------
@@ -119,7 +126,8 @@ class EHVIAcquisition(AcquisitionFunction):
         n_cand, n_obj = mu.shape
 
         # Draw all MC samples at once: (n_samples, n_cand, n_obj)
-        eps = self._rng.standard_normal((self.n_samples, n_cand, n_obj))
+        _rng = rng if rng is not None else self._rng
+        eps = _rng.standard_normal((self.n_samples, n_cand, n_obj))
         mc_samples = mu[np.newaxis] + sigma[np.newaxis] * eps
 
         ehvi = np.zeros(n_cand)

--- a/src/saealib/acquisition/ei.py
+++ b/src/saealib/acquisition/ei.py
@@ -46,7 +46,7 @@ class ExpectedImprovement(AcquisitionFunction):
         self.obj_idx = obj_idx
         self.reference = reference
 
-    def compute_reference(self, archive: Archive) -> np.ndarray:
+    def compute_reference(self, archive: Archive, rng: np.random.Generator | None = None) -> np.ndarray:
         """Return fixed reference if set, otherwise component-wise best from archive."""
         if self.reference is not None:
             return self.reference
@@ -56,6 +56,7 @@ class ExpectedImprovement(AcquisitionFunction):
         self,
         prediction: SurrogatePrediction,
         reference: Any,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         """
         Compute Expected Improvement scores.

--- a/src/saealib/acquisition/ei.py
+++ b/src/saealib/acquisition/ei.py
@@ -46,7 +46,9 @@ class ExpectedImprovement(AcquisitionFunction):
         self.obj_idx = obj_idx
         self.reference = reference
 
-    def compute_reference(self, archive: Archive, rng: np.random.Generator | None = None) -> np.ndarray:
+    def compute_reference(
+        self, archive: Archive, rng: np.random.Generator | None = None
+    ) -> np.ndarray:
         """Return fixed reference if set, otherwise component-wise best from archive."""
         if self.reference is not None:
             return self.reference

--- a/src/saealib/acquisition/lcb.py
+++ b/src/saealib/acquisition/lcb.py
@@ -45,7 +45,7 @@ class LowerConfidenceBound(AcquisitionFunction):
         self.obj_idx = obj_idx
         self.reference = reference
 
-    def compute_reference(self, archive: Archive) -> Any:
+    def compute_reference(self, archive: Archive, rng: np.random.Generator | None = None) -> Any:
         """Return fixed reference if set, otherwise None."""
         return self.reference
 
@@ -53,6 +53,7 @@ class LowerConfidenceBound(AcquisitionFunction):
         self,
         prediction: SurrogatePrediction,
         reference: Any = None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         """
         Compute negated LCB scores (higher is better).

--- a/src/saealib/acquisition/lcb.py
+++ b/src/saealib/acquisition/lcb.py
@@ -45,7 +45,9 @@ class LowerConfidenceBound(AcquisitionFunction):
         self.obj_idx = obj_idx
         self.reference = reference
 
-    def compute_reference(self, archive: Archive, rng: np.random.Generator | None = None) -> Any:
+    def compute_reference(
+        self, archive: Archive, rng: np.random.Generator | None = None
+    ) -> Any:
         """Return fixed reference if set, otherwise None."""
         return self.reference
 

--- a/src/saealib/acquisition/mean.py
+++ b/src/saealib/acquisition/mean.py
@@ -48,7 +48,7 @@ class MeanPrediction(AcquisitionFunction):
         self.direction = direction
         self.reference = reference
 
-    def compute_reference(self, archive: Archive) -> Any:
+    def compute_reference(self, archive: Archive, rng: np.random.Generator | None = None) -> Any:
         """Return fixed reference if set, otherwise None."""
         return self.reference
 
@@ -56,6 +56,7 @@ class MeanPrediction(AcquisitionFunction):
         self,
         prediction: SurrogatePrediction,
         reference: Any = None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         """
         Compute scores based on predicted mean.

--- a/src/saealib/acquisition/mean.py
+++ b/src/saealib/acquisition/mean.py
@@ -48,7 +48,9 @@ class MeanPrediction(AcquisitionFunction):
         self.direction = direction
         self.reference = reference
 
-    def compute_reference(self, archive: Archive, rng: np.random.Generator | None = None) -> Any:
+    def compute_reference(
+        self, archive: Archive, rng: np.random.Generator | None = None
+    ) -> Any:
         """Return fixed reference if set, otherwise None."""
         return self.reference
 

--- a/src/saealib/acquisition/parego.py
+++ b/src/saealib/acquisition/parego.py
@@ -70,7 +70,9 @@ class ParEGOAcquisition(AcquisitionFunction):
         return weighted.max(axis=-1) + self.alpha * weighted.sum(axis=-1)
 
     def compute_reference(
-        self, archive: Archive
+        self,
+        archive: Archive,
+        rng: np.random.Generator | None = None,
     ) -> tuple[np.ndarray, np.ndarray, float]:
         """
         Sample a new weight vector and compute the ideal point.
@@ -79,6 +81,10 @@ class ParEGOAcquisition(AcquisitionFunction):
         ----------
         archive : Archive
             Archive of evaluated solutions.
+        rng : np.random.Generator or None, optional
+            Random number generator.  When provided (e.g. ``ctx.rng``), it is
+            used instead of the instance-level ``_rng`` so all randomness flows
+            through the master RNG.
 
         Returns
         -------
@@ -90,7 +96,7 @@ class ParEGOAcquisition(AcquisitionFunction):
         """
         n_obj = archive.f.shape[1]
         z_star = archive.f.min(axis=0)
-        weights = self._rng.dirichlet(np.ones(n_obj))
+        weights = (rng if rng is not None else self._rng).dirichlet(np.ones(n_obj))
         f_best = float(self._scalarize(archive.f, weights, z_star).min())
         return z_star, weights, f_best
 
@@ -98,6 +104,7 @@ class ParEGOAcquisition(AcquisitionFunction):
         self,
         prediction: SurrogatePrediction,
         reference: Any,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         """
         Compute EI on the Augmented Tchebycheff scalarised prediction.

--- a/src/saealib/acquisition/pof.py
+++ b/src/saealib/acquisition/pof.py
@@ -40,7 +40,7 @@ class ProbabilityOfFeasibility(AcquisitionFunction):
         self.obj_idx = obj_idx
         self.reference = reference
 
-    def compute_reference(self, archive: Archive) -> Any:
+    def compute_reference(self, archive: Archive, rng: np.random.Generator | None = None) -> Any:
         """Return fixed reference if set, otherwise None."""
         return self.reference
 
@@ -48,6 +48,7 @@ class ProbabilityOfFeasibility(AcquisitionFunction):
         self,
         prediction: SurrogatePrediction,
         reference: Any = None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         """
         Compute Probability of Feasibility scores.
@@ -125,7 +126,7 @@ class ProductOfFeasibility(AcquisitionFunction):
 
     requires_uncertainty: bool = True
 
-    def compute_reference(self, archive: Archive) -> Any:
+    def compute_reference(self, archive: Archive, rng: np.random.Generator | None = None) -> Any:
         """Return None (no reference needed)."""
         return None
 
@@ -133,6 +134,7 @@ class ProductOfFeasibility(AcquisitionFunction):
         self,
         prediction: SurrogatePrediction,
         reference: Any = None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         """
         Compute joint probability of feasibility scores.

--- a/src/saealib/acquisition/pof.py
+++ b/src/saealib/acquisition/pof.py
@@ -40,7 +40,9 @@ class ProbabilityOfFeasibility(AcquisitionFunction):
         self.obj_idx = obj_idx
         self.reference = reference
 
-    def compute_reference(self, archive: Archive, rng: np.random.Generator | None = None) -> Any:
+    def compute_reference(
+        self, archive: Archive, rng: np.random.Generator | None = None
+    ) -> Any:
         """Return fixed reference if set, otherwise None."""
         return self.reference
 
@@ -126,7 +128,9 @@ class ProductOfFeasibility(AcquisitionFunction):
 
     requires_uncertainty: bool = True
 
-    def compute_reference(self, archive: Archive, rng: np.random.Generator | None = None) -> Any:
+    def compute_reference(
+        self, archive: Archive, rng: np.random.Generator | None = None
+    ) -> Any:
         """Return None (no reference needed)."""
         return None
 

--- a/src/saealib/acquisition/smsego.py
+++ b/src/saealib/acquisition/smsego.py
@@ -54,7 +54,9 @@ class SMSEGOAcquisition(AcquisitionFunction):
         )
 
     def compute_reference(
-        self, archive: Archive
+        self,
+        archive: Archive,
+        rng: np.random.Generator | None = None,
     ) -> tuple[np.ndarray, np.ndarray, float]:
         """
         Extract the Pareto front and (if needed) compute the reference point.
@@ -87,6 +89,7 @@ class SMSEGOAcquisition(AcquisitionFunction):
         self,
         prediction: SurrogatePrediction,
         reference: Any,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         """
         Compute hypervolume improvement of the LCB-predicted candidates.

--- a/src/saealib/acquisition/uncertainty.py
+++ b/src/saealib/acquisition/uncertainty.py
@@ -36,7 +36,7 @@ class MaxUncertainty(AcquisitionFunction):
         self.weights = weights
         self.reference = reference
 
-    def compute_reference(self, archive: Archive) -> Any:
+    def compute_reference(self, archive: Archive, rng: np.random.Generator | None = None) -> Any:
         """Return fixed reference if set, otherwise None."""
         return self.reference
 
@@ -44,6 +44,7 @@ class MaxUncertainty(AcquisitionFunction):
         self,
         prediction: SurrogatePrediction,
         reference: Any = None,
+        rng: np.random.Generator | None = None,
     ) -> np.ndarray:
         """
         Compute scores based on predictive standard deviation.

--- a/src/saealib/acquisition/uncertainty.py
+++ b/src/saealib/acquisition/uncertainty.py
@@ -36,7 +36,9 @@ class MaxUncertainty(AcquisitionFunction):
         self.weights = weights
         self.reference = reference
 
-    def compute_reference(self, archive: Archive, rng: np.random.Generator | None = None) -> Any:
+    def compute_reference(
+        self, archive: Archive, rng: np.random.Generator | None = None
+    ) -> Any:
         """Return fixed reference if set, otherwise None."""
         return self.reference
 

--- a/src/saealib/checkpoint.py
+++ b/src/saealib/checkpoint.py
@@ -1,0 +1,107 @@
+"""CheckpointCallback: automatic checkpoint saving during optimization."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from saealib.callback import CallbackManager, GenerationEndEvent, RunEndEvent
+    from saealib.optimizer import Optimizer
+
+
+class CheckpointCallback:
+    """
+    Callback that saves checkpoints at regular generation intervals.
+
+    Two formats are supported:
+
+    - ``'npz'``: portable numpy format (best-effort reproducibility).
+    - ``'pickle'``: full optimizer + context state (limited complete
+      reproducibility; version-sensitive).
+    - ``'both'``: saves both formats each checkpoint.
+
+    Register this callback with :meth:`register`, or pass it implicitly
+    via the ``checkpoint_*`` parameters of :meth:`~saealib.Optimizer.run`
+    and :meth:`~saealib.Optimizer.iterate`.
+
+    Parameters
+    ----------
+    path : str or Path
+        Directory where checkpoint files are saved.  Created if absent.
+    interval : int, optional
+        Save a checkpoint every *interval* generations.  Default: 1.
+    format : {'npz', 'pickle', 'both'}, optional
+        Checkpoint format.  Default: ``'npz'``.
+    delete_on_success : bool, optional
+        If True, all checkpoint files produced by this callback are
+        deleted when the run terminates normally (``RunEndEvent``).
+        Useful to avoid accumulating files after a successful run.
+        Default: False.
+    optimizer : Optimizer or None, optional
+        Required when *format* is ``'pickle'`` or ``'both'``.
+    """
+
+    _VALID_FORMATS = frozenset({"npz", "pickle", "both"})
+
+    def __init__(
+        self,
+        path: str | Path,
+        interval: int = 1,
+        format: str = "npz",
+        delete_on_success: bool = False,
+        optimizer: Optimizer | None = None,
+    ) -> None:
+        if format not in self._VALID_FORMATS:
+            raise ValueError(
+                f"format must be one of {sorted(self._VALID_FORMATS)!r}, "
+                f"got {format!r}"
+            )
+        if format in ("pickle", "both") and optimizer is None:
+            raise ValueError(
+                "optimizer must be provided when format is 'pickle' or 'both'"
+            )
+        self._base = Path(path)
+        self.interval = interval
+        self.format = format
+        self.delete_on_success = delete_on_success
+        self._optimizer = optimizer
+        self._saved: list[Path] = []
+
+    def register(self, cbmanager: CallbackManager) -> None:
+        """Register generation-end and run-end handlers on *cbmanager*."""
+        from saealib.callback import GenerationEndEvent, RunEndEvent
+
+        cbmanager.register(GenerationEndEvent, self._on_generation_end)
+        cbmanager.register(RunEndEvent, self._on_run_end)
+
+    def _on_generation_end(self, event: GenerationEndEvent) -> None:
+        ctx = event.ctx
+        if ctx.gen % self.interval != 0:
+            return
+
+        self._base.mkdir(parents=True, exist_ok=True)
+        stem = f"checkpoint_{ctx.gen:06d}"
+
+        if self.format in ("npz", "both"):
+            p = self._base / f"{stem}.npz"
+            ctx.save(p)
+            self._saved.append(p)
+
+        if self.format in ("pickle", "both"):
+            p = self._base / f"{stem}.pkl"
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                self._optimizer.save_pickle(ctx, p)  # type: ignore[union-attr]
+            self._saved.append(p)
+
+    def _on_run_end(self, event: RunEndEvent) -> None:
+        if not self.delete_on_success:
+            return
+        for p in self._saved:
+            try:
+                p.unlink(missing_ok=True)
+            except OSError:
+                pass
+        self._saved.clear()

--- a/src/saealib/checkpoint.py
+++ b/src/saealib/checkpoint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -55,8 +56,7 @@ class CheckpointCallback:
     ) -> None:
         if format not in self._VALID_FORMATS:
             raise ValueError(
-                f"format must be one of {sorted(self._VALID_FORMATS)!r}, "
-                f"got {format!r}"
+                f"format must be one of {sorted(self._VALID_FORMATS)!r}, got {format!r}"
             )
         if format in ("pickle", "both") and optimizer is None:
             raise ValueError(
@@ -100,8 +100,6 @@ class CheckpointCallback:
         if not self.delete_on_success:
             return
         for p in self._saved:
-            try:
+            with contextlib.suppress(OSError):
                 p.unlink(missing_ok=True)
-            except OSError:
-                pass
         self._saved.clear()

--- a/src/saealib/context.py
+++ b/src/saealib/context.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -34,6 +36,8 @@ class OptimizationContext:
         Number of function evaluations.
     gen : int
         Number of generations.
+    resumed : bool
+        True when this context was restored from a checkpoint.
     metadata : dict
         Metadata.
     """
@@ -47,6 +51,7 @@ class OptimizationContext:
 
     fe: int = 0
     gen: int = 0
+    resumed: bool = False
 
     metadata: dict = field(default_factory=dict)
 
@@ -94,3 +99,151 @@ class OptimizationContext:
     def count_generation(self) -> None:
         """Count generations."""
         self.gen += 1
+
+    # ------------------------------------------------------------------
+    # Checkpoint: npz (best-effort reproducibility)
+    # ------------------------------------------------------------------
+
+    def save(self, path: str | Path) -> None:
+        """
+        Save optimization state to an npz file.
+
+        Saves archive, population, Pareto archive arrays and the RNG state.
+        Reproducibility is best-effort: bit-exact resume is expected within
+        the same NumPy version and environment, but not guaranteed across
+        versions.
+
+        Parameters
+        ----------
+        path : str or Path
+            Destination file path.  The ``.npz`` extension is added if absent.
+        """
+        p = Path(path)
+        if not p.suffix:
+            p = p.with_suffix(".npz")
+
+        save_dict: dict[str, np.ndarray] = {}
+
+        # Schema — serialise attribute definitions from the archive
+        schema = []
+        for name, attr in self.archive.schema.items():
+            arr = self.archive._data[name]
+            default = attr.default
+            default_json: object = "__nan__" if (
+                isinstance(default, float) and np.isnan(default)
+            ) else default
+            schema.append({
+                "name": name,
+                "dtype": arr.dtype.str,
+                "shape": list(arr.shape[1:]),
+                "default": default_json,
+            })
+        save_dict["_schema"] = np.frombuffer(
+            json.dumps(schema).encode(), dtype=np.uint8
+        )
+
+        # RNG state (full bit-generator state for exact restoration)
+        save_dict["_rng_state"] = np.frombuffer(
+            json.dumps(self.rng.bit_generator.state).encode(), dtype=np.uint8
+        )
+
+        # Scalar counters
+        save_dict["_fe"] = np.array(self.fe)
+        save_dict["_gen"] = np.array(self.gen)
+
+        # Archive arrays
+        n_arch = len(self.archive)
+        save_dict["_archive_size"] = np.array(n_arch)
+        for name, arr in self.archive._data.items():
+            save_dict[f"archive__{name}"] = arr[:n_arch]
+
+        # Population arrays
+        n_pop = len(self.population)
+        save_dict["_pop_size"] = np.array(n_pop)
+        for name, arr in self.population._data.items():
+            save_dict[f"pop__{name}"] = arr[:n_pop]
+
+        # Pareto archive arrays
+        n_pareto = len(self.pareto_archive)
+        save_dict["_pareto_size"] = np.array(n_pareto)
+        for name, arr in self.pareto_archive._data.items():
+            save_dict[f"pareto__{name}"] = arr[:n_pareto]
+
+        np.savez(p, **save_dict)
+
+    @classmethod
+    def load(cls, path: str | Path, problem: Problem) -> OptimizationContext:
+        """
+        Restore an OptimizationContext from an npz checkpoint file.
+
+        The returned context has ``resumed=True``.
+
+        Parameters
+        ----------
+        path : str or Path
+            Path to the npz file.  The ``.npz`` extension is added if absent.
+        problem : Problem
+            The problem instance to attach (must match the one used when saving).
+
+        Returns
+        -------
+        OptimizationContext
+        """
+        from saealib.population import Archive, ParetoArchive, Population, PopulationAttribute
+
+        p = Path(path)
+        if not p.suffix:
+            p = p.with_suffix(".npz")
+
+        data = np.load(p, allow_pickle=False)
+
+        # Reconstruct attribute schema
+        schema_list = json.loads(bytes(data["_schema"]).decode())
+        attrs = []
+        for s in schema_list:
+            default = s["default"]
+            if default == "__nan__":
+                default = np.nan
+            attrs.append(PopulationAttribute(
+                name=s["name"],
+                dtype=np.dtype(s["dtype"]),
+                shape=tuple(s["shape"]),
+                default=default,
+            ))
+
+        n_arch = int(data["_archive_size"])
+        n_pop = int(data["_pop_size"])
+        n_pareto = int(data["_pareto_size"])
+        attr_names = [a.name for a in attrs]
+
+        archive = Archive(attrs=attrs, init_capacity=max(n_arch, 1))
+        if n_arch > 0:
+            archive.extend({name: data[f"archive__{name}"] for name in attr_names})
+
+        population = Population(attrs=attrs, init_capacity=max(n_pop, 1))
+        if n_pop > 0:
+            population.extend({name: data[f"pop__{name}"] for name in attr_names})
+
+        pareto_archive = ParetoArchive(
+            attrs=attrs,
+            init_capacity=max(n_pareto, 1),
+            direction=problem.direction,
+        )
+        if n_pareto > 0:
+            pareto_archive.extend({name: data[f"pareto__{name}"] for name in attr_names})
+
+        # Restore RNG to exact saved state
+        rng_state = json.loads(bytes(data["_rng_state"]).decode())
+        rng = np.random.default_rng()
+        rng.bit_generator.state = rng_state
+
+        return cls(
+            problem=problem,
+            population=population,
+            archive=archive,
+            pareto_archive=pareto_archive,
+            rng=rng,
+            fe=int(data["_fe"]),
+            gen=int(data["_gen"]),
+            resumed=True,
+        )

--- a/src/saealib/context.py
+++ b/src/saealib/context.py
@@ -129,15 +129,19 @@ class OptimizationContext:
         for name, attr in self.archive.schema.items():
             arr = self.archive._data[name]
             default = attr.default
-            default_json: object = "__nan__" if (
-                isinstance(default, float) and np.isnan(default)
-            ) else default
-            schema.append({
-                "name": name,
-                "dtype": arr.dtype.str,
-                "shape": list(arr.shape[1:]),
-                "default": default_json,
-            })
+            default_json: object = (
+                "__nan__"
+                if (isinstance(default, float) and np.isnan(default))
+                else default
+            )
+            schema.append(
+                {
+                    "name": name,
+                    "dtype": arr.dtype.str,
+                    "shape": list(arr.shape[1:]),
+                    "default": default_json,
+                }
+            )
         save_dict["_schema"] = np.frombuffer(
             json.dumps(schema).encode(), dtype=np.uint8
         )
@@ -189,7 +193,12 @@ class OptimizationContext:
         -------
         OptimizationContext
         """
-        from saealib.population import Archive, ParetoArchive, Population, PopulationAttribute
+        from saealib.population import (
+            Archive,
+            ParetoArchive,
+            Population,
+            PopulationAttribute,
+        )
 
         p = Path(path)
         if not p.suffix:
@@ -204,12 +213,14 @@ class OptimizationContext:
             default = s["default"]
             if default == "__nan__":
                 default = np.nan
-            attrs.append(PopulationAttribute(
-                name=s["name"],
-                dtype=np.dtype(s["dtype"]),
-                shape=tuple(s["shape"]),
-                default=default,
-            ))
+            attrs.append(
+                PopulationAttribute(
+                    name=s["name"],
+                    dtype=np.dtype(s["dtype"]),
+                    shape=tuple(s["shape"]),
+                    default=default,
+                )
+            )
 
         n_arch = int(data["_archive_size"])
         n_pop = int(data["_pop_size"])
@@ -230,7 +241,9 @@ class OptimizationContext:
             direction=problem.direction,
         )
         if n_pareto > 0:
-            pareto_archive.extend({name: data[f"pareto__{name}"] for name in attr_names})
+            pareto_archive.extend(
+                {name: data[f"pareto__{name}"] for name in attr_names}
+            )
 
         # Restore RNG to exact saved state
         rng_state = json.loads(bytes(data["_rng_state"]).decode())

--- a/src/saealib/execution/initializer.py
+++ b/src/saealib/execution/initializer.py
@@ -150,7 +150,10 @@ class LHSInitializer(Initializer):
         -------
         OptimizationContext
         """
-        rng = np.random.default_rng(self.seed)
+        provider_seed = getattr(provider, "seed", None)
+        rng = np.random.default_rng(
+            provider_seed if provider_seed is not None else self.seed
+        )
         attrs = self._create_attrs(problem, provider)
 
         population = provider.algorithm.population_class(

--- a/src/saealib/execution/runner.py
+++ b/src/saealib/execution/runner.py
@@ -36,6 +36,12 @@ class Runner:
             pass
         return ctx
 
+    def run_from(self, ctx: OptimizationContext) -> OptimizationContext:
+        """Resume from an existing context and run to completion."""
+        for ctx in self.iterate_from(ctx):
+            pass
+        return ctx
+
     def iterate(self) -> Generator[OptimizationContext, None, None]:
         """
         Iterate the optimization loop, yielding the context after each generation.
@@ -46,6 +52,26 @@ class Runner:
         """
         opt = self.optimizer
         ctx = opt.initializer.initialize(opt, opt.problem)
+        yield from self.iterate_from(ctx)
+
+    def iterate_from(
+        self, ctx: OptimizationContext
+    ) -> Generator[OptimizationContext, None, None]:
+        """
+        Resume the optimization loop from an existing context.
+
+        Skips initialization; useful after loading a checkpoint.
+
+        Parameters
+        ----------
+        ctx : OptimizationContext
+            Previously saved (or freshly constructed) context to resume from.
+
+        Returns
+        -------
+        Generator[OptimizationContext, None, None]
+        """
+        opt = self.optimizer
         ctx.comparator.eps_cv = ctx.problem.handler.feasibility_threshold
 
         opt.dispatch(RunStartEvent(ctx=ctx))

--- a/src/saealib/optimizer.py
+++ b/src/saealib/optimizer.py
@@ -260,9 +260,45 @@ class Optimizer:
 
         return issues
 
-    def iterate(self) -> Generator[OptimizationContext, None, None]:
+    def _register_checkpoint(
+        self,
+        path: str | Path,
+        interval: int,
+        format: str,
+        delete_on_success: bool,
+    ) -> None:
+        from saealib.checkpoint import CheckpointCallback
+
+        cb = CheckpointCallback(
+            path=path,
+            interval=interval,
+            format=format,
+            delete_on_success=delete_on_success,
+            optimizer=self if format in ("pickle", "both") else None,
+        )
+        cb.register(self.cbmanager)
+
+    def iterate(
+        self,
+        checkpoint_path: str | Path | None = None,
+        checkpoint_interval: int = 1,
+        checkpoint_format: str = "npz",
+        checkpoint_delete_on_success: bool = False,
+    ) -> Generator[OptimizationContext, None, None]:
         """
         Iterate the optimization process.
+
+        Parameters
+        ----------
+        checkpoint_path : str, Path, or None, optional
+            If provided, checkpoints are saved to this directory every
+            *checkpoint_interval* generations.
+        checkpoint_interval : int, optional
+            Generations between checkpoints.  Default: 1.
+        checkpoint_format : {'npz', 'pickle', 'both'}, optional
+            Checkpoint format.  Default: ``'npz'``.
+        checkpoint_delete_on_success : bool, optional
+            Delete checkpoints on normal termination.  Default: False.
 
         Returns
         -------
@@ -274,11 +310,36 @@ class Optimizer:
             raise ConfigurationError(
                 "Optimizer misconfigured:\n" + "\n".join(f"  - {m}" for m in issues)
             )
+        if checkpoint_path is not None:
+            self._register_checkpoint(
+                checkpoint_path,
+                checkpoint_interval,
+                checkpoint_format,
+                checkpoint_delete_on_success,
+            )
         return Runner(self).iterate()
 
-    def run(self) -> OptimizationContext:
+    def run(
+        self,
+        checkpoint_path: str | Path | None = None,
+        checkpoint_interval: int = 1,
+        checkpoint_format: str = "npz",
+        checkpoint_delete_on_success: bool = False,
+    ) -> OptimizationContext:
         """
         Run the optimization process.
+
+        Parameters
+        ----------
+        checkpoint_path : str, Path, or None, optional
+            If provided, checkpoints are saved to this directory every
+            *checkpoint_interval* generations.
+        checkpoint_interval : int, optional
+            Generations between checkpoints.  Default: 1.
+        checkpoint_format : {'npz', 'pickle', 'both'}, optional
+            Checkpoint format.  Default: ``'npz'``.
+        checkpoint_delete_on_success : bool, optional
+            Delete checkpoints on normal termination.  Default: False.
 
         Returns
         -------
@@ -289,6 +350,13 @@ class Optimizer:
         if issues:
             raise ConfigurationError(
                 "Optimizer misconfigured:\n" + "\n".join(f"  - {m}" for m in issues)
+            )
+        if checkpoint_path is not None:
+            self._register_checkpoint(
+                checkpoint_path,
+                checkpoint_interval,
+                checkpoint_format,
+                checkpoint_delete_on_success,
             )
         return Runner(self).run()
 

--- a/src/saealib/optimizer.py
+++ b/src/saealib/optimizer.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import pickle
+import warnings
 from collections.abc import Generator
+from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
 from saealib.acquisition.mean import MeanPrediction
@@ -192,8 +195,16 @@ class Optimizer:
 
     # --- run ---
 
-    def validate(self) -> list[str]:
-        """Check configuration consistency. Returns list of issues."""
+    def validate(self, *, require_initializer: bool = True) -> list[str]:
+        """
+        Check configuration consistency. Returns list of issues.
+
+        Parameters
+        ----------
+        require_initializer : bool, optional
+            When False, skip the initializer presence check.  Use this when
+            resuming from a checkpoint where initialization is not needed.
+        """
         issues: list[str] = []
 
         algorithm = getattr(self, "algorithm", None)
@@ -205,7 +216,7 @@ class Optimizer:
             issues.append("algorithm is not set; call set_algorithm()")
         if strategy is None:
             issues.append("strategy is not set; call set_strategy()")
-        if self.initializer is None:
+        if require_initializer and self.initializer is None:
             issues.append("initializer is not set; call set_initializer()")
         if termination is None:
             issues.append("termination is not set; call set_termination()")
@@ -280,3 +291,115 @@ class Optimizer:
                 "Optimizer misconfigured:\n" + "\n".join(f"  - {m}" for m in issues)
             )
         return Runner(self).run()
+
+    def iterate_from(
+        self, ctx: OptimizationContext
+    ) -> Generator[OptimizationContext, None, None]:
+        """
+        Resume iteration from an existing context (e.g. loaded from checkpoint).
+
+        Does not call the initializer; all other components must be configured.
+
+        Parameters
+        ----------
+        ctx : OptimizationContext
+            Context to resume from.
+
+        Returns
+        -------
+        Generator[OptimizationContext, None, None]
+        """
+        issues = self.validate(require_initializer=False)
+        if issues:
+            raise ConfigurationError(
+                "Optimizer misconfigured:\n" + "\n".join(f"  - {m}" for m in issues)
+            )
+        return Runner(self).iterate_from(ctx)
+
+    def run_from(self, ctx: OptimizationContext) -> OptimizationContext:
+        """
+        Resume and run to completion from an existing context.
+
+        Parameters
+        ----------
+        ctx : OptimizationContext
+            Context to resume from.
+
+        Returns
+        -------
+        OptimizationContext
+            The final optimization context.
+        """
+        issues = self.validate(require_initializer=False)
+        if issues:
+            raise ConfigurationError(
+                "Optimizer misconfigured:\n" + "\n".join(f"  - {m}" for m in issues)
+            )
+        return Runner(self).run_from(ctx)
+
+    # ------------------------------------------------------------------
+    # Checkpoint: pickle (limited complete reproducibility)
+    # ------------------------------------------------------------------
+
+    _PICKLE_WARNING = (
+        "Pickle checkpoints are version-sensitive. "
+        "Reproducibility is only guaranteed within the same Python "
+        "and library versions."
+    )
+
+    def save_pickle(self, ctx: OptimizationContext, path: str | Path) -> None:
+        """
+        Save the optimizer and context together as a pickle checkpoint.
+
+        This preserves fitted surrogate state and all component objects,
+        offering complete reproducibility within the same environment.
+
+        .. warning::
+            Pickle files are tied to specific Python and library versions.
+            Use :meth:`OptimizationContext.save` for a more portable format.
+
+        Parameters
+        ----------
+        ctx : OptimizationContext
+            Current optimization context.
+        path : str or Path
+            Destination file path.  The ``.pkl`` extension is added if absent.
+        """
+        warnings.warn(self._PICKLE_WARNING, UserWarning, stacklevel=2)
+        p = Path(path)
+        if not p.suffix:
+            p = p.with_suffix(".pkl")
+        with open(p, "wb") as f:
+            pickle.dump((self, ctx), f)
+
+    @classmethod
+    def load_pickle(
+        cls, path: str | Path
+    ) -> tuple[Optimizer, OptimizationContext]:
+        """
+        Load an optimizer and context from a pickle checkpoint.
+
+        The returned context has ``resumed=True``.  Call
+        :meth:`run_from` or :meth:`iterate_from` on the returned optimizer
+        to continue the optimization.
+
+        .. warning::
+            Pickle files are tied to specific Python and library versions.
+
+        Parameters
+        ----------
+        path : str or Path
+            Path to the ``.pkl`` file.  The extension is added if absent.
+
+        Returns
+        -------
+        tuple[Optimizer, OptimizationContext]
+        """
+        warnings.warn(cls._PICKLE_WARNING, UserWarning, stacklevel=2)
+        p = Path(path)
+        if not p.suffix:
+            p = p.with_suffix(".pkl")
+        with open(p, "rb") as f:
+            optimizer, ctx = pickle.load(f)
+        ctx.resumed = True
+        return optimizer, ctx

--- a/src/saealib/optimizer.py
+++ b/src/saealib/optimizer.py
@@ -31,6 +31,11 @@ class ComponentProvider(Protocol):
     """The interface for components that can be used by the Optimizer."""
 
     @property
+    def seed(self) -> int | None:
+        """Return the master random seed."""
+        ...
+
+    @property
     def algorithm(self) -> Algorithm:
         """Return the algorithm instance."""
         ...
@@ -89,10 +94,8 @@ class Optimizer:
         The archive of evaluated solutions.
     popsize : int
         The population size.
-    seed : int
-        The random seed.
-    rng : numpy.random.Generator
-        The random number generator.
+    seed : int or None
+        The master random seed.  ``None`` means non-deterministic.
     fe : int
         The current number of function evaluations.
     gen : int
@@ -103,7 +106,7 @@ class Optimizer:
         The name of the optimizer instance.
     """
 
-    def __init__(self, problem: Problem):
+    def __init__(self, problem: Problem, seed: int | None = None):
         """
         Initialize the Optimizer.
 
@@ -111,8 +114,12 @@ class Optimizer:
         ----------
         problem : Problem
             The optimization problem.
+        seed : int or None, optional
+            Master random seed propagated to the initializer.  ``None`` (default)
+            means non-deterministic.
         """
         self.problem: Problem = problem
+        self.seed: int | None = seed
         self.cbmanager: CallbackManager = CallbackManager()
         self.cbmanager.register(GenerationStartEvent, logging_generation)
         self.initializer: Initializer | None = None
@@ -120,6 +127,11 @@ class Optimizer:
         self.instance_name: str = ""
 
     # --- setters (all return self for chaining) ---
+
+    def set_seed(self, seed: int | None) -> Optimizer:
+        """Set the master random seed. Returns self."""
+        self.seed = seed
+        return self
 
     def set_initializer(self, initializer: Initializer) -> Optimizer:
         """Set the initializer. Returns self."""

--- a/src/saealib/optimizer.py
+++ b/src/saealib/optimizer.py
@@ -441,9 +441,7 @@ class Optimizer:
             pickle.dump((self, ctx), f)
 
     @classmethod
-    def load_pickle(
-        cls, path: str | Path
-    ) -> tuple[Optimizer, OptimizationContext]:
+    def load_pickle(cls, path: str | Path) -> tuple[Optimizer, OptimizationContext]:
         """
         Load an optimizer and context from a pickle checkpoint.
 

--- a/src/saealib/surrogate/manager.py
+++ b/src/saealib/surrogate/manager.py
@@ -312,9 +312,10 @@ class GlobalSurrogateManager(SurrogateManager):
         if refit:
             self.fit(archive, ctx)
 
-        reference = self.acquisition.compute_reference(archive)
+        rng = ctx.rng if ctx is not None else None
+        reference = self.acquisition.compute_reference(archive, rng=rng)
         prediction = self.surrogate.predict(candidates_x)  # mean: (n_candidates, n_obj)
-        scores = self.acquisition.score(prediction, reference)
+        scores = self.acquisition.score(prediction, reference, rng=rng)
 
         # Split batch prediction into per-candidate SurrogatePrediction objects
         predictions = _split_prediction(prediction)
@@ -408,7 +409,8 @@ class LocalSurrogateManager(SurrogateManager):
         are always used.
         """
         predictions: list[SurrogatePrediction] = []
-        reference = self.acquisition.compute_reference(archive)
+        rng = ctx.rng if ctx is not None else None
+        reference = self.acquisition.compute_reference(archive, rng=rng)
         population = ctx.population if ctx is not None else None
         compute_accuracy = refit and self.accuracy_evaluator is not None
         y_true_list: list[np.ndarray] = []
@@ -443,7 +445,7 @@ class LocalSurrogateManager(SurrogateManager):
                     pass
 
         scores = np.array(
-            [self.acquisition.score(p, reference)[0] for p in predictions]
+            [self.acquisition.score(p, reference, rng=rng)[0] for p in predictions]
         )
         scores, predictions = self._sanitize_nan(scores, predictions)
 

--- a/src/saealib/termination.py
+++ b/src/saealib/termination.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import operator
 from collections.abc import Callable
-from functools import reduce
+from functools import partial, reduce
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -274,6 +274,13 @@ class Termination:
 
 # Built-in termination condition factories
 
+def _fe_reached(ctx: OptimizationContext, value: int) -> bool:
+    return ctx.fe >= value
+
+
+def _gen_reached(ctx: OptimizationContext, value: int) -> bool:
+    return ctx.gen >= value
+
 
 def max_fe(value: int) -> TerminationCondition:
     """
@@ -295,7 +302,7 @@ def max_fe(value: int) -> TerminationCondition:
     >>> condition = max_fe(2000) & max_gen(100)
     """
     return TerminationCondition(
-        lambda ctx: ctx.fe >= value,
+        partial(_fe_reached, value=value),
         name=f"max_fe({value})",
         doc=f"Terminate when fe >= {value}.",
     )
@@ -321,7 +328,7 @@ def max_gen(value: int) -> TerminationCondition:
     >>> condition = max_gen(100) | max_fe(2000)
     """
     return TerminationCondition(
-        lambda ctx: ctx.gen >= value,
+        partial(_gen_reached, value=value),
         name=f"max_gen({value})",
         doc=f"Terminate when gen >= {value}.",
     )

--- a/src/saealib/termination.py
+++ b/src/saealib/termination.py
@@ -274,6 +274,7 @@ class Termination:
 
 # Built-in termination condition factories
 
+
 def _fe_reached(ctx: OptimizationContext, value: int) -> bool:
     return ctx.fe >= value
 

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -51,7 +51,9 @@ def _make_problem() -> Problem:
     )
 
 
-def _make_optimizer(problem: Problem, seed: int | None = None, n_gen: int = 4) -> Optimizer:
+def _make_optimizer(
+    problem: Problem, seed: int | None = None, n_gen: int = 4
+) -> Optimizer:
     return (
         Optimizer(problem, seed=seed)
         .set_initializer(LHSInitializer(N_INIT_ARCHIVE, N_INIT_POP))
@@ -189,7 +191,7 @@ def test_pickle_roundtrip(tmp_path):
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
-        opt2, ctx2 = Optimizer.load_pickle(p)
+        _opt2, ctx2 = Optimizer.load_pickle(p)
 
     np.testing.assert_array_equal(ctx2.archive.x, ctx.archive.x)
     assert ctx2.gen == ctx.gen

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,360 @@
+"""Tests for seed, checkpoint, and resume features (Issue #95)."""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+from saealib import (
+    GA,
+    CheckpointCallback,
+    CrossoverBLXAlpha,
+    IndividualBasedStrategy,
+    LHSInitializer,
+    MutationUniform,
+    Optimizer,
+    RBFsurrogate,
+    SequentialSelection,
+    Termination,
+    TruncationSelection,
+    gaussian_kernel,
+    max_gen,
+)
+from saealib.comparators import SingleObjectiveComparator
+from saealib.context import OptimizationContext
+from saealib.problem import Problem
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+DIM = 2
+N_INIT_ARCHIVE = 10
+N_INIT_POP = 6
+
+
+def _sphere(x: np.ndarray) -> np.ndarray:
+    return np.array([np.sum(x**2)])
+
+
+def _make_problem() -> Problem:
+    return Problem(
+        func=_sphere,
+        dim=DIM,
+        n_obj=1,
+        direction=np.array([-1.0]),
+        lb=[-5.0] * DIM,
+        ub=[5.0] * DIM,
+        comparator=SingleObjectiveComparator(),
+    )
+
+
+def _make_optimizer(problem: Problem, seed: int | None = None, n_gen: int = 4) -> Optimizer:
+    return (
+        Optimizer(problem, seed=seed)
+        .set_initializer(LHSInitializer(N_INIT_ARCHIVE, N_INIT_POP))
+        .set_algorithm(
+            GA(
+                crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.5),
+                mutation=MutationUniform(mutation_rate=0.1),
+                parent_selection=SequentialSelection(),
+                survivor_selection=TruncationSelection(),
+            )
+        )
+        .set_surrogate(RBFsurrogate(gaussian_kernel, DIM), n_neighbors=5)
+        .set_strategy(IndividualBasedStrategy(evaluation_ratio=0.5))
+        .set_termination(Termination(max_gen(n_gen)))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Seed
+# ---------------------------------------------------------------------------
+
+
+def test_seed_reproducibility():
+    problem = _make_problem()
+    ctx1 = _make_optimizer(problem, seed=42).run()
+    ctx2 = _make_optimizer(problem, seed=42).run()
+    np.testing.assert_array_equal(ctx1.archive.x, ctx2.archive.x)
+    np.testing.assert_array_equal(ctx1.archive.f, ctx2.archive.f)
+
+
+def test_set_seed_method():
+    problem = _make_problem()
+    opt = _make_optimizer(problem)
+    opt.set_seed(99)
+    assert opt.seed == 99
+
+
+def test_seed_none_stored():
+    problem = _make_problem()
+    opt = Optimizer(problem)
+    assert opt.seed is None
+
+
+def test_lhs_uses_optimizer_seed_over_own():
+    """Optimizer.seed takes priority over LHSInitializer.seed."""
+    problem = _make_problem()
+
+    opt_a = (
+        Optimizer(problem, seed=7)
+        .set_initializer(LHSInitializer(N_INIT_ARCHIVE, N_INIT_POP, seed=999))
+        .set_algorithm(
+            GA(
+                crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.5),
+                mutation=MutationUniform(mutation_rate=0.1),
+                parent_selection=SequentialSelection(),
+                survivor_selection=TruncationSelection(),
+            )
+        )
+        .set_surrogate(RBFsurrogate(gaussian_kernel, DIM), n_neighbors=5)
+        .set_strategy(IndividualBasedStrategy(evaluation_ratio=0.5))
+        .set_termination(Termination(max_gen(2)))
+    )
+    opt_b = _make_optimizer(problem, seed=7, n_gen=2)
+
+    ctx_a = opt_a.run()
+    ctx_b = opt_b.run()
+    np.testing.assert_array_equal(ctx_a.archive.x, ctx_b.archive.x)
+
+
+# ---------------------------------------------------------------------------
+# OptimizationContext.save / load (npz)
+# ---------------------------------------------------------------------------
+
+
+def test_npz_roundtrip(tmp_path):
+    problem = _make_problem()
+    ctx = _make_optimizer(problem, seed=0, n_gen=2).run()
+
+    p = tmp_path / "ckpt.npz"
+    ctx.save(p)
+    assert p.exists()
+
+    loaded = OptimizationContext.load(p, problem)
+    np.testing.assert_array_equal(loaded.archive.x, ctx.archive.x)
+    np.testing.assert_array_equal(loaded.archive.f, ctx.archive.f)
+    np.testing.assert_array_equal(loaded.population.x, ctx.population.x)
+    assert loaded.fe == ctx.fe
+    assert loaded.gen == ctx.gen
+
+
+def test_npz_extension_added(tmp_path):
+    problem = _make_problem()
+    ctx = _make_optimizer(problem, seed=0, n_gen=2).run()
+    ctx.save(tmp_path / "ckpt")
+    assert (tmp_path / "ckpt.npz").exists()
+
+
+def test_npz_rng_state_preserved(tmp_path):
+    problem = _make_problem()
+    ctx = _make_optimizer(problem, seed=0, n_gen=2).run()
+    state_before = ctx.rng.bit_generator.state
+
+    p = tmp_path / "ckpt.npz"
+    ctx.save(p)
+    loaded = OptimizationContext.load(p, problem)
+    assert loaded.rng.bit_generator.state == state_before
+
+
+def test_resumed_flag_npz(tmp_path):
+    problem = _make_problem()
+    ctx = _make_optimizer(problem, seed=0, n_gen=2).run()
+    assert ctx.resumed is False
+
+    p = tmp_path / "ckpt.npz"
+    ctx.save(p)
+    loaded = OptimizationContext.load(p, problem)
+    assert loaded.resumed is True
+
+
+# ---------------------------------------------------------------------------
+# Optimizer.save_pickle / load_pickle
+# ---------------------------------------------------------------------------
+
+
+def test_pickle_roundtrip(tmp_path):
+    problem = _make_problem()
+    opt = _make_optimizer(problem, seed=0, n_gen=2)
+    ctx = opt.run()
+
+    p = tmp_path / "ckpt.pkl"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        opt.save_pickle(ctx, p)
+    assert p.exists()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        opt2, ctx2 = Optimizer.load_pickle(p)
+
+    np.testing.assert_array_equal(ctx2.archive.x, ctx.archive.x)
+    assert ctx2.gen == ctx.gen
+
+
+def test_resumed_flag_pickle(tmp_path):
+    problem = _make_problem()
+    opt = _make_optimizer(problem, seed=0, n_gen=2)
+    ctx = opt.run()
+
+    p = tmp_path / "ckpt.pkl"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        opt.save_pickle(ctx, p)
+        _, ctx2 = Optimizer.load_pickle(p)
+    assert ctx2.resumed is True
+
+
+def test_pickle_extension_added(tmp_path):
+    problem = _make_problem()
+    opt = _make_optimizer(problem, seed=0, n_gen=2)
+    ctx = opt.run()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        opt.save_pickle(ctx, tmp_path / "ckpt")
+    assert (tmp_path / "ckpt.pkl").exists()
+
+
+# ---------------------------------------------------------------------------
+# run_from / iterate_from
+# ---------------------------------------------------------------------------
+
+
+def test_run_from_npz_resumed_flag(tmp_path):
+    problem = _make_problem()
+    ctx_mid = _make_optimizer(problem, seed=42, n_gen=2).run()
+    p = tmp_path / "ckpt.npz"
+    ctx_mid.save(p)
+
+    loaded = OptimizationContext.load(p, problem)
+    ctx_final = _make_optimizer(problem, seed=42, n_gen=4).run_from(loaded)
+    assert ctx_final.resumed is True
+    assert ctx_final.gen == 4
+
+
+def test_run_from_npz_matches_full_run(tmp_path):
+    """Resume from npz checkpoint produces identical results to uninterrupted run."""
+    problem = _make_problem()
+
+    # Full run: 4 generations
+    ctx_full = _make_optimizer(problem, seed=42, n_gen=4).run()
+
+    # Split: 2 + 2 generations
+    ctx_mid = _make_optimizer(problem, seed=42, n_gen=2).run()
+    p = tmp_path / "ckpt.npz"
+    ctx_mid.save(p)
+
+    ctx_loaded = OptimizationContext.load(p, problem)
+    ctx_resumed = _make_optimizer(problem, seed=42, n_gen=4).run_from(ctx_loaded)
+
+    np.testing.assert_array_equal(ctx_full.archive.x, ctx_resumed.archive.x)
+    np.testing.assert_array_equal(ctx_full.archive.f, ctx_resumed.archive.f)
+
+
+def test_run_from_pickle_matches_full_run(tmp_path):
+    """Resume from pickle checkpoint produces identical results to uninterrupted run."""
+    problem = _make_problem()
+
+    ctx_full = _make_optimizer(problem, seed=42, n_gen=4).run()
+
+    opt_mid = _make_optimizer(problem, seed=42, n_gen=2)
+    ctx_mid = opt_mid.run()
+    p = tmp_path / "ckpt.pkl"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        opt_mid.save_pickle(ctx_mid, p)
+        opt_resume, ctx_loaded = Optimizer.load_pickle(p)
+
+    opt_resume.set_termination(Termination(max_gen(4)))
+    ctx_resumed = opt_resume.run_from(ctx_loaded)
+
+    np.testing.assert_array_equal(ctx_full.archive.x, ctx_resumed.archive.x)
+    np.testing.assert_array_equal(ctx_full.archive.f, ctx_resumed.archive.f)
+
+
+def test_iterate_from_yields_correct_gen(tmp_path):
+    problem = _make_problem()
+    ctx_mid = _make_optimizer(problem, seed=0, n_gen=2).run()
+    p = tmp_path / "ckpt.npz"
+    ctx_mid.save(p)
+
+    loaded = OptimizationContext.load(p, problem)
+    gens = [ctx.gen for ctx in _make_optimizer(problem, n_gen=4).iterate_from(loaded)]
+    assert gens[-1] == 4
+
+
+# ---------------------------------------------------------------------------
+# CheckpointCallback
+# ---------------------------------------------------------------------------
+
+
+def test_checkpoint_callback_files_created(tmp_path):
+    problem = _make_problem()
+    cb = CheckpointCallback(tmp_path / "ckpts", interval=1, format="npz")
+    opt = _make_optimizer(problem, seed=0, n_gen=3)
+    cb.register(opt.cbmanager)
+    opt.run()
+
+    npz_files = sorted((tmp_path / "ckpts").glob("checkpoint_*.npz"))
+    assert len(npz_files) == 3
+
+
+def test_checkpoint_callback_interval(tmp_path):
+    problem = _make_problem()
+    cb = CheckpointCallback(tmp_path / "ckpts", interval=2, format="npz")
+    opt = _make_optimizer(problem, seed=0, n_gen=4)
+    cb.register(opt.cbmanager)
+    opt.run()
+
+    npz_files = sorted((tmp_path / "ckpts").glob("checkpoint_*.npz"))
+    assert len(npz_files) == 2
+
+
+def test_checkpoint_callback_delete_on_success(tmp_path):
+    problem = _make_problem()
+    cb = CheckpointCallback(
+        tmp_path / "ckpts", interval=1, format="npz", delete_on_success=True
+    )
+    opt = _make_optimizer(problem, seed=0, n_gen=3)
+    cb.register(opt.cbmanager)
+    opt.run()
+
+    npz_files = list((tmp_path / "ckpts").glob("checkpoint_*.npz"))
+    assert len(npz_files) == 0
+
+
+def test_checkpoint_callback_both_formats(tmp_path):
+    problem = _make_problem()
+    opt = _make_optimizer(problem, seed=0, n_gen=2)
+    cb = CheckpointCallback(
+        tmp_path / "ckpts", interval=1, format="both", optimizer=opt
+    )
+    cb.register(opt.cbmanager)
+    opt.run()
+
+    npz_files = list((tmp_path / "ckpts").glob("checkpoint_*.npz"))
+    pkl_files = list((tmp_path / "ckpts").glob("checkpoint_*.pkl"))
+    assert len(npz_files) == 2
+    assert len(pkl_files) == 2
+
+
+def test_run_with_checkpoint_path(tmp_path):
+    problem = _make_problem()
+    opt = _make_optimizer(problem, seed=0, n_gen=3)
+    opt.run(checkpoint_path=tmp_path / "ckpts", checkpoint_interval=1)
+
+    npz_files = sorted((tmp_path / "ckpts").glob("checkpoint_*.npz"))
+    assert len(npz_files) == 3
+
+
+def test_checkpoint_callback_invalid_format():
+    with pytest.raises(ValueError, match="format must be"):
+        CheckpointCallback("/tmp", format="json")
+
+
+def test_checkpoint_callback_pickle_requires_optimizer():
+    with pytest.raises(ValueError, match="optimizer must be provided"):
+        CheckpointCallback("/tmp", format="pickle")


### PR DESCRIPTION
## Related Issue
Closes #95

## Overview
Adds a top-level `seed` to `Optimizer` for unified RNG control, npz/pickle checkpoint save-and-resume, and `CheckpointCallback` for automatic per-generation checkpointing.

## Changes

### Seed / RNG
- `Optimizer(problem, seed=None)` and `set_seed()` — master seed propagated to `ctx.rng` (single RNG source for the whole run)
- `LHSInitializer` gives `provider.seed` priority over its own `seed`
- `AcquisitionFunction.compute_reference` / `score` accept `rng=None`; `SurrogateManager` passes `ctx.rng` so acquisition functions draw from the unified stream

### Checkpoint: npz (portable)
- `OptimizationContext.save(path)` — serialises archive, population, and RNG bit-generator state to `.npz`
- `OptimizationContext.load(path, problem)` — reconstructs context; sets `resumed=True`
- Same-version resume is bit-exact with an uninterrupted run

### Checkpoint: pickle (complete state)
- `Optimizer.save_pickle(ctx, path)` / `Optimizer.load_pickle(path)` — serialises the full optimizer (including fitted surrogate) alongside the context
- Emits `UserWarning` about version sensitivity

### Resume API
- `Optimizer.run_from(ctx)` / `iterate_from(ctx)` — skip initialisation, dispatch `RunStartEvent`, continue from existing context
- `validate(require_initializer=False)` to allow resuming without an initializer

### Automatic checkpointing
- `run()` / `iterate()` accept `checkpoint_path`, `checkpoint_interval`, `checkpoint_format`, `checkpoint_delete_on_success`
- `CheckpointCallback(path, interval, format, delete_on_success, optimizer)` — registers on `GenerationEndEvent` and `RunEndEvent`; filenames are `checkpoint_{gen:06d}.npz/.pkl`

### `resumed` flag
- `OptimizationContext.resumed: bool` — `False` on a fresh run, `True` after `load` or `load_pickle`; accessible from any callback

### Tests / docs
- 22 tests covering seed reproducibility, npz/pickle round-trip, `resumed` flag, `run_from` bit-exact match, `CheckpointCallback` file counts and deletion
- `docs/tutorials/checkpoint.md` — Japanese tutorial covering seed, npz resume, pickle resume, automatic checkpointing, and the `resumed` flag

## Verification Steps
run pytest

## Notes
- `functools.partial` is used for `max_fe` / `max_gen` internals to keep termination conditions picklable (lambdas are not)
- Bit-exact reproducibility across library versions is best-effort; the `resumed` flag lets callers detect resumed runs programmatically