### PR TITLE
refactor: [#156] Rename RBFsurrogate → RBFSurrogate and Result.X/F → Result.x/f

### DIFF
--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -212,7 +212,7 @@ _TIER2_MAP: dict[str, str] = {
     "NNSurrogate": "saealib.surrogate",
     "NoveltyManager": "saealib.surrogate",
     "PerObjectiveSurrogate": "saealib.surrogate",
-    "RBFsurrogate": "saealib.surrogate",
+    "RBFSurrogate": "saealib.surrogate",
     "SklearnSurrogate": "saealib.surrogate",
     "SVMSurrogate": "saealib.surrogate",
     "SurrogatePrediction": "saealib.surrogate",
@@ -255,6 +255,10 @@ def __getattr__(name: str) -> object:
         from saealib.surrogate._deprecated import GPSurrogate
 
         return GPSurrogate
+    if name == "RBFsurrogate":
+        from saealib.surrogate.rbf import RBFSurrogate
+
+        return RBFSurrogate
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/src/saealib/__init__.pyi
+++ b/src/saealib/__init__.pyi
@@ -150,7 +150,7 @@ from saealib.surrogate import NichingManager as NichingManager
 from saealib.surrogate import NNSurrogate as NNSurrogate
 from saealib.surrogate import NoveltyManager as NoveltyManager
 from saealib.surrogate import PerObjectiveSurrogate as PerObjectiveSurrogate
-from saealib.surrogate import RBFsurrogate as RBFsurrogate
+from saealib.surrogate import RBFSurrogate as RBFSurrogate
 from saealib.surrogate import SklearnSurrogate as SklearnSurrogate
 from saealib.surrogate import StrategySwitcher as StrategySwitcher
 from saealib.surrogate import Surrogate as Surrogate

--- a/src/saealib/api.py
+++ b/src/saealib/api.py
@@ -24,7 +24,7 @@ from saealib.strategies.gb import GenerationBasedStrategy
 from saealib.strategies.ib import IndividualBasedStrategy
 from saealib.strategies.ps import PreSelectionStrategy
 from saealib.surrogate.manager import LocalSurrogateManager, SurrogateManager
-from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+from saealib.surrogate.rbf import RBFSurrogate, gaussian_kernel
 from saealib.termination import Termination
 from saealib.termination import max_fe as max_fe_cond
 
@@ -40,10 +40,10 @@ class Result:
 
     Attributes
     ----------
-    X : np.ndarray
+    x : np.ndarray
         Best design variables. Shape ``(dim,)`` for single-objective,
         ``(n_pareto, dim)`` for multi-objective.
-    F : np.ndarray
+    f : np.ndarray
         Best objective values. Shape ``(n_obj,)`` for single-objective,
         ``(n_pareto, n_obj)`` for multi-objective.
     fe : int
@@ -54,8 +54,8 @@ class Result:
         Full optimization context providing access to the archive and more.
     """
 
-    X: np.ndarray
-    F: np.ndarray
+    x: np.ndarray
+    f: np.ndarray
     fe: int
     gen: int
     ctx: OptimizationContext
@@ -136,7 +136,7 @@ def _resolve_surrogate(
         if surrogate.lower() == "rbf":
             from saealib.surrogate.training_set import KNNObjectiveSet
 
-            rbf = RBFsurrogate(gaussian_kernel, problem.dim)
+            rbf = RBFSurrogate(gaussian_kernel, problem.dim)
             return LocalSurrogateManager(
                 rbf,
                 MeanPrediction(direction=problem.direction),
@@ -203,7 +203,7 @@ def _build_result(ctx: OptimizationContext) -> Result:
             best_x = archive_x[pareto_idx]
             best_f = archive_f[pareto_idx]
 
-    return Result(X=best_x, F=best_f, fe=ctx.fe, gen=ctx.gen, ctx=ctx)
+    return Result(x=best_x, f=best_f, fe=ctx.fe, gen=ctx.gen, ctx=ctx)
 
 
 def _run(
@@ -320,7 +320,7 @@ def minimize(
     >>> import numpy as np
     >>> result = minimize(lambda x: np.sum(x**2), dim=5, lb=[-5]*5, ub=[5]*5,
     ...                   max_fe=500, seed=0, verbose=False)
-    >>> result.X, result.F
+    >>> result.x, result.f
     """
     direction_arr = _resolve_direction(direction, n_obj, default=-1.0)
     problem = _ensure_problem(func, dim, lb, ub, n_obj, direction_arr)
@@ -404,7 +404,7 @@ def maximize(
     >>> import numpy as np
     >>> result = maximize(lambda x: -np.sum(x**2) + 10, dim=5, lb=[-5]*5, ub=[5]*5,
     ...                   max_fe=500, seed=0, verbose=False)
-    >>> result.X, result.F
+    >>> result.x, result.f
     """
     direction_arr = _resolve_direction(direction, n_obj, default=+1.0)
     problem = _ensure_problem(func, dim, lb, ub, n_obj, direction_arr)

--- a/src/saealib/surrogate/__init__.py
+++ b/src/saealib/surrogate/__init__.py
@@ -26,7 +26,7 @@ from saealib.surrogate.manager import (
 )
 from saealib.surrogate.per_objective import PerObjectiveSurrogate
 from saealib.surrogate.prediction import SurrogatePrediction
-from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+from saealib.surrogate.rbf import RBFSurrogate, gaussian_kernel
 from saealib.surrogate.sklearn_surrogate import (
     DTSurrogate,
     GPRSurrogate,
@@ -85,7 +85,7 @@ __all__ = [
     "PairwiseComparisonSet",
     "PerObjectiveSurrogate",
     "R2Score",
-    "RBFsurrogate",
+    "RBFSurrogate",
     "SVMSurrogate",
     "SklearnSurrogate",
     "SpearmanCorrelation",
@@ -111,4 +111,8 @@ def __getattr__(name: str) -> object:
         from saealib.surrogate._deprecated import GPSurrogate
 
         return GPSurrogate
+    if name == "RBFsurrogate":
+        from saealib.surrogate.rbf import RBFSurrogate
+
+        return RBFSurrogate
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/saealib/surrogate/rbf.py
+++ b/src/saealib/surrogate/rbf.py
@@ -2,7 +2,7 @@
 RBF surrogate model module.
 
 This module defines the Radial Basis Function (RBF) surrogate model.
-RBFsurrogate supports multi-objective problems by maintaining one
+RBFSurrogate supports multi-objective problems by maintaining one
 independent RBF model per objective (ensemble approach).
 """
 
@@ -46,7 +46,7 @@ class _RBFModel:
     Single-objective RBF interpolation model (internal use only).
 
     Holds all state for one objective's RBF fit. Used as a building
-    block by RBFsurrogate to support multi-objective problems.
+    block by RBFSurrogate to support multi-objective problems.
     """
 
     def __init__(self, kernel: Callable[..., Any], dim: int):
@@ -111,7 +111,7 @@ class _RBFModel:
         return np.asarray(preds).flatten()
 
 
-class RBFsurrogate(Surrogate):
+class RBFSurrogate(Surrogate):
     """
     Radial Basis Function (RBF) Interpolation surrogate model.
 

--- a/src/saealib/surrogate/sklearn_surrogate.py
+++ b/src/saealib/surrogate/sklearn_surrogate.py
@@ -14,7 +14,7 @@ class SklearnSurrogate(Surrogate):
 
     Wraps any estimator that implements ``fit(X, y)`` and ``predict(X)``.
     Multi-objective problems are handled by fitting one cloned estimator
-    per objective, following the same pattern as ``RBFsurrogate``.
+    per objective, following the same pattern as ``RBFSurrogate``.
 
     Parameters
     ----------

--- a/src/saealib/surrogate/training_set.py
+++ b/src/saealib/surrogate/training_set.py
@@ -406,7 +406,7 @@ class PairwiseComparisonSet(TrainingSet):
 
     .. warning::
         ``train_x`` has shape ``(n_pairs, 2 * dim)``, which is incompatible with
-        standard regression surrogates (e.g. ``RBFsurrogate``).  Use a
+        standard regression surrogates (e.g. ``RBFSurrogate``).  Use a
         pairwise-specific surrogate that expects concatenated feature pairs.
 
     Parameters

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -37,7 +37,7 @@ from saealib.comparators import SingleObjectiveComparator
 from saealib.context import OptimizationContext
 from saealib.population import Archive, ParetoArchive, Population, PopulationAttribute
 from saealib.problem import Problem
-from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+from saealib.surrogate.rbf import RBFSurrogate, gaussian_kernel
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -310,7 +310,7 @@ class TestEventClasses:
 
     def test_post_surrogate_fit_event_fields(self) -> None:
         ctx = _make_ctx()
-        surrogate = RBFsurrogate(gaussian_kernel, DIM)
+        surrogate = RBFSurrogate(gaussian_kernel, DIM)
         train_x = np.zeros((10, DIM))
         train_f = np.zeros((10, N_OBJ))
         e = PostSurrogateFitEvent(
@@ -471,7 +471,7 @@ class TestPostEvaluationDispatch:
                     survivor_selection=TruncationSelection(),
                 )
             )
-            .set_surrogate(RBFsurrogate(gaussian_kernel, dim), n_neighbors=10)
+            .set_surrogate(RBFSurrogate(gaussian_kernel, dim), n_neighbors=10)
             .set_strategy(IndividualBasedStrategy(evaluation_ratio=evaluation_ratio))
             .set_termination(Termination(max_fe(100)))
         )

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -15,7 +15,7 @@ from saealib import (
     LHSInitializer,
     MutationUniform,
     Optimizer,
-    RBFsurrogate,
+    RBFSurrogate,
     SequentialSelection,
     Termination,
     TruncationSelection,
@@ -65,7 +65,7 @@ def _make_optimizer(
                 survivor_selection=TruncationSelection(),
             )
         )
-        .set_surrogate(RBFsurrogate(gaussian_kernel, DIM), n_neighbors=5)
+        .set_surrogate(RBFSurrogate(gaussian_kernel, DIM), n_neighbors=5)
         .set_strategy(IndividualBasedStrategy(evaluation_ratio=0.5))
         .set_termination(Termination(max_gen(n_gen)))
     )
