### PR TITLE
fix: [#146] validate crossover operator consistency in GA.ask() for mixed-variable problems

### DIFF
--- a/src/saealib/algorithms/ga.py
+++ b/src/saealib/algorithms/ga.py
@@ -244,6 +244,26 @@ class GA(Algorithm):
         -------
         Population
         """
+        # Re-validate per-type crossover consistency here because operators may be
+        # replaced or mutated after __init__, bypassing constructor checks.
+        if ctx.problem.integer_mask.any() or ctx.problem.categorical_mask.any():
+            for _name, _op in [
+                ("integer_crossover", self.integer_crossover),
+                ("categorical_crossover", self.categorical_crossover),
+            ]:
+                if _op.n_children != self.crossover.n_children:
+                    raise ConfigurationError(
+                        f"{_name}.n_children={_op.n_children} must equal "
+                        f"crossover.n_children={self.crossover.n_children} "
+                        "for mixed-variable routing"
+                    )
+                if _op.n_parents != self.crossover.n_parents:
+                    raise ConfigurationError(
+                        f"{_name}.n_parents={_op.n_parents} must equal "
+                        f"crossover.n_parents={self.crossover.n_parents} "
+                        "for mixed-variable routing"
+                    )
+
         pop = ctx.population.get_array("x")
         popsize = len(pop)
         target = n_offspring if n_offspring is not None else popsize

--- a/tests/test_ga_mixed.py
+++ b/tests/test_ga_mixed.py
@@ -394,3 +394,23 @@ class TestGAMixedAsk:
         ctx = _make_ctx_for(problem)
         offspring = ga.ask(ctx, _NoopProvider(), n_offspring=4)
         assert offspring.get_array("x").shape == (4, 3)
+
+    def test_ask_raises_when_primary_n_children_mutated(self):
+        """Mutating crossover.n_children after init must raise ConfigurationError."""
+        problem = _make_problem_mixed()
+        ga = _make_ga()
+        # Bypass __init__ validation by directly changing the attribute.
+        ga.crossover.n_children = 1
+        ctx = _make_ctx_for(problem)
+        with pytest.raises(ConfigurationError, match=r"integer_crossover\.n_children"):
+            ga.ask(ctx, _NoopProvider())
+
+    def test_ask_raises_when_integer_crossover_replaced_with_mismatched(self):
+        """Replacing integer_crossover with a different n_children must raise."""
+        problem = _make_problem_mixed()
+        ga = _make_ga()
+        # _CrossoverN1C has n_children=1; crossover has n_children=2.
+        ga.integer_crossover = _CrossoverN1C()
+        ctx = _make_ctx_for(problem)
+        with pytest.raises(ConfigurationError, match=r"integer_crossover\.n_children"):
+            ga.ask(ctx, _NoopProvider())


### PR DESCRIPTION
## Related Issue
Closes #146

## Overview
`GA.__init__` validates that per-type crossover operators share the same `n_children` and `n_parents` as the primary operator, but this check can be bypassed by mutating operators after construction. The mismatch then causes an opaque `ValueError` inside `_route_crossover`.

## Changes
- Added a consistency check at the start of `GA.ask()` that runs only when the problem has integer or categorical variables
- Raises `ConfigurationError` with a descriptive message when `n_children` or `n_parents` differ between the primary and per-type crossover operators

## Verification Steps
- `uv run pytest tests/test_ga_mixed.py -x -q`

## Concerns
- The check adds a small per-generation overhead for mixed-variable problems; purely continuous problems are not affected

## Other