### PR TITLE
fix: [#170] RNSGA2Comparator.compare_population uses rank then reference-point distance

### DIFF
--- a/src/saealib/comparators/comparators.py
+++ b/src/saealib/comparators/comparators.py
@@ -1442,6 +1442,9 @@ class RNSGA2Comparator(ParetoComparator):
         feasible = np.where(cv <= self.eps_cv)[0]
         infeasible = np.where(cv > self.eps_cv)[0]
 
+        rank_full = np.full(len(population), np.inf)
+        dist_min_full = np.full(len(population), np.inf)
+
         sorted_feasible: list[int] = []
         if len(feasible):
             _ranks, fronts = self._sorter(
@@ -1458,6 +1461,9 @@ class RNSGA2Comparator(ParetoComparator):
             dist_matrix = np.linalg.norm(diff, axis=2)  # (n_feasible, n_ref)
             assoc_idx = np.argmin(dist_matrix, axis=1)  # (n_feasible,)
             dist_min = dist_matrix[np.arange(len(feasible)), assoc_idx]
+
+            rank_full[feasible] = _ranks
+            dist_min_full[feasible] = dist_min
 
             niche_count = np.zeros(len(self._reference_points), dtype=int)
 
@@ -1478,7 +1484,54 @@ class RNSGA2Comparator(ParetoComparator):
             [np.array(sorted_feasible, dtype=int), sorted_infeasible]
         ).astype(int)
         population.set_cache(_cache_key, result)
+        _rd_key = ("rnsga2_rank_dist", self._sorter, self._dominator, _dir_key)
+        population.set_cache(_rd_key, (rank_full, dist_min_full))
         return result
+
+    def compare_population(self, population: Population, idx_a: int, idx_b: int) -> int:
+        """Compare via R-NSGA-II operator: rank first, then reference-point distance.
+
+        Lower rank wins; within the same rank, closer to the nearest reference
+        point wins (smaller distance is better, opposite of NSGA-II crowding
+        distance). Infeasibility is handled with the standard constraint-
+        domination rule (Deb 2000).
+        """
+        cv = population.get_array("cv")
+        cv_a = float(cv[idx_a])
+        cv_b = float(cv[idx_b])
+
+        if cv_a > self.eps_cv and cv_b > self.eps_cv:
+            if cv_a < cv_b:
+                return -1
+            if cv_a > cv_b:
+                return 1
+            return 0
+        if cv_a > self.eps_cv:
+            return 1
+        if cv_b > self.eps_cv:
+            return -1
+
+        # Both feasible: rank first, then distance to nearest reference point
+        # (smaller distance = better, i.e. closer to user preference).
+        self.sort_population(population)
+        _dir_key = (
+            tuple(self.direction.tolist()) if self.direction is not None else None
+        )
+        _rd_key = ("rnsga2_rank_dist", self._sorter, self._dominator, _dir_key)
+        cached = population.get_cache(_rd_key)
+        assert cached is not None
+        rank_full, dist_min_full = cached
+        rank_a, rank_b = rank_full[idx_a], rank_full[idx_b]
+        if rank_a < rank_b:
+            return -1
+        if rank_a > rank_b:
+            return 1
+        dist_a, dist_b = dist_min_full[idx_a], dist_min_full[idx_b]
+        if dist_a < dist_b:
+            return -1
+        if dist_a > dist_b:
+            return 1
+        return 0
 
     def _order_front(
         self,

--- a/tests/test_moo.py
+++ b/tests/test_moo.py
@@ -2395,3 +2395,64 @@ class TestRNSGA2Comparator:
         comp = RNSGA2Comparator(ref, direction=np.array([-1.0, -1.0]))
         order = comp.sort_population(pop)
         assert order[0] == 0  # [0.1, 0.9] is closer to ref [0.1, 0.9]
+
+    # compare_population tests
+
+    def test_compare_population_lower_rank_wins(self) -> None:
+        """Lower Pareto rank beats higher rank regardless of ref-point distance."""
+        ref = np.array([[0.5, 0.5]])
+        # idx 0 dominates idx 1 (lower rank); idx 1 might be closer to ref
+        f = np.array([[0.0, 0.0], [5.0, 5.0]])
+        pop = _make_pop(f)
+        comp = RNSGA2Comparator(ref)
+        assert comp.compare_population(pop, 0, 1) == -1
+        assert comp.compare_population(pop, 1, 0) == 1
+
+    def test_compare_population_same_front_closer_ref_wins(self) -> None:
+        """Within the same front, the individual closer to a reference point wins."""
+        ref = np.array([[0.0, 1.0]])
+        # Both non-dominated; idx 0 is near ref [0,1], idx 1 is far
+        f = np.array([[0.1, 0.9], [0.9, 0.1]])
+        pop = _make_pop(f)
+        comp = RNSGA2Comparator(ref)
+        assert comp.compare_population(pop, 0, 1) == -1  # idx 0 closer to ref
+        assert comp.compare_population(pop, 1, 0) == 1
+
+    def test_compare_population_feasible_beats_infeasible(self) -> None:
+        """A feasible individual always beats an infeasible one."""
+        ref = np.array([[0.5, 0.5]])
+        f = np.array([[0.0, 0.0], [0.0, 0.0]])
+        cv = np.array([1.0, 0.0])  # idx 0 infeasible, idx 1 feasible
+        pop = _make_pop(f, cv)
+        comp = RNSGA2Comparator(ref)
+        assert comp.compare_population(pop, 0, 1) == 1  # infeasible loses
+        assert comp.compare_population(pop, 1, 0) == -1  # feasible wins
+
+    def test_compare_population_both_infeasible_lower_cv_wins(self) -> None:
+        """Both infeasible: lower constraint violation wins."""
+        ref = np.array([[0.5, 0.5]])
+        f = np.array([[0.0, 0.0], [0.0, 0.0]])
+        cv = np.array([0.5, 2.0])
+        pop = _make_pop(f, cv)
+        comp = RNSGA2Comparator(ref)
+        assert comp.compare_population(pop, 0, 1) == -1
+        assert comp.compare_population(pop, 1, 0) == 1
+
+    def test_compare_population_tie(self) -> None:
+        """Identical individuals on the same front at the same distance tie."""
+        ref = np.array([[0.5, 0.5]])
+        f = np.array([[0.5, 0.5], [0.5, 0.5]])
+        pop = _make_pop(f)
+        comp = RNSGA2Comparator(ref)
+        assert comp.compare_population(pop, 0, 1) == 0
+
+    def test_compare_population_three_fronts(self) -> None:
+        """Three-level domination: rank 0 < rank 1 < rank 2."""
+        ref = np.array([[0.5, 0.5]])
+        # idx 0 dominates idx 1 dominates idx 2
+        f = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]])
+        pop = _make_pop(f)
+        comp = RNSGA2Comparator(ref)
+        assert comp.compare_population(pop, 0, 1) == -1
+        assert comp.compare_population(pop, 1, 2) == -1
+        assert comp.compare_population(pop, 0, 2) == -1


### PR DESCRIPTION
## Related Issue
Closes #170

## Overview
`RNSGA2Comparator.compare_population()` was inherited from `ParetoComparator` and used Pareto dominance only. All individuals within the same front were tied, so reference-point proximity never influenced tournament parent selection. This is the same pattern fixed for NSGA-II in PR #163.

## Changes
- `sort_population()` now caches `rank_full` and `dist_min_full` per individual under the key `"rnsga2_rank_dist"`
- Added `compare_population()` override: rank ascending, then distance to nearest reference point ascending (smaller distance wins, opposite of NSGA-II crowding distance)

## Verification Steps
- `uv run pytest tests/test_moo.py -x -q`

## Concerns
- Distance direction is the reverse of NSGA-II: smaller `dist_min` is better (closer to user-specified reference point is preferred)

## Other