@@ -112,7 +112,7 @@ def test_lhs_uses_optimizer_seed_over_own():
                 survivor_selection=TruncationSelection(),
             )
         )
-        .set_surrogate(RBFsurrogate(gaussian_kernel, DIM), n_neighbors=5)
+        .set_surrogate(RBFSurrogate(gaussian_kernel, DIM), n_neighbors=5)
         .set_strategy(IndividualBasedStrategy(evaluation_ratio=0.5))
         .set_termination(Termination(max_gen(2)))
     )

--- a/tests/test_epsilon_constraint_handler.py
+++ b/tests/test_epsilon_constraint_handler.py
@@ -204,7 +204,7 @@ def _make_optimizer(problem, n_gen: int):
         TruncationSelection,
         max_gen,
     )
-    from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+    from saealib.surrogate.rbf import RBFSurrogate, gaussian_kernel
 
     return (
         Optimizer(problem)
@@ -217,7 +217,7 @@ def _make_optimizer(problem, n_gen: int):
                 survivor_selection=TruncationSelection(),
             )
         )
-        .set_surrogate(RBFsurrogate(gaussian_kernel, problem.dim), n_neighbors=5)
+        .set_surrogate(RBFSurrogate(gaussian_kernel, problem.dim), n_neighbors=5)
         .set_strategy(IndividualBasedStrategy(evaluation_ratio=1.0))
         .set_termination(Termination(max_gen(n_gen)))
     )

