### PR TITLE
perf: [#90] Replace Archive.get_knn brute-force search with cKDTree

### DIFF
--- a/src/saealib/population/archive.py
+++ b/src/saealib/population/archive.py
@@ -151,6 +151,7 @@ class ArchiveMixin:
         return dup_pop
 
     def delete(self, index):
+        """Delete element(s) and invalidate the kNN cache."""
         super().delete(index)
         self._kdtree = None
 

--- a/src/saealib/population/archive.py
+++ b/src/saealib/population/archive.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+from scipy.spatial import cKDTree
 
 from saealib.population.population import Individual, Population, PopulationAttribute
 
@@ -52,6 +53,7 @@ class ArchiveMixin:
         self.key_attr = key_attr
         self.atol = atol
         self.rtol = rtol
+        self._kdtree: cKDTree | None = None
 
     def add(self, element: Individual | dict[str, Any] | None = None, **kwargs) -> int:
         """
@@ -95,6 +97,7 @@ class ArchiveMixin:
             new_idx = self._size
             super().append(element, **kwargs)
             self._duplicate_indices.append(new_idx)
+            self._kdtree = None
             return new_idx
 
     def _find_idx(self, element: np.ndarray | np.floating) -> int | None:
@@ -147,6 +150,14 @@ class ArchiveMixin:
         dup_pop._structure_version = self._structure_version
         return dup_pop
 
+    def delete(self, index):
+        super().delete(index)
+        self._kdtree = None
+
+    def _ensure_kdtree(self) -> None:
+        if self._kdtree is None:
+            self._kdtree = cKDTree(self.get_array(self.key_attr))
+
     def get_knn(self, x: np.ndarray, k: int) -> tuple[np.ndarray, np.ndarray]:
         """
         Get k-nearest neighbors of the given solution from the archive.
@@ -161,15 +172,14 @@ class ArchiveMixin:
         Returns
         -------
         tuple[np.ndarray, np.ndarray]
-            The k-nearest neighbors' solutions and their objective values.
+            Indices and distances of the k-nearest neighbors.
         """
         if self._size == 0:
             return np.array([]), np.array([])
-        key_attr_arr = self.get_array(self.key_attr)
-        dist = np.linalg.norm(key_attr_arr - x, axis=1)
+        self._ensure_kdtree()
         k = min(k, self._size)
-        idx = np.argsort(dist)[:k]
-        return idx, dist[idx]
+        dist, idx = self._kdtree.query(x, k=k)
+        return np.atleast_1d(idx), np.atleast_1d(dist)
 
 
 class Archive(ArchiveMixin, Population):

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -668,6 +668,19 @@ class TestArchive:
         idx, _dist = archive.get_knn(np.array([1.0, 2.0]), k=100)
         assert len(idx) == 1
 
+    def test_get_knn_kdtree_built_on_demand(self, archive: Archive) -> None:
+        archive.add(x=np.array([0.0, 0.0]), f=0.0)
+        assert archive._kdtree is None
+        archive.get_knn(np.array([0.0, 0.0]), k=1)
+        assert archive._kdtree is not None
+
+    def test_get_knn_cache_invalidated_on_add(self, archive: Archive) -> None:
+        archive.add(x=np.array([0.0, 0.0]), f=0.0)
+        archive.get_knn(np.array([0.0, 0.0]), k=1)
+        assert archive._kdtree is not None
+        archive.add(x=np.array([1.0, 0.0]), f=1.0)
+        assert archive._kdtree is None
+
     def test_invalid_key_attr_raises(
         self, archive_attrs: list[PopulationAttribute]
     ) -> None:


### PR DESCRIPTION
## Related Issue
Closes #90

## Overview
Replace the brute-force O(N·M) distance computation in `Archive.get_knn` with a lazy `scipy.spatial.cKDTree`. The tree is built on the first query and invalidated whenever `add()` or `delete()` modifies the archive, so the rebuild cost is paid at most once per generation.

## Changes
- Add `_kdtree: cKDTree | None` field to `ArchiveMixin.__init__`
- Add `_ensure_kdtree()` to build the tree on demand
- Override `delete()` in `ArchiveMixin` to invalidate the cache
- Invalidate cache in `add()` when a new point is actually inserted
- Replace `np.linalg.norm` + `np.argsort` in `get_knn` with `cKDTree.query`
- Add two unit tests for lazy build and cache invalidation

## Verification Steps
Benchmark (dim=10, k=5):

| Config | Before | After | Speedup |
|--------|--------|-------|---------|
| N=100, M=1000 | 36.5 ms | 3.6 ms | 10.2× |
| N=200, M=5000 | 63.1 ms | 10.1 ms | 6.3× |

All existing tests pass.

## Concerns
None. `scipy.spatial.cKDTree` is already a project dependency. Public API (`get_knn` signature and return order) is unchanged.

## Other
