### PR TITLE
feat: [#179] add RandomInitializer, SobolInitializer, and DirectStrategy

### DIFF
--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -27,7 +27,12 @@ from saealib.checkpoint import CheckpointCallback
 from saealib.comparators import Comparator, NSGA2Comparator, SingleObjectiveComparator
 from saealib.exceptions import ConfigurationError, SaealibError, ValidationError
 from saealib.execution.evaluator import EvaluationResult, Evaluator, SerialEvaluator
-from saealib.execution.initializer import Initializer, LHSInitializer
+from saealib.execution.initializer import (
+    Initializer,
+    LHSInitializer,
+    RandomInitializer,
+    SobolInitializer,
+)
 from saealib.operators import (
     Crossover,
     CrossoverSBX,
@@ -142,12 +147,14 @@ __all__ = [
     "PostEvaluationEvent",
     "PreSelectionStrategy",
     "Problem",
+    "RandomInitializer",
     "Result",
     "RunEndEvent",
     "RunStartEvent",
     "SaealibError",
     "SerialEvaluator",
     "SingleObjectiveComparator",
+    "SobolInitializer",
     "SortByScoreStage",
     "Stage",
     "StaticToleranceHandler",

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -74,6 +74,7 @@ from saealib.stages import (
     TrueEvaluationStage,
 )
 from saealib.strategies import (
+    DirectStrategy,
     GenerationBasedStrategy,
     IndividualBasedStrategy,
     OptimizationStrategy,
@@ -116,6 +117,7 @@ __all__ = [
     "CountGenerationStage",
     "Crossover",
     "CrossoverSBX",
+    "DirectStrategy",
     "EpsilonConstraintHandler",
     "EqualityConstraint",
     "EvaluationResult",

--- a/src/saealib/execution/__init__.py
+++ b/src/saealib/execution/__init__.py
@@ -1,10 +1,17 @@
 from saealib.execution.evaluator import EvaluationResult, Evaluator, SerialEvaluator
-from saealib.execution.initializer import Initializer, LHSInitializer
+from saealib.execution.initializer import (
+    Initializer,
+    LHSInitializer,
+    RandomInitializer,
+    SobolInitializer,
+)
 
 __all__ = [
     "EvaluationResult",
     "Evaluator",
     "Initializer",
     "LHSInitializer",
+    "RandomInitializer",
     "SerialEvaluator",
+    "SobolInitializer",
 ]

--- a/src/saealib/execution/initializer.py
+++ b/src/saealib/execution/initializer.py
@@ -202,3 +202,180 @@ class LHSInitializer(Initializer):
         population.extend(archive[: self.n_init_population])
 
         return ctx
+
+
+class RandomInitializer(Initializer):
+    """
+    Random uniform sampling initializer.
+
+    Attributes
+    ----------
+    n_init_archive : int
+        The number of individuals to initialize in the archive.
+    n_init_population : int
+        The number of individuals to initialize in the population.
+    seed : int | None
+        The seed for the random number generator.
+    """
+
+    def __init__(
+        self, n_init_archive: int, n_init_population: int, seed: int | None = None
+    ):
+        self.n_init_archive = n_init_archive
+        self.n_init_population = n_init_population
+        self.seed = seed
+
+    def initialize(
+        self, provider: ComponentProvider, problem: Problem
+    ) -> OptimizationState:
+        """
+        Initialize Population and Archive with uniform random samples.
+
+        Parameters
+        ----------
+        provider : ComponentProvider
+            The component provider instance.
+        problem : Problem
+            The problem instance.
+
+        Returns
+        -------
+        OptimizationState
+        """
+        provider_seed = getattr(provider, "seed", None)
+        rng = np.random.default_rng(
+            provider_seed if provider_seed is not None else self.seed
+        )
+        attrs = self._create_attrs(problem, provider)
+
+        population = provider.algorithm.population_class(
+            attrs=attrs, init_capacity=self.n_init_population
+        )
+        archive = provider.algorithm.archive_class(
+            attrs=attrs, init_capacity=self.n_init_archive
+        )
+        pareto_archive = provider.algorithm.create_pareto_archive(
+            attrs=attrs, init_capacity=self.n_init_archive, problem=problem
+        )
+
+        ctx = self._create_context(problem, archive, pareto_archive, population, rng)
+
+        archive_x = rng.uniform(
+            problem.lb, problem.ub, size=(self.n_init_archive, problem.dim)
+        )
+
+        provider.dispatch(InitialEvaluationStartEvent(ctx=ctx, candidates_x=archive_x))
+
+        result = provider.evaluator.evaluate_batch(archive_x, problem)
+
+        for i in range(self.n_init_archive):
+            data = {
+                "x": archive_x[i],
+                "f": result.f[i],
+                "g": result.g[i],
+                "cv": float(result.cv[i]),
+            }
+            archive.add(data)
+            pareto_archive.add(data)
+
+        ctx.count_fe(self.n_init_archive)
+
+        provider.dispatch(InitialEvaluationEndEvent(ctx=ctx, archive=archive))
+
+        sorted_idx = problem.comparator.sort_population(archive)
+        archive_sorted = archive.extract(sorted_idx)
+        archive.clear()
+        archive.extend(archive_sorted)
+
+        population.extend(archive[: self.n_init_population])
+
+        return ctx
+
+
+class SobolInitializer(Initializer):
+    """
+    Sobol quasi-random sequence initializer.
+
+    Attributes
+    ----------
+    n_init_archive : int
+        The number of individuals to initialize in the archive.
+    n_init_population : int
+        The number of individuals to initialize in the population.
+    seed : int | None
+        The seed for the random number generator.
+    """
+
+    def __init__(
+        self, n_init_archive: int, n_init_population: int, seed: int | None = None
+    ):
+        self.n_init_archive = n_init_archive
+        self.n_init_population = n_init_population
+        self.seed = seed
+
+    def initialize(
+        self, provider: ComponentProvider, problem: Problem
+    ) -> OptimizationState:
+        """
+        Initialize Population and Archive with scrambled Sobol samples.
+
+        Parameters
+        ----------
+        provider : ComponentProvider
+            The component provider instance.
+        problem : Problem
+            The problem instance.
+
+        Returns
+        -------
+        OptimizationState
+        """
+        provider_seed = getattr(provider, "seed", None)
+        rng = np.random.default_rng(
+            provider_seed if provider_seed is not None else self.seed
+        )
+        attrs = self._create_attrs(problem, provider)
+
+        population = provider.algorithm.population_class(
+            attrs=attrs, init_capacity=self.n_init_population
+        )
+        archive = provider.algorithm.archive_class(
+            attrs=attrs, init_capacity=self.n_init_archive
+        )
+        pareto_archive = provider.algorithm.create_pareto_archive(
+            attrs=attrs, init_capacity=self.n_init_archive, problem=problem
+        )
+
+        ctx = self._create_context(problem, archive, pareto_archive, population, rng)
+
+        archive_x = scipy.stats.qmc.Sobol(
+            d=problem.dim, scramble=True, seed=rng
+        ).random(self.n_init_archive)
+        archive_x = scipy.stats.qmc.scale(archive_x, problem.lb, problem.ub)
+
+        provider.dispatch(InitialEvaluationStartEvent(ctx=ctx, candidates_x=archive_x))
+
+        result = provider.evaluator.evaluate_batch(archive_x, problem)
+
+        for i in range(self.n_init_archive):
+            data = {
+                "x": archive_x[i],
+                "f": result.f[i],
+                "g": result.g[i],
+                "cv": float(result.cv[i]),
+            }
+            archive.add(data)
+            pareto_archive.add(data)
+
+        ctx.count_fe(self.n_init_archive)
+
+        provider.dispatch(InitialEvaluationEndEvent(ctx=ctx, archive=archive))
+
+        sorted_idx = problem.comparator.sort_population(archive)
+        archive_sorted = archive.extract(sorted_idx)
+        archive.clear()
+        archive.extend(archive_sorted)
+
+        population.extend(archive[: self.n_init_population])
+
+        return ctx

--- a/src/saealib/strategies/__init__.py
+++ b/src/saealib/strategies/__init__.py
@@ -1,9 +1,11 @@
 from saealib.strategies.base import OptimizationStrategy
+from saealib.strategies.direct import DirectStrategy
 from saealib.strategies.gb import GenerationBasedStrategy
 from saealib.strategies.ib import IndividualBasedStrategy
 from saealib.strategies.ps import PreSelectionStrategy
 
 __all__ = [
+    "DirectStrategy",
     "GenerationBasedStrategy",
     "IndividualBasedStrategy",
     "OptimizationStrategy",

--- a/src/saealib/strategies/direct.py
+++ b/src/saealib/strategies/direct.py
@@ -1,0 +1,61 @@
+"""Direct strategy: plain EA without surrogate evaluation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from saealib.pipeline import Pipeline
+from saealib.stages import (
+    ArchiveUpdateStage,
+    AskStage,
+    CountGenerationStage,
+    TellStage,
+    TrueEvaluationStage,
+)
+from saealib.strategies.base import OptimizationStrategy
+
+if TYPE_CHECKING:
+    from saealib.context import OptimizationState
+    from saealib.optimizer import ComponentProvider
+
+
+class DirectStrategy(OptimizationStrategy):
+    """Plain EA strategy without surrogate scoring.
+
+    Every candidate produced by :meth:`~saealib.algorithms.Algorithm.ask` is
+    evaluated with the true objective function.  No surrogate manager is
+    required.
+    """
+
+    requires_surrogate: bool = False
+
+    def __init__(self) -> None:
+        self.pipeline: Pipeline | None = None
+
+    def _build_pipeline(self, provider: ComponentProvider) -> Pipeline:
+        cbmanager = getattr(provider, "cbmanager", None)
+        return Pipeline(
+            [
+                CountGenerationStage(),
+                AskStage(provider.algorithm, cbmanager=cbmanager),
+                TrueEvaluationStage(provider.evaluator, cbmanager=cbmanager),
+                ArchiveUpdateStage(),
+                TellStage(provider.algorithm),
+            ]
+        )
+
+    def step(
+        self, ctx: OptimizationState, provider: ComponentProvider
+    ) -> OptimizationState:
+        """Evaluate all offspring with the true objective function.
+
+        Parameters
+        ----------
+        ctx : OptimizationState
+            Current optimization context.
+        provider : ComponentProvider
+            Component provider.
+        """
+        if self.pipeline is None:
+            self.pipeline = self._build_pipeline(provider)
+        return self.pipeline.execute(ctx)

--- a/tests/test_direct_strategy.py
+++ b/tests/test_direct_strategy.py
@@ -81,7 +81,9 @@ def _make_ga() -> GA:
 
 
 class _MockSurrogateManager:
-    def fit(self, archive, ctx=None): pass
+    def fit(self, archive, ctx=None):
+        pass
+
     def score_candidates(self, candidates_x, archive, ctx=None, *, refit=True):
         return np.zeros(len(candidates_x)), []
 

--- a/tests/test_direct_strategy.py
+++ b/tests/test_direct_strategy.py
@@ -7,7 +7,6 @@ import numpy as np
 from saealib import (
     GA,
     CrossoverBLXAlpha,
-    DirectStrategy,
     LHSInitializer,
     MutationUniform,
     Optimizer,
@@ -24,6 +23,8 @@ from saealib.pipeline import Pipeline
 from saealib.population import Archive, ParetoArchive, Population, PopulationAttribute
 from saealib.problem import Problem
 from saealib.strategies.base import OptimizationStrategy
+from saealib.strategies.direct import DirectStrategy
+from saealib.surrogate import SurrogateManager
 
 DIM = 4
 N_OBJ = 1
@@ -79,11 +80,20 @@ def _make_ga() -> GA:
     )
 
 
+class _MockSurrogateManager:
+    def fit(self, archive, ctx=None): pass
+    def score_candidates(self, candidates_x, archive, ctx=None, *, refit=True):
+        return np.zeros(len(candidates_x)), []
+
+
 class _MockProvider:
     seed: int | None = None
+    strategy: OptimizationStrategy = DirectStrategy()
+    termination: Termination = Termination(max_gen(100_000))
 
     def __init__(self):
         self.algorithm = _make_ga()
+        self.surrogate_manager: SurrogateManager = _MockSurrogateManager()  # type: ignore
         self.evaluator = SerialEvaluator()
         self.cbmanager = CallbackManager()
 
@@ -168,7 +178,8 @@ def test_minimize_without_surrogate_manager():
 def test_importable_from_top_level():
     import saealib
 
-    assert saealib.DirectStrategy is DirectStrategy
+    assert hasattr(saealib, "DirectStrategy")
+    assert saealib.DirectStrategy is DirectStrategy  # type: ignore[attr-defined]
 
 
 def test_importable_from_strategies():

--- a/tests/test_direct_strategy.py
+++ b/tests/test_direct_strategy.py
@@ -1,0 +1,177 @@
+"""Tests for DirectStrategy."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from saealib import (
+    GA,
+    CrossoverBLXAlpha,
+    DirectStrategy,
+    LHSInitializer,
+    MutationUniform,
+    Optimizer,
+    SequentialSelection,
+    Termination,
+    TruncationSelection,
+    max_gen,
+)
+from saealib.callback import CallbackManager
+from saealib.comparators import SingleObjectiveComparator
+from saealib.context import OptimizationState
+from saealib.execution.evaluator import SerialEvaluator
+from saealib.pipeline import Pipeline
+from saealib.population import Archive, ParetoArchive, Population, PopulationAttribute
+from saealib.problem import Problem
+from saealib.strategies.base import OptimizationStrategy
+
+DIM = 4
+N_OBJ = 1
+N_POP = 8
+
+_ATTRS = [
+    PopulationAttribute(name="x", dtype=np.float64, shape=(DIM,)),
+    PopulationAttribute(name="f", dtype=np.float64, shape=(N_OBJ,)),
+    PopulationAttribute(name="g", dtype=np.float64, shape=(0,)),
+    PopulationAttribute(name="cv", dtype=np.float64, shape=()),
+]
+
+
+def _make_problem() -> Problem:
+    return Problem(
+        func=lambda x: np.array([np.sum(x**2)]),
+        dim=DIM,
+        n_obj=N_OBJ,
+        direction=np.array([-1.0]),
+        lb=[-5.0] * DIM,
+        ub=[5.0] * DIM,
+        comparator=SingleObjectiveComparator(),
+    )
+
+
+def _make_ctx(rng_seed: int = 0) -> OptimizationState:
+    problem = _make_problem()
+    rng = np.random.default_rng(rng_seed)
+    pop = Population(_ATTRS, init_capacity=N_POP + 5)
+    xs = rng.uniform(-3.0, 3.0, size=(N_POP, DIM))
+    fs = np.array([[np.sum(x**2)] for x in xs])
+    pop.extend({"x": xs, "f": fs, "g": np.zeros((N_POP, 0)), "cv": np.zeros(N_POP)})
+    arc = Archive(_ATTRS, init_capacity=N_POP + 5)
+    arc.extend({"x": xs, "f": fs, "g": np.zeros((N_POP, 0)), "cv": np.zeros(N_POP)})
+    pareto_arc = ParetoArchive(
+        _ATTRS, init_capacity=N_POP + 5, direction=np.array([-1.0])
+    )
+    return OptimizationState(
+        problem=problem,
+        population=pop,
+        archive=arc,
+        pareto_archive=pareto_arc,
+        rng=np.random.default_rng(rng_seed + 1),
+    )
+
+
+def _make_ga() -> GA:
+    return GA(
+        crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4),
+        mutation=MutationUniform(mutation_rate=0.1),
+        parent_selection=SequentialSelection(),
+        survivor_selection=TruncationSelection(),
+    )
+
+
+class _MockProvider:
+    seed: int | None = None
+
+    def __init__(self):
+        self.algorithm = _make_ga()
+        self.evaluator = SerialEvaluator()
+        self.cbmanager = CallbackManager()
+
+    def dispatch(self, event):
+        self.cbmanager.dispatch(event)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestDirectStrategy:
+    def test_requires_surrogate_is_false(self):
+        assert DirectStrategy.requires_surrogate is False
+
+    def test_is_optimization_strategy_subclass(self):
+        assert isinstance(DirectStrategy(), OptimizationStrategy)
+
+    def test_pipeline_none_before_step(self):
+        assert DirectStrategy().pipeline is None
+
+    def test_pipeline_is_pipeline_after_step(self):
+        strategy = DirectStrategy()
+        ctx = _make_ctx()
+        provider = _MockProvider()
+        strategy.step(ctx, provider)
+        assert isinstance(strategy.pipeline, Pipeline)
+
+    def test_pipeline_reused_across_steps(self):
+        strategy = DirectStrategy()
+        ctx = _make_ctx()
+        provider = _MockProvider()
+        strategy.step(ctx, provider)
+        first = strategy.pipeline
+        strategy.step(ctx, provider)
+        assert strategy.pipeline is first
+
+    def test_generation_incremented(self):
+        strategy = DirectStrategy()
+        ctx = _make_ctx()
+        provider = _MockProvider()
+        ctx = strategy.step(ctx, provider)
+        assert ctx.gen == 1
+
+    def test_fe_equals_offspring_count(self):
+        strategy = DirectStrategy()
+        ctx = _make_ctx()
+        provider = _MockProvider()
+        ctx = strategy.step(ctx, provider)
+        assert ctx.fe == N_POP
+
+    def test_archive_grows_by_offspring_count(self):
+        strategy = DirectStrategy()
+        ctx = _make_ctx()
+        provider = _MockProvider()
+        before = len(ctx.archive)
+        ctx = strategy.step(ctx, provider)
+        assert len(ctx.archive) == before + N_POP
+
+
+# ---------------------------------------------------------------------------
+# Integration: minimize without surrogate manager
+# ---------------------------------------------------------------------------
+
+
+def test_minimize_without_surrogate_manager():
+    problem = _make_problem()
+    ctx = (
+        Optimizer(problem)
+        .set_initializer(LHSInitializer(n_init_archive=10, n_init_population=8, seed=0))
+        .set_algorithm(_make_ga())
+        .set_strategy(DirectStrategy())
+        .set_termination(Termination(max_gen(5)))
+        .run()
+    )
+    assert ctx is not None
+    assert ctx.gen == 5
+    assert ctx.fe > 0
+
+
+def test_importable_from_top_level():
+    import saealib
+
+    assert saealib.DirectStrategy is DirectStrategy
+
+
+def test_importable_from_strategies():
+    import saealib.strategies as m
+
+    assert m.DirectStrategy is DirectStrategy

--- a/tests/test_initializers.py
+++ b/tests/test_initializers.py
@@ -1,0 +1,160 @@
+"""Tests for RandomInitializer and SobolInitializer."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from saealib import (
+    GA,
+    CrossoverBLXAlpha,
+    LHSInitializer,
+    MutationUniform,
+    RandomInitializer,
+    SequentialSelection,
+    SobolInitializer,
+    TruncationSelection,
+)
+from saealib.comparators import SingleObjectiveComparator
+from saealib.execution.evaluator import SerialEvaluator
+from saealib.execution.initializer import Initializer
+from saealib.problem import Problem
+
+DIM = 3
+N_ARCHIVE = 8
+N_POP = 4
+
+LB = [-2.0] * DIM
+UB = [3.0] * DIM
+
+
+def _make_problem() -> Problem:
+    return Problem(
+        func=lambda x: np.array([np.sum(x**2)]),
+        dim=DIM,
+        n_obj=1,
+        direction=np.array([-1.0]),
+        lb=LB,
+        ub=UB,
+        comparator=SingleObjectiveComparator(),
+    )
+
+
+class _MockProvider:
+    seed: int | None = None
+
+    def __init__(self):
+        from saealib.callback import CallbackManager
+
+        self.algorithm = GA(
+            crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4),
+            mutation=MutationUniform(mutation_rate=0.1),
+            parent_selection=SequentialSelection(),
+            survivor_selection=TruncationSelection(),
+        )
+        self.evaluator = SerialEvaluator()
+        self.cbmanager = CallbackManager()
+
+    def dispatch(self, event):
+        self.cbmanager.dispatch(event)
+
+
+@pytest.fixture
+def problem():
+    return _make_problem()
+
+
+@pytest.fixture
+def provider():
+    return _MockProvider()
+
+
+# ---------------------------------------------------------------------------
+# Shared behaviour: all initializers must satisfy these properties
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "initializer",
+    [
+        RandomInitializer(N_ARCHIVE, N_POP, seed=0),
+        SobolInitializer(N_ARCHIVE, N_POP, seed=0),
+        LHSInitializer(N_ARCHIVE, N_POP, seed=0),
+    ],
+    ids=["random", "sobol", "lhs"],
+)
+class TestInitializerContract:
+    def test_archive_size(self, initializer, problem, provider):
+        ctx = initializer.initialize(provider, problem)
+        assert len(ctx.archive) == N_ARCHIVE
+
+    def test_population_size(self, initializer, problem, provider):
+        ctx = initializer.initialize(provider, problem)
+        assert len(ctx.population) == N_POP
+
+    def test_fe_equals_n_archive(self, initializer, problem, provider):
+        ctx = initializer.initialize(provider, problem)
+        assert ctx.fe == N_ARCHIVE
+
+    def test_archive_x_within_bounds(self, initializer, problem, provider):
+        ctx = initializer.initialize(provider, problem)
+        x = ctx.archive.get_array("x")
+        lb = np.array(LB)
+        ub = np.array(UB)
+        assert np.all(x >= lb - 1e-9)
+        assert np.all(x <= ub + 1e-9)
+
+    def test_is_initializer_subclass(self, initializer, problem, provider):
+        assert isinstance(initializer, Initializer)
+
+
+# ---------------------------------------------------------------------------
+# Importability
+# ---------------------------------------------------------------------------
+
+
+def test_random_initializer_importable_from_top_level():
+    import saealib
+
+    assert saealib.RandomInitializer is RandomInitializer
+
+
+def test_sobol_initializer_importable_from_top_level():
+    import saealib
+
+    assert saealib.SobolInitializer is SobolInitializer
+
+
+def test_random_initializer_importable_from_execution():
+    import saealib.execution.initializer as m
+
+    assert m.RandomInitializer is RandomInitializer
+
+
+def test_sobol_initializer_importable_from_execution():
+    import saealib.execution.initializer as m
+
+    assert m.SobolInitializer is SobolInitializer
+
+
+# ---------------------------------------------------------------------------
+# Reproducibility
+# ---------------------------------------------------------------------------
+
+
+def test_random_initializer_same_seed_reproducible(problem, provider):
+    ctx1 = RandomInitializer(N_ARCHIVE, N_POP, seed=42).initialize(provider, problem)
+    provider2 = _MockProvider()
+    ctx2 = RandomInitializer(N_ARCHIVE, N_POP, seed=42).initialize(provider2, problem)
+    np.testing.assert_array_equal(
+        ctx1.archive.get_array("x"), ctx2.archive.get_array("x")
+    )
+
+
+def test_sobol_initializer_same_seed_reproducible(problem, provider):
+    ctx1 = SobolInitializer(N_ARCHIVE, N_POP, seed=42).initialize(provider, problem)
+    provider2 = _MockProvider()
+    ctx2 = SobolInitializer(N_ARCHIVE, N_POP, seed=42).initialize(provider2, problem)
+    np.testing.assert_array_equal(
+        ctx1.archive.get_array("x"), ctx2.archive.get_array("x")
+    )

--- a/tests/test_initializers.py
+++ b/tests/test_initializers.py
@@ -10,15 +10,22 @@ from saealib import (
     CrossoverBLXAlpha,
     LHSInitializer,
     MutationUniform,
-    RandomInitializer,
     SequentialSelection,
-    SobolInitializer,
+    Termination,
     TruncationSelection,
+    max_gen,
 )
 from saealib.comparators import SingleObjectiveComparator
 from saealib.execution.evaluator import SerialEvaluator
-from saealib.execution.initializer import Initializer
+from saealib.execution.initializer import (
+    Initializer,
+    RandomInitializer,
+    SobolInitializer,
+)
 from saealib.problem import Problem
+from saealib.strategies.base import OptimizationStrategy
+from saealib.strategies.direct import DirectStrategy
+from saealib.surrogate import SurrogateManager
 
 DIM = 3
 N_ARCHIVE = 8
@@ -40,8 +47,16 @@ def _make_problem() -> Problem:
     )
 
 
+class _MockSurrogateManager:
+    def fit(self, archive, ctx=None): pass
+    def score_candidates(self, candidates_x, archive, ctx=None, *, refit=True):
+        return np.zeros(len(candidates_x)), []
+
+
 class _MockProvider:
     seed: int | None = None
+    strategy: OptimizationStrategy = DirectStrategy()
+    termination: Termination = Termination(max_gen(100_000))
 
     def __init__(self):
         from saealib.callback import CallbackManager
@@ -52,6 +67,7 @@ class _MockProvider:
             parent_selection=SequentialSelection(),
             survivor_selection=TruncationSelection(),
         )
+        self.surrogate_manager: SurrogateManager = _MockSurrogateManager()  # type: ignore
         self.evaluator = SerialEvaluator()
         self.cbmanager = CallbackManager()
 
@@ -116,13 +132,15 @@ class TestInitializerContract:
 def test_random_initializer_importable_from_top_level():
     import saealib
 
-    assert saealib.RandomInitializer is RandomInitializer
+    assert hasattr(saealib, "RandomInitializer")
+    assert saealib.RandomInitializer is RandomInitializer  # type: ignore[attr-defined]
 
 
 def test_sobol_initializer_importable_from_top_level():
     import saealib
 
-    assert saealib.SobolInitializer is SobolInitializer
+    assert hasattr(saealib, "SobolInitializer")
+    assert saealib.SobolInitializer is SobolInitializer  # type: ignore[attr-defined]
 
 
 def test_random_initializer_importable_from_execution():

--- a/tests/test_initializers.py
+++ b/tests/test_initializers.py
@@ -48,7 +48,9 @@ def _make_problem() -> Problem:
 
 
 class _MockSurrogateManager:
-    def fit(self, archive, ctx=None): pass
+    def fit(self, archive, ctx=None):
+        pass
+
     def score_candidates(self, candidates_x, archive, ctx=None, *, refit=True):
         return np.zeros(len(candidates_x)), []
 


### PR DESCRIPTION
## Related Issue

Closes #179

## Overview

Adds the minimum components needed to run an EA without a surrogate model: `RandomInitializer` (uniform random sampling) and `SobolInitializer` (scrambled Sobol quasi-random sequence) as initialization methods, and `DirectStrategy` (a surrogate-free EA strategy).

## Changes

- `src/saealib/execution/initializer.py`: add `RandomInitializer` and `SobolInitializer`
- `src/saealib/execution/__init__.py`: export both classes
- `src/saealib/strategies/direct.py` (new): implement `DirectStrategy` (`requires_surrogate=False`)
- `src/saealib/strategies/__init__.py`: export `DirectStrategy`
- `src/saealib/__init__.py`: add all three classes to eager imports and `__all__`
- `tests/test_initializers.py` (new): 21 tests (bounds check, FE count, reproducibility, etc.)
- `tests/test_direct_strategy.py` (new): 11 tests (unit + `Optimizer.run()` integration test)

## Verification Steps

```
pytest tests/test_initializers.py tests/test_direct_strategy.py -v
pytest tests/ -q
ruff check src/ tests/
ty check src/ tests/
```

## Concerns

- `SobolInitializer` may produce a scipy warning when the sample count is not a power of 2, due to the nature of Sobol sequences. No user-facing notice is provided at this point.

## Other

None