--- a/tests/test_initial_evaluation_event.py
+++ b/tests/test_initial_evaluation_event.py
@@ -19,7 +19,7 @@ from saealib import (
     LHSInitializer,
     MutationUniform,
     Optimizer,
-    RBFsurrogate,
+    RBFSurrogate,
     RunStartEvent,
     SequentialSelection,
     Termination,
@@ -72,7 +72,7 @@ def _make_optimizer(problem: Problem | None = None) -> Optimizer:
                 survivor_selection=TruncationSelection(),
             )
         )
-        .set_surrogate(RBFsurrogate(gaussian_kernel, DIM), n_neighbors=5)
+        .set_surrogate(RBFSurrogate(gaussian_kernel, DIM), n_neighbors=5)
         .set_strategy(IndividualBasedStrategy(evaluation_ratio=0.5))
         .set_termination(Termination(max_fe(50)))
     )
@@ -316,7 +316,7 @@ class TestInitialEvaluationEndEventMutation:
                     survivor_selection=TruncationSelection(),
                 )
             )
-            .set_surrogate(RBFsurrogate(gaussian_kernel, DIM), n_neighbors=5)
+            .set_surrogate(RBFSurrogate(gaussian_kernel, DIM), n_neighbors=5)
             .set_strategy(IndividualBasedStrategy(evaluation_ratio=0.5))
             .set_termination(Termination(max_fe(50)))
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -11,7 +11,7 @@ from saealib import (
     MutationUniform,
     Optimizer,
     Problem,
-    RBFsurrogate,
+    RBFSurrogate,
     SequentialSelection,
     Termination,
     TruncationSelection,
@@ -40,7 +40,7 @@ def test_integration(seed: int):
     - ParentSelection (SequentialSelection)
     - SurvivorSelection (TruncationSelection)
     - Termination
-    - Surrogate (RBFsurrogate)
+    - Surrogate (RBFSurrogate)
     - Strategy (IndividualBasedStrategy)
     - Callback (logging_generation, repair_clipping)
     """
@@ -75,7 +75,7 @@ def test_integration(seed: int):
         survivor_selection=TruncationSelection(),
     )
     termination = Termination(max_fe(200 * dim))
-    surrogate = RBFsurrogate(gaussian_kernel, dim)
+    surrogate = RBFSurrogate(gaussian_kernel, dim)
     strategy = IndividualBasedStrategy(evaluation_ratio=rsm)
 
     opt = (

--- a/tests/test_moo.py
+++ b/tests/test_moo.py
@@ -25,7 +25,7 @@ from saealib import (
     NonDominatedSorter,
     Optimizer,
     Problem,
-    RBFsurrogate,
+    RBFSurrogate,
     SequentialSelection,
     Termination,
     TruncationSelection,
@@ -763,7 +763,7 @@ class TestMOOIntegration:
             survivor_selection=TruncationSelection(),
         )
         termination = Termination(max_fe(80 * dim))
-        surrogate = RBFsurrogate(gaussian_kernel, dim)
+        surrogate = RBFSurrogate(gaussian_kernel, dim)
         strategy = IndividualBasedStrategy(evaluation_ratio=0.1)
 
         opt = (

--- a/tests/test_optimizer_validate.py
+++ b/tests/test_optimizer_validate.py
@@ -15,7 +15,7 @@ from saealib.problem import Problem
 from saealib.strategies.base import OptimizationStrategy
 from saealib.strategies.ib import IndividualBasedStrategy
 from saealib.surrogate.manager import GlobalSurrogateManager
-from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+from saealib.surrogate.rbf import RBFSurrogate, gaussian_kernel
 
 DIM = 2
 N_OBJ = 1
@@ -109,7 +109,7 @@ def test_strategy_requires_surrogate_present():
     opt.set_strategy(IndividualBasedStrategy())
     opt.set_surrogate_manager(
         GlobalSurrogateManager(
-            RBFsurrogate(kernel=gaussian_kernel, dim=DIM),
+            RBFSurrogate(kernel=gaussian_kernel, dim=DIM),
             MeanPrediction(),
         )
     )
@@ -136,7 +136,7 @@ def test_acquisition_uncertainty_mismatch():
     opt = _fully_configured()
     opt.set_surrogate_manager(
         GlobalSurrogateManager(
-            RBFsurrogate(kernel=gaussian_kernel, dim=DIM),
+            RBFSurrogate(kernel=gaussian_kernel, dim=DIM),
             ExpectedImprovement(),
         )
     )
@@ -147,7 +147,7 @@ def test_mean_prediction_with_rbf_ok():
     opt = _fully_configured()
     opt.set_surrogate_manager(
         GlobalSurrogateManager(
-            RBFsurrogate(kernel=gaussian_kernel, dim=DIM),
+            RBFSurrogate(kernel=gaussian_kernel, dim=DIM),
             MeanPrediction(),
         )
     )

--- a/tests/test_per_objective.py
+++ b/tests/test_per_objective.py
@@ -20,7 +20,7 @@ from saealib.surrogate.base import Surrogate
 from saealib.surrogate.manager import GlobalSurrogateManager
 from saealib.surrogate.per_objective import PerObjectiveSurrogate
 from saealib.surrogate.prediction import SurrogatePrediction
-from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+from saealib.surrogate.rbf import RBFSurrogate, gaussian_kernel
 from saealib.surrogate.sklearn_surrogate import DTSurrogate, SVMSurrogate
 
 # ---------------------------------------------------------------------------
@@ -105,7 +105,7 @@ class TestPerObjectiveSurrogate:
 
     def test_fit_predict_1obj_single_surrogate(self, train_data_1obj, test_x) -> None:
         X, y = train_data_1obj
-        s = PerObjectiveSurrogate([RBFsurrogate(gaussian_kernel, DIM)])
+        s = PerObjectiveSurrogate([RBFSurrogate(gaussian_kernel, DIM)])
         s.fit(X, y)
         pred = s.predict(test_x)
         assert pred.value.shape == (5, 1)
@@ -113,7 +113,7 @@ class TestPerObjectiveSurrogate:
     def test_fit_predict_2obj_two_surrogates(self, train_data_2obj, test_x) -> None:
         X, y = train_data_2obj
         s = PerObjectiveSurrogate(
-            [RBFsurrogate(gaussian_kernel, DIM), RBFsurrogate(gaussian_kernel, DIM)]
+            [RBFSurrogate(gaussian_kernel, DIM), RBFSurrogate(gaussian_kernel, DIM)]
         )
         s.fit(X, y)
         pred = s.predict(test_x)
@@ -130,13 +130,13 @@ class TestPerObjectiveSurrogate:
 
     def test_nobj_mismatch_raises(self, train_data_2obj) -> None:
         X, y = train_data_2obj
-        s = PerObjectiveSurrogate([RBFsurrogate(gaussian_kernel, DIM)])
+        s = PerObjectiveSurrogate([RBFSurrogate(gaussian_kernel, DIM)])
         with pytest.raises(ValueError, match="n_obj=2"):
             s.fit(X, y)
 
     def test_predict_1d_input(self, train_data_1obj) -> None:
         X, y = train_data_1obj
-        s = PerObjectiveSurrogate([RBFsurrogate(gaussian_kernel, DIM)])
+        s = PerObjectiveSurrogate([RBFSurrogate(gaussian_kernel, DIM)])
         s.fit(X, y)
         pred = s.predict(X[0])
         assert pred.value.shape == (1, 1)
@@ -144,14 +144,14 @@ class TestPerObjectiveSurrogate:
     def test_std_none_when_no_uncertainty(self, train_data_2obj, test_x) -> None:
         X, y = train_data_2obj
         s = PerObjectiveSurrogate(
-            [RBFsurrogate(gaussian_kernel, DIM), RBFsurrogate(gaussian_kernel, DIM)]
+            [RBFSurrogate(gaussian_kernel, DIM), RBFSurrogate(gaussian_kernel, DIM)]
         )
         s.fit(X, y)
         assert s.predict(test_x).std is None
 
     def test_provides_uncertainty_false_if_any_missing(self) -> None:
         s = PerObjectiveSurrogate(
-            [_StubSurrogateWithUncertainty(), RBFsurrogate(gaussian_kernel, DIM)]
+            [_StubSurrogateWithUncertainty(), RBFSurrogate(gaussian_kernel, DIM)]
         )
         assert s.provides_uncertainty is False
 
@@ -177,7 +177,7 @@ class TestPerObjectiveSurrogate:
     def test_1d_train_y_accepted(self, train_data_1obj, test_x) -> None:
         X, y = train_data_1obj
         assert y.ndim == 1
-        s = PerObjectiveSurrogate([RBFsurrogate(gaussian_kernel, DIM)])
+        s = PerObjectiveSurrogate([RBFSurrogate(gaussian_kernel, DIM)])
         s.fit(X, y)
         assert s.predict(test_x).value.shape == (5, 1)
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -34,7 +34,7 @@ from saealib.surrogate.manager import (
     rank_weighted_combine,
 )
 from saealib.surrogate.prediction import SurrogatePrediction
-from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+from saealib.surrogate.rbf import RBFSurrogate, gaussian_kernel
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -182,7 +182,7 @@ class TestGenerationBasedStrategy:
         fit_count = [0]
 
         ctx = _make_ctx()
-        surrogate = RBFsurrogate(gaussian_kernel, DIM).with_post_fit(
+        surrogate = RBFSurrogate(gaussian_kernel, DIM).with_post_fit(
             lambda tx, ty, c: operator.setitem(fit_count, 0, fit_count[0] + 1)
         )
         manager = GlobalSurrogateManager(surrogate, MeanPrediction())
@@ -198,7 +198,7 @@ class TestGenerationBasedStrategy:
         fit_count = [0]
 
         ctx = _make_ctx()
-        surrogate = RBFsurrogate(gaussian_kernel, DIM).with_post_fit(
+        surrogate = RBFSurrogate(gaussian_kernel, DIM).with_post_fit(
             lambda tx, ty, c: operator.setitem(fit_count, 0, fit_count[0] + 1)
         )
         manager = LocalSurrogateManager(surrogate, MeanPrediction())
@@ -271,7 +271,7 @@ def _make_ensemble_novelty() -> CompositeSurrogateManager:
     """Regression surrogate first (finite tell_f) + NoveltyManager second."""
     return CompositeSurrogateManager(
         [
-            LocalSurrogateManager(RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()),
+            LocalSurrogateManager(RBFSurrogate(gaussian_kernel, DIM), MeanPrediction()),
             NoveltyManager(k=3),
         ],
         combine_fn=rank_weighted_combine(np.array([0.7, 0.3])),
@@ -282,7 +282,7 @@ def _make_ensemble_density() -> CompositeSurrogateManager:
     """Regression surrogate first (finite tell_f) + DensityManager second."""
     return CompositeSurrogateManager(
         [
-            LocalSurrogateManager(RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()),
+            LocalSurrogateManager(RBFSurrogate(gaussian_kernel, DIM), MeanPrediction()),
             DensityManager(eps=1.0),
         ],
         combine_fn=rank_weighted_combine(np.array([0.7, 0.3])),

--- a/tests/test_surrogate_accuracy.py
+++ b/tests/test_surrogate_accuracy.py
@@ -13,7 +13,7 @@ from saealib.surrogate.accuracy import (
     SpearmanCorrelation,
     SurrogateAccuracy,
 )
-from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+from saealib.surrogate.rbf import RBFSurrogate, gaussian_kernel
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -23,8 +23,8 @@ DIM = 1
 N_OBJ = 1
 
 
-def _make_surrogate() -> RBFsurrogate:
-    return RBFsurrogate(kernel=gaussian_kernel, dim=DIM)
+def _make_surrogate() -> RBFSurrogate:
+    return RBFSurrogate(kernel=gaussian_kernel, dim=DIM)
 
 
 def _sphere_data(n: int = 30, rng_seed: int = 0) -> tuple[np.ndarray, np.ndarray]:

--- a/tests/test_surrogate_manager.py
+++ b/tests/test_surrogate_manager.py
@@ -36,7 +36,7 @@ from saealib.surrogate.manager import (
     rank_weighted_combine,
 )
 from saealib.surrogate.prediction import SurrogatePrediction
-from saealib.surrogate.rbf import RBFsurrogate, gaussian_kernel
+from saealib.surrogate.rbf import RBFSurrogate, gaussian_kernel
 from saealib.surrogate.training_set import KNNObjectiveSet
 
 # ---------------------------------------------------------------------------
@@ -86,13 +86,13 @@ def candidates() -> np.ndarray:
 
 
 @pytest.fixture
-def surrogate_1obj() -> RBFsurrogate:
-    return RBFsurrogate(gaussian_kernel, DIM)
+def surrogate_1obj() -> RBFSurrogate:
+    return RBFSurrogate(gaussian_kernel, DIM)
 
 
 @pytest.fixture
-def surrogate_2obj() -> RBFsurrogate:
-    return RBFsurrogate(gaussian_kernel, DIM)
+def surrogate_2obj() -> RBFSurrogate:
+    return RBFSurrogate(gaussian_kernel, DIM)
 
 
 # ===========================================================================
@@ -304,7 +304,7 @@ class TestGlobalSurrogateManager:
 
     def test_score_candidates_returns_tuple(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -315,7 +315,7 @@ class TestGlobalSurrogateManager:
 
     def test_scores_shape(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -325,7 +325,7 @@ class TestGlobalSurrogateManager:
 
     def test_predictions_count(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -335,7 +335,7 @@ class TestGlobalSurrogateManager:
 
     def test_predictions_are_surrogate_prediction(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -346,7 +346,7 @@ class TestGlobalSurrogateManager:
 
     def test_prediction_mean_shape_per_candidate(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -357,7 +357,7 @@ class TestGlobalSurrogateManager:
 
     def test_scores_finite(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -367,7 +367,7 @@ class TestGlobalSurrogateManager:
 
     def test_biobj_scores_shape(
         self,
-        surrogate_2obj: RBFsurrogate,
+        surrogate_2obj: RBFSurrogate,
         archive_2obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -390,7 +390,7 @@ class TestLocalSurrogateManager:
 
     def test_score_candidates_returns_tuple(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -402,7 +402,7 @@ class TestLocalSurrogateManager:
 
     def test_scores_shape(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -414,7 +414,7 @@ class TestLocalSurrogateManager:
 
     def test_predictions_count(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -426,7 +426,7 @@ class TestLocalSurrogateManager:
 
     def test_prediction_mean_shape(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -439,7 +439,7 @@ class TestLocalSurrogateManager:
 
     def test_n_neighbors_default(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -453,7 +453,7 @@ class TestLocalSurrogateManager:
 
     def test_scores_finite(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -478,10 +478,10 @@ class TestCompositeSurrogateManager:
         self, archive_1obj: Archive, candidates: np.ndarray
     ) -> None:
         m1 = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
+            RBFSurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         m2 = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
+            RBFSurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         mgr = CompositeSurrogateManager([m1, m2], combine_fn=product_combine)
         scores, _ = mgr.score_candidates(candidates, archive_1obj)
@@ -491,10 +491,10 @@ class TestCompositeSurrogateManager:
         self, archive_1obj: Archive, candidates: np.ndarray
     ) -> None:
         m1 = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
+            RBFSurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         m2 = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
+            RBFSurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         mgr = CompositeSurrogateManager([m1, m2], combine_fn=rank_weighted_combine())
         scores, _ = mgr.score_candidates(candidates, archive_1obj)
@@ -505,10 +505,10 @@ class TestCompositeSurrogateManager:
         self, archive_1obj: Archive, candidates: np.ndarray
     ) -> None:
         m1 = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
+            RBFSurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         m2 = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
+            RBFSurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         mgr = CompositeSurrogateManager(
             [m1, m2], combine_fn=rank_weighted_combine(np.array([1.0, 3.0]))
@@ -521,10 +521,10 @@ class TestCompositeSurrogateManager:
     ) -> None:
         """predictions always come from managers[0]."""
         m1 = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
+            RBFSurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         m2 = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
+            RBFSurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         mgr = CompositeSurrogateManager([m1, m2], combine_fn=product_combine)
         _, predictions = mgr.score_candidates(candidates, archive_1obj)
@@ -534,7 +534,7 @@ class TestCompositeSurrogateManager:
 
     def test_single_manager(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -774,7 +774,7 @@ class TestCompositeSurrogateManagerWithArchiveBased:
         self, archive_1obj: Archive, candidates: np.ndarray
     ) -> None:
         m_reg = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
+            RBFSurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         mgr = CompositeSurrogateManager(
             [m_reg, NoveltyManager(k=3)],
@@ -787,7 +787,7 @@ class TestCompositeSurrogateManagerWithArchiveBased:
         self, archive_1obj: Archive, candidates: np.ndarray
     ) -> None:
         m_reg = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
+            RBFSurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         mgr = CompositeSurrogateManager(
             [m_reg, NoveltyManager(k=3)], combine_fn=rank_weighted_combine()
@@ -800,7 +800,7 @@ class TestCompositeSurrogateManagerWithArchiveBased:
     ) -> None:
         """Regression surrogate listed first → predictions returned are finite."""
         m_reg = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
+            RBFSurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         mgr = CompositeSurrogateManager(
             [m_reg, NoveltyManager(k=3)], combine_fn=rank_weighted_combine()
@@ -825,7 +825,7 @@ class TestCompositeSurrogateManagerWithArchiveBased:
         self, archive_1obj: Archive, candidates: np.ndarray
     ) -> None:
         m_reg = GlobalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
+            RBFSurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         mgr = CompositeSurrogateManager(
             [m_reg, DensityManager(eps=0.5)],
@@ -846,7 +846,7 @@ class TestSurrogateHooks:
     """Tests for Surrogate.post_fit and with_post_fit."""
 
     def test_post_fit_default_is_noop(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         train_x, train_y = archive_1obj.x, archive_1obj.f
         surrogate_1obj.fit(train_x, train_y)
@@ -854,7 +854,7 @@ class TestSurrogateHooks:
         assert result is None
 
     def test_with_post_fit_fn_is_called(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         called = [False]
 
@@ -868,7 +868,7 @@ class TestSurrogateHooks:
         assert called[0]
 
     def test_with_post_fit_fn_receives_correct_args(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         received = {}
 
@@ -883,7 +883,7 @@ class TestSurrogateHooks:
         assert received["train_y_shape"] == train_y.shape
 
     def test_with_post_fit_chains_in_order(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         log: list[int] = []
         surrogate = surrogate_1obj.with_post_fit(
@@ -894,7 +894,7 @@ class TestSurrogateHooks:
         assert log == [1, 2]
 
     def test_with_post_fit_does_not_mutate_original(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         called = [False]
 
@@ -917,7 +917,7 @@ class TestSurrogateManagerHooks:
 
     def test_post_score_default_is_noop(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -929,7 +929,7 @@ class TestSurrogateManagerHooks:
 
     def test_with_post_score_transforms_scores(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -944,7 +944,7 @@ class TestSurrogateManagerHooks:
 
     def test_with_post_score_called_once_per_score_candidates(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -962,7 +962,7 @@ class TestSurrogateManagerHooks:
 
     def test_with_post_score_does_not_mutate_original(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -973,7 +973,7 @@ class TestSurrogateManagerHooks:
 
     def test_post_fit_called_in_global_manager(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -989,7 +989,7 @@ class TestSurrogateManagerHooks:
 
     def test_post_fit_called_per_candidate_in_local_manager(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
         candidates: np.ndarray,
     ) -> None:
@@ -1016,7 +1016,7 @@ class TestSurrogateManagerGenerationHook:
 
     def test_on_generation_end_default_is_noop(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
     ) -> None:
         manager = GlobalSurrogateManager(surrogate_1obj, MeanPrediction())
@@ -1024,7 +1024,7 @@ class TestSurrogateManagerGenerationHook:
 
     def test_with_on_generation_end_fn_is_called(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
     ) -> None:
         calls: list[tuple] = []
@@ -1042,7 +1042,7 @@ class TestSurrogateManagerGenerationHook:
 
     def test_with_on_generation_end_chains_in_order(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
     ) -> None:
         order: list[int] = []
@@ -1056,7 +1056,7 @@ class TestSurrogateManagerGenerationHook:
 
     def test_with_on_generation_end_does_not_mutate_original(
         self,
-        surrogate_1obj: RBFsurrogate,
+        surrogate_1obj: RBFSurrogate,
         archive_1obj: Archive,
     ) -> None:
         called = [False]
@@ -1077,20 +1077,20 @@ class TestSurrogateManagerGenerationHook:
 
 class TestLastAccuracy:
     def test_last_accuracy_none_by_default(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         manager = GlobalSurrogateManager(surrogate_1obj, MeanPrediction())
         assert manager.last_accuracy is None
 
     def test_last_accuracy_none_without_evaluator(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         manager = GlobalSurrogateManager(surrogate_1obj, MeanPrediction())
         manager.fit(archive_1obj)
         assert manager.last_accuracy is None
 
     def test_last_accuracy_set_after_fit_with_evaluator(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=5)
         manager = GlobalSurrogateManager(
@@ -1101,7 +1101,7 @@ class TestLastAccuracy:
         assert "spearman" in manager.last_accuracy.metrics
 
     def test_last_accuracy_updated_on_score_candidates_with_refit(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
         manager = GlobalSurrogateManager(
@@ -1113,7 +1113,7 @@ class TestLastAccuracy:
         assert manager.last_accuracy is not None
 
     def test_last_accuracy_not_updated_when_refit_false(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
         manager = GlobalSurrogateManager(
@@ -1128,7 +1128,7 @@ class TestLastAccuracy:
         assert manager.last_accuracy is first  # same object, not updated
 
     def test_composite_propagates_last_accuracy_from_first_manager(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
         m1 = GlobalSurrogateManager(
@@ -1145,13 +1145,13 @@ class TestLastAccuracy:
 
 class TestLocalSurrogateManagerAccuracy:
     def test_last_accuracy_none_by_default(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         manager = LocalSurrogateManager(surrogate_1obj, MeanPrediction())
         assert manager.last_accuracy is None
 
     def test_fit_sets_last_accuracy(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
         manager = LocalSurrogateManager(
@@ -1162,14 +1162,14 @@ class TestLocalSurrogateManagerAccuracy:
         assert "spearman" in manager.last_accuracy.metrics
 
     def test_fit_noop_without_evaluator(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         manager = LocalSurrogateManager(surrogate_1obj, MeanPrediction())
         manager.fit(archive_1obj)
         assert manager.last_accuracy is None
 
     def test_last_accuracy_set_after_score_candidates_with_refit(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
         manager = LocalSurrogateManager(
@@ -1184,7 +1184,7 @@ class TestLocalSurrogateManagerAccuracy:
         assert manager.last_accuracy.n_samples == len(candidates)
 
     def test_last_accuracy_not_updated_when_refit_false(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
         manager = LocalSurrogateManager(
@@ -1198,7 +1198,7 @@ class TestLocalSurrogateManagerAccuracy:
         assert manager.last_accuracy is first  # not updated
 
     def test_generation_based_pattern_sets_last_accuracy(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         """fit() + score_candidates(refit=False) pattern (GenerationBasedStrategy)."""
         evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
@@ -1215,7 +1215,7 @@ class TestLocalSurrogateManagerAccuracy:
         assert manager.last_accuracy is accuracy_after_fit
 
     def test_nearest_neighbor_excluded_from_training(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         """Nearest archive neighbor is held out; training uses n_neighbors-1 points."""
         evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)
@@ -1223,7 +1223,7 @@ class TestLocalSurrogateManagerAccuracy:
             surrogate_1obj, MeanPrediction(), accuracy_evaluator=evaluator
         )
         manager_without = LocalSurrogateManager(
-            RBFsurrogate(gaussian_kernel, DIM), MeanPrediction()
+            RBFSurrogate(gaussian_kernel, DIM), MeanPrediction()
         )
         rng = np.random.default_rng(99)
         candidates = rng.uniform(-2.0, 2.0, size=(5, DIM))
@@ -1235,7 +1235,7 @@ class TestLocalSurrogateManagerAccuracy:
         assert not np.any(np.isnan(scores_with))
 
     def test_loo_self_exclusion_in_update_accuracy(
-        self, surrogate_1obj: RBFsurrogate, archive_1obj: Archive
+        self, surrogate_1obj: RBFSurrogate, archive_1obj: Archive
     ) -> None:
         """_update_accuracy uses LOO self-exclusion; RBF no longer gives perfect score."""  # noqa: E501
         evaluator = KFoldAccuracyEvaluator(metrics=[SpearmanCorrelation()], n_splits=3)


### PR DESCRIPTION
## Related Issue
Closes #156

## Overview
Enforce PEP 8 naming conventions before the API freeze.

## Changes
- Rename `RBFsurrogate` → `RBFSurrogate` (CapWords); add silent backward-compat alias via `__getattr__`
- Rename `Result.X/F` → `Result.x/f` to match the rest of the codebase

## Verification Steps
- `uv run pytest tests/` — 1190 passed
- `uv run ruff check src/ tests/` — no issues
- `uv run --with ty ty check src/` — no new errors