### PR TITLE
feat: add benchmark module with ZDT, DTLZ, and single-objective suites

### DIFF
--- a/src/saealib/benchmarks/__init__.py
+++ b/src/saealib/benchmarks/__init__.py
@@ -2,17 +2,25 @@
 
 Multi-objective suites
 ----------------------
-- :mod:`saealib.benchmarks.zdt`  -- ZDT1-4, ZDT6 (Zitzler et al. 2000)
+- :mod:`saealib.benchmarks.zdt`  -- ZDT1-6 (Zitzler et al. 2000)
 - :mod:`saealib.benchmarks.dtlz` -- DTLZ1-4, DTLZ7 (Deb et al. 2005)
 
 Single-objective functions
 --------------------------
-- :mod:`saealib.benchmarks.singleobj` — Sphere, Rastrigin, Rosenbrock, Ackley
+- :mod:`saealib.benchmarks.singleobj` -- Sphere, Rastrigin, Rosenbrock, Ackley
 """
 
+from saealib.benchmarks.dtlz import dtlz1, dtlz2, dtlz3, dtlz4, dtlz5, dtlz6, dtlz7
 from saealib.benchmarks.zdt import zdt1, zdt2, zdt3, zdt4, zdt5, zdt6
 
 __all__ = [
+    "dtlz1",
+    "dtlz2",
+    "dtlz3",
+    "dtlz4",
+    "dtlz5",
+    "dtlz6",
+    "dtlz7",
     "zdt1",
     "zdt2",
     "zdt3",

--- a/src/saealib/benchmarks/__init__.py
+++ b/src/saealib/benchmarks/__init__.py
@@ -1,0 +1,22 @@
+"""Benchmark problems for saealib.
+
+Multi-objective suites
+----------------------
+- :mod:`saealib.benchmarks.zdt`  -- ZDT1-4, ZDT6 (Zitzler et al. 2000)
+- :mod:`saealib.benchmarks.dtlz` -- DTLZ1-4, DTLZ7 (Deb et al. 2005)
+
+Single-objective functions
+--------------------------
+- :mod:`saealib.benchmarks.singleobj` — Sphere, Rastrigin, Rosenbrock, Ackley
+"""
+
+from saealib.benchmarks.zdt import zdt1, zdt2, zdt3, zdt4, zdt5, zdt6
+
+__all__ = [
+    "zdt1",
+    "zdt2",
+    "zdt3",
+    "zdt4",
+    "zdt5",
+    "zdt6",
+]

--- a/src/saealib/benchmarks/__init__.py
+++ b/src/saealib/benchmarks/__init__.py
@@ -2,18 +2,20 @@
 
 Multi-objective suites
 ----------------------
-- :mod:`saealib.benchmarks.zdt`  -- ZDT1-6 (Zitzler et al. 2000)
-- :mod:`saealib.benchmarks.dtlz` -- DTLZ1-4, DTLZ7 (Deb et al. 2005)
+- :mod:`saealib.benchmarks.zdt`      -- ZDT1-6 (Zitzler et al. 2000)
+- :mod:`saealib.benchmarks.dtlz`     -- DTLZ1-7 (Deb et al. 2005)
 
 Single-objective functions
 --------------------------
-- :mod:`saealib.benchmarks.singleobj` -- Sphere, Rastrigin, Rosenbrock, Ackley
+- :mod:`saealib.benchmarks.singleobj` -- Sphere, Rosenbrock, Ackley, Rastrigin
 """
 
 from saealib.benchmarks.dtlz import dtlz1, dtlz2, dtlz3, dtlz4, dtlz5, dtlz6, dtlz7
+from saealib.benchmarks.singleobj import ackley, rastrigin, rosenbrock, sphere
 from saealib.benchmarks.zdt import zdt1, zdt2, zdt3, zdt4, zdt5, zdt6
 
 __all__ = [
+    "ackley",
     "dtlz1",
     "dtlz2",
     "dtlz3",
@@ -21,6 +23,9 @@ __all__ = [
     "dtlz5",
     "dtlz6",
     "dtlz7",
+    "rastrigin",
+    "rosenbrock",
+    "sphere",
     "zdt1",
     "zdt2",
     "zdt3",

--- a/src/saealib/benchmarks/dtlz.py
+++ b/src/saealib/benchmarks/dtlz.py
@@ -1,0 +1,294 @@
+"""DTLZ multi-objective benchmark suite.
+
+Test problems DTLZ1-7 introduced in:
+
+Deb, K., Thiele, L., Laumanns, M., & Zitzler, E. (2005).
+Scalable test problems for evolutionary multiobjective optimization.
+In A. Abraham, L. Jain, & R. Goldberg (Eds.),
+Evolutionary Multiobjective Optimization (pp. 105-145). Springer.
+https://doi.org/10.1007/1-84628-137-7_6
+
+Section 6.7, Eq. (6.18)-(6.25).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from saealib.problem.problem import Problem
+
+__all__ = ["dtlz1", "dtlz2", "dtlz3", "dtlz4", "dtlz5", "dtlz6", "dtlz7"]
+
+_HALF_PI = 0.5 * np.pi
+
+
+def dtlz1(n_obj: int = 3, k: int = 5) -> Problem:
+    """DTLZ1 -- linear Pareto hyperplane; (11^k - 1) local Pareto fronts.
+
+    Position variables x1,...,x_{M-1} in [0,1]; k distance variables in [0,1].
+    Pareto front: g(x_M)=0 (all x_i=0.5), sum(f_i)=0.5.
+
+    Parameters
+    ----------
+    n_obj : int
+        Number of objectives M. Default: 3.
+    k : int
+        Number of distance variables; n_var = n_obj - 1 + k. Default: 5.
+
+    References
+    ----------
+    Deb, Thiele, Laumanns & Zitzler (2005) Springer Ch. 6, Eq. (6.18)-(6.19).
+    """
+    n_var = n_obj - 1 + k
+
+    def func(x: np.ndarray) -> np.ndarray:
+        x_m = x[n_obj - 1 :]
+        g = 100.0 * (k + np.sum((x_m - 0.5) ** 2 - np.cos(20.0 * np.pi * (x_m - 0.5))))
+        half_g = 0.5 * (1.0 + g)
+        f = np.empty(n_obj)
+        for i in range(n_obj):
+            if i == 0:
+                f[i] = half_g * np.prod(x[: n_obj - 1])
+            else:
+                f[i] = half_g * np.prod(x[: n_obj - 1 - i]) * (1.0 - x[n_obj - 1 - i])
+        return f
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=n_obj,
+        direction=np.full(n_obj, -1.0),
+        lb=[0.0] * n_var,
+        ub=[1.0] * n_var,
+    )
+
+
+def dtlz2(n_obj: int = 3, k: int = 10) -> Problem:
+    """DTLZ2 -- spherical Pareto front; tests distribution on unit hypersphere.
+
+    Position variables x1,...,x_{M-1} in [0,1]; k distance variables in [0,1].
+    Pareto front: g(x_M)=0 (all x_i=0.5), sum(f_i^2)=1.
+
+    Parameters
+    ----------
+    n_obj : int
+        Number of objectives M. Default: 3.
+    k : int
+        Number of distance variables. Default: 10.
+
+    References
+    ----------
+    Deb, Thiele, Laumanns & Zitzler (2005) Springer Ch. 6, Eq. (6.20).
+    """
+    n_var = n_obj - 1 + k
+
+    def func(x: np.ndarray) -> np.ndarray:
+        theta = x[: n_obj - 1] * _HALF_PI
+        g = float(np.sum((x[n_obj - 1 :] - 0.5) ** 2))
+        return _sphere_objectives(theta, g, n_obj)
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=n_obj,
+        direction=np.full(n_obj, -1.0),
+        lb=[0.0] * n_var,
+        ub=[1.0] * n_var,
+    )
+
+
+def dtlz3(n_obj: int = 3, k: int = 10) -> Problem:
+    """DTLZ3 -- spherical Pareto front; 3^k local Pareto fronts.
+
+    Same spherical objective shape as DTLZ2 with DTLZ1's multimodal g function.
+    Pareto front: g(x_M)=0 (all x_i=0.5), sum(f_i^2)=1.
+
+    Parameters
+    ----------
+    n_obj : int
+        Number of objectives M. Default: 3.
+    k : int
+        Number of distance variables. Default: 10.
+
+    References
+    ----------
+    Deb, Thiele, Laumanns & Zitzler (2005) Springer Ch. 6, Eq. (6.21).
+    """
+    n_var = n_obj - 1 + k
+
+    def func(x: np.ndarray) -> np.ndarray:
+        theta = x[: n_obj - 1] * _HALF_PI
+        x_m = x[n_obj - 1 :]
+        g = 100.0 * (k + np.sum((x_m - 0.5) ** 2 - np.cos(20.0 * np.pi * (x_m - 0.5))))
+        return _sphere_objectives(theta, g, n_obj)
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=n_obj,
+        direction=np.full(n_obj, -1.0),
+        lb=[0.0] * n_var,
+        ub=[1.0] * n_var,
+    )
+
+
+def dtlz4(n_obj: int = 3, k: int = 10, alpha: float = 100.0) -> Problem:
+    """DTLZ4 -- biased solution density on spherical Pareto front.
+
+    Modifies DTLZ2 with x_i^alpha mapping; solutions cluster near the f_M-f_1 plane.
+    Pareto front: g(x_M)=0 (all x_i=0.5), sum(f_i^2)=1.
+
+    Parameters
+    ----------
+    n_obj : int
+        Number of objectives M. Default: 3.
+    k : int
+        Number of distance variables. Default: 10.
+    alpha : float
+        Density bias exponent. Default: 100.
+
+    References
+    ----------
+    Deb, Thiele, Laumanns & Zitzler (2005) Springer Ch. 6, Eq. (6.22).
+    """
+    n_var = n_obj - 1 + k
+
+    def func(x: np.ndarray) -> np.ndarray:
+        theta = (x[: n_obj - 1] ** alpha) * _HALF_PI
+        g = float(np.sum((x[n_obj - 1 :] - 0.5) ** 2))
+        return _sphere_objectives(theta, g, n_obj)
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=n_obj,
+        direction=np.full(n_obj, -1.0),
+        lb=[0.0] * n_var,
+        ub=[1.0] * n_var,
+    )
+
+
+def _sphere_objectives(theta: np.ndarray, g: float, n_obj: int) -> np.ndarray:
+    """Compute spherical objectives shared by DTLZ2/3/4/5/6."""
+    cos_theta = np.cos(theta)
+    f = np.empty(n_obj)
+    for i in range(n_obj):
+        prod = (1.0 + g) * float(np.prod(cos_theta[: n_obj - 1 - i]))
+        if i > 0:
+            prod *= np.sin(theta[n_obj - 1 - i])
+        f[i] = prod
+    return f
+
+
+def dtlz5(n_obj: int = 3, k: int = 10) -> Problem:
+    """DTLZ5 -- degenerate 1-D Pareto curve on unit hypersphere.
+
+    Replaces the uniform theta mapping of DTLZ2 with a g-dependent mapping
+    (Eq. 6.10) that collapses the PF to a curve: only x_1 varies freely.
+    Pareto front: g(x_M)=0 (all x_i=0.5), theta_i=pi/4 for i>=2, sum(f_i^2)=1.
+
+    Parameters
+    ----------
+    n_obj : int
+        Number of objectives M. Default: 3.
+    k : int
+        Number of distance variables. Default: 10.
+
+    References
+    ----------
+    Deb, Thiele, Laumanns & Zitzler (2005) Springer Ch. 6, Eq. (6.23).
+    """
+    n_var = n_obj - 1 + k
+
+    def func(x: np.ndarray) -> np.ndarray:
+        g = float(np.sum((x[n_obj - 1 :] - 0.5) ** 2))
+        theta = np.empty(n_obj - 1)
+        theta[0] = x[0] * _HALF_PI
+        for i in range(1, n_obj - 1):
+            theta[i] = np.pi / (4.0 * (1.0 + g)) * (1.0 + 2.0 * g * x[i])
+        return _sphere_objectives(theta, g, n_obj)
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=n_obj,
+        direction=np.full(n_obj, -1.0),
+        lb=[0.0] * n_var,
+        ub=[1.0] * n_var,
+    )
+
+
+def dtlz6(n_obj: int = 3, k: int = 10) -> Problem:
+    """DTLZ6 -- harder variant of DTLZ5 with nonlinear g function.
+
+    Same degenerate PF structure as DTLZ5 (1-D curve on unit sphere) but
+    g = sum(x_i^0.1) makes convergence harder than DTLZ5.
+    Pareto front: g(x_M)=0 (all x_i=0), sum(f_i^2)=1.
+
+    Parameters
+    ----------
+    n_obj : int
+        Number of objectives M. Default: 3.
+    k : int
+        Number of distance variables. Default: 10.
+
+    References
+    ----------
+    Deb, Thiele, Laumanns & Zitzler (2005) Springer Ch. 6, Eq. (6.24).
+    """
+    n_var = n_obj - 1 + k
+
+    def func(x: np.ndarray) -> np.ndarray:
+        g = float(np.sum(x[n_obj - 1 :] ** 0.1))
+        theta = np.empty(n_obj - 1)
+        theta[0] = x[0] * _HALF_PI
+        for i in range(1, n_obj - 1):
+            theta[i] = np.pi / (4.0 * (1.0 + g)) * (1.0 + 2.0 * g * x[i])
+        return _sphere_objectives(theta, g, n_obj)
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=n_obj,
+        direction=np.full(n_obj, -1.0),
+        lb=[0.0] * n_var,
+        ub=[1.0] * n_var,
+    )
+
+
+def dtlz7(n_obj: int = 3, k: int = 20) -> Problem:
+    """DTLZ7 -- 2^{M-1} disconnected Pareto fronts.
+
+    f_i = x_i for i=1,...,M-1; f_M couples through the h function.
+    Distance variables x_M promote diversity in the last objective.
+
+    Parameters
+    ----------
+    n_obj : int
+        Number of objectives M. Default: 3.
+    k : int
+        Number of distance variables. Default: 20.
+
+    References
+    ----------
+    Deb, Thiele, Laumanns & Zitzler (2005) Springer Ch. 6, Eq. (6.25).
+    """
+    n_var = n_obj - 1 + k
+
+    def func(x: np.ndarray) -> np.ndarray:
+        f = np.empty(n_obj)
+        f[: n_obj - 1] = x[: n_obj - 1]
+        g = 1.0 + (9.0 / k) * np.sum(x[n_obj - 1 :])
+        fi = f[: n_obj - 1]
+        h = n_obj - float(np.sum(fi / (1.0 + g) * (1.0 + np.sin(3.0 * np.pi * fi))))
+        f[n_obj - 1] = (1.0 + g) * h
+        return f
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=n_obj,
+        direction=np.full(n_obj, -1.0),
+        lb=[0.0] * n_var,
+        ub=[1.0] * n_var,
+    )

--- a/src/saealib/benchmarks/singleobj.py
+++ b/src/saealib/benchmarks/singleobj.py
@@ -1,0 +1,151 @@
+"""Classical single-objective benchmark functions.
+
+Functions and bounds from:
+
+Jamil, M., & Yang, X.-S. (2013).
+A literature survey of benchmark functions for global optimisation problems.
+International Journal of Mathematical Modelling and Numerical Optimisation,
+4(2), 150-194.
+https://doi.org/10.1504/IJMMNO.2013.055204
+
+Notes
+-----
+- Sphere: Jamil & Yang (2013) f137.
+- Rosenbrock: Jamil & Yang (2013) f105.
+- Ackley: Jamil & Yang (2013) f1; standard a=20, b=0.2, c=2*pi.
+- Rastrigin: well-known scalable function; Jamil & Yang list it (f84) but
+  that page is absent from the available PDF conversion.  The formula
+  f(x) = A*D + sum(xi^2 - A*cos(2*pi*xi)) with A=10 is used universally.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from saealib.problem.problem import Problem
+
+__all__ = ["ackley", "rastrigin", "rosenbrock", "sphere"]
+
+_TWO_PI = 2.0 * np.pi
+
+
+def sphere(n_var: int = 10) -> Problem:
+    """Sphere function -- unimodal, separable, global min at origin.
+
+    f(x) = sum(xi^2),  x* = (0,...,0),  f* = 0.
+
+    Parameters
+    ----------
+    n_var : int
+        Number of variables. Default: 10.
+
+    References
+    ----------
+    Jamil & Yang (2013) IJMMNO 4(2), f137.
+    """
+
+    def func(x: np.ndarray) -> np.ndarray:
+        return np.array([float(np.sum(x**2))])
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=1,
+        direction=np.array([-1.0]),
+        lb=[-5.12] * n_var,
+        ub=[5.12] * n_var,
+    )
+
+
+def rosenbrock(n_var: int = 10) -> Problem:
+    """Rosenbrock (banana) function -- narrow curved valley, global min at (1,...,1).
+
+    f(x) = sum_{i=1}^{D-1} [100*(x_{i+1}-xi^2)^2 + (xi-1)^2],
+    x* = (1,...,1),  f* = 0.
+
+    Parameters
+    ----------
+    n_var : int
+        Number of variables. Default: 10.
+
+    References
+    ----------
+    Jamil & Yang (2013) IJMMNO 4(2), f105.
+    """
+
+    def func(x: np.ndarray) -> np.ndarray:
+        val = np.sum(100.0 * (x[1:] - x[:-1] ** 2) ** 2 + (x[:-1] - 1.0) ** 2)
+        return np.array([float(val)])
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=1,
+        direction=np.array([-1.0]),
+        lb=[-30.0] * n_var,
+        ub=[30.0] * n_var,
+    )
+
+
+def ackley(n_var: int = 10) -> Problem:
+    """Ackley function -- nearly flat outer region, deep global minimum at origin.
+
+    f(x) = -a*exp(-b*sqrt(1/D*sum(xi^2))) - exp(1/D*sum(cos(c*xi))) + a + exp(1),
+    a=20, b=0.2, c=2*pi.  x* = (0,...,0),  f* = 0.
+
+    Parameters
+    ----------
+    n_var : int
+        Number of variables. Default: 10.
+
+    References
+    ----------
+    Jamil & Yang (2013) IJMMNO 4(2), f1; standard a=20, b=0.2, c=2*pi.
+    """
+
+    def func(x: np.ndarray) -> np.ndarray:
+        d = len(x)
+        term1 = -20.0 * np.exp(-0.2 * np.sqrt(np.sum(x**2) / d))
+        term2 = -np.exp(np.sum(np.cos(_TWO_PI * x)) / d)
+        return np.array([float(term1 + term2 + 20.0 + np.e)])
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=1,
+        direction=np.array([-1.0]),
+        lb=[-35.0] * n_var,
+        ub=[35.0] * n_var,
+    )
+
+
+def rastrigin(n_var: int = 10, amplitude: float = 10.0) -> Problem:
+    """Rastrigin function -- highly multimodal with regular local minima grid.
+
+    f(x) = amplitude*D + sum(xi^2 - amplitude*cos(2*pi*xi)),  x* = (0,...,0),  f* = 0.
+
+    Parameters
+    ----------
+    n_var : int
+        Number of variables. Default: 10.
+    amplitude : float
+        Amplitude of cosine perturbation. Default: 10.
+
+    References
+    ----------
+    Standard Rastrigin function; see Jamil & Yang (2013) IJMMNO 4(2) f84
+    (page not captured in available PDF conversion).
+    """
+
+    def func(x: np.ndarray) -> np.ndarray:
+        val = amplitude * len(x) + float(np.sum(x**2 - amplitude * np.cos(_TWO_PI * x)))
+        return np.array([val])
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=1,
+        direction=np.array([-1.0]),
+        lb=[-5.12] * n_var,
+        ub=[5.12] * n_var,
+    )

--- a/src/saealib/benchmarks/zdt.py
+++ b/src/saealib/benchmarks/zdt.py
@@ -1,0 +1,234 @@
+"""ZDT multi-objective benchmark suite.
+
+Six two-objective test functions (T1-T6) introduced in:
+
+Zitzler, E., Deb, K., & Thiele, L. (2000).
+Comparison of multiobjective evolutionary algorithms: Empirical results.
+Evolutionary Computation, 8(2), 173-195.
+https://doi.org/10.1162/106365600568202
+
+Section 4, Definition 4, Eq. (7)-(12).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from saealib.problem.problem import Problem
+from saealib.variables import IntegerVariable
+
+__all__ = ["zdt1", "zdt2", "zdt3", "zdt4", "zdt5", "zdt6"]
+
+_DIR2 = np.array([-1.0, -1.0])
+
+
+def zdt1(n_var: int = 30) -> Problem:
+    """ZDT1 — convex Pareto front.
+
+    Pareto front: f2 = 1 - sqrt(f1), f1 in [0, 1].
+
+    Parameters
+    ----------
+    n_var : int
+        Number of decision variables. Default: 30.
+
+    References
+    ----------
+    Zitzler, Deb & Thiele (2000) EC 8(2), Section 4 Def. 4, Eq. (7).
+    """
+
+    def func(x: np.ndarray) -> np.ndarray:
+        f1 = x[0]
+        g = 1.0 + 9.0 * np.sum(x[1:]) / (n_var - 1)
+        h = 1.0 - np.sqrt(f1 / g)
+        return np.array([f1, g * h])
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=2,
+        direction=_DIR2.copy(),
+        lb=[0.0] * n_var,
+        ub=[1.0] * n_var,
+    )
+
+
+def zdt2(n_var: int = 30) -> Problem:
+    """ZDT2 — non-convex Pareto front.
+
+    Pareto front: f2 = 1 - f1**2, f1 in [0, 1].
+
+    Parameters
+    ----------
+    n_var : int
+        Number of decision variables. Default: 30.
+
+    References
+    ----------
+    Zitzler, Deb & Thiele (2000) EC 8(2), Section 4 Def. 4, Eq. (8).
+    """
+
+    def func(x: np.ndarray) -> np.ndarray:
+        f1 = x[0]
+        g = 1.0 + 9.0 * np.sum(x[1:]) / (n_var - 1)
+        h = 1.0 - (f1 / g) ** 2
+        return np.array([f1, g * h])
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=2,
+        direction=_DIR2.copy(),
+        lb=[0.0] * n_var,
+        ub=[1.0] * n_var,
+    )
+
+
+def zdt3(n_var: int = 30) -> Problem:
+    """ZDT3 — disconnected Pareto front.
+
+    Pareto front: f2 = 1 - sqrt(f1) - f1*sin(10*pi*f1), f1 in [0, 1].
+    The front consists of several non-contiguous convex parts.
+
+    Parameters
+    ----------
+    n_var : int
+        Number of decision variables. Default: 30.
+
+    References
+    ----------
+    Zitzler, Deb & Thiele (2000) EC 8(2), Section 4 Def. 4, Eq. (9).
+    """
+
+    def func(x: np.ndarray) -> np.ndarray:
+        f1 = x[0]
+        g = 1.0 + 9.0 * np.sum(x[1:]) / (n_var - 1)
+        ratio = f1 / g
+        h = 1.0 - np.sqrt(ratio) - ratio * np.sin(10.0 * np.pi * f1)
+        return np.array([f1, g * h])
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=2,
+        direction=_DIR2.copy(),
+        lb=[0.0] * n_var,
+        ub=[1.0] * n_var,
+    )
+
+
+def zdt4(n_var: int = 10) -> Problem:
+    """ZDT4 — multimodal; 21^(n_var-1) local Pareto fronts.
+
+    x1 in [0, 1]; x2, ..., x_n in [-5, 5].
+    Global Pareto front formed with g(x) = 1: f2 = 1 - sqrt(f1).
+
+    Parameters
+    ----------
+    n_var : int
+        Number of decision variables. Default: 10.
+
+    References
+    ----------
+    Zitzler, Deb & Thiele (2000) EC 8(2), Section 4 Def. 4, Eq. (10).
+    """
+
+    def func(x: np.ndarray) -> np.ndarray:
+        f1 = x[0]
+        g = (
+            1.0
+            + 10.0 * (n_var - 1)
+            + np.sum(x[1:] ** 2 - 10.0 * np.cos(4.0 * np.pi * x[1:]))
+        )
+        h = 1.0 - np.sqrt(f1 / g)
+        return np.array([f1, g * h])
+
+    lb = [0.0] + [-5.0] * (n_var - 1)
+    ub = [1.0] + [5.0] * (n_var - 1)
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=2,
+        direction=_DIR2.copy(),
+        lb=lb,
+        ub=ub,
+    )
+
+
+def zdt5(
+    n_bits_b1: int = 30,
+    n_bits_rest: int = 5,
+    n_rest: int = 10,
+) -> Problem:
+    """ZDT5 -- deceptive binary problem.
+
+    x1 is a binary string of n_bits_b1 bits; x2,...,x_m each have n_bits_rest bits.
+    Total variables: n_bits_b1 + n_rest * n_bits_rest (default: 80).
+    Global Pareto front at g(x)=n_rest: f2 = n_rest/f1, f1 in {1,...,n_bits_b1+1}.
+
+    Parameters
+    ----------
+    n_bits_b1 : int
+        Length of the first binary substring. Default: 30.
+    n_bits_rest : int
+        Length of each remaining binary substring. Default: 5.
+    n_rest : int
+        Number of remaining substrings (m-1). Default: 10.
+
+    References
+    ----------
+    Zitzler, Deb & Thiele (2000) EC 8(2), Section 4 Def. 4, Eq. (11).
+    """
+    n_var = n_bits_b1 + n_rest * n_bits_rest
+    variables = [IntegerVariable(lb=0, ub=1) for _ in range(n_var)]
+
+    def func(x: np.ndarray) -> np.ndarray:
+        xi = np.round(x).astype(int)
+        u1 = int(np.sum(xi[:n_bits_b1]))
+        f1 = 1.0 + u1
+        g = 0.0
+        for i in range(n_rest):
+            start = n_bits_b1 + i * n_bits_rest
+            u_i = int(np.sum(xi[start : start + n_bits_rest]))
+            g += 1.0 if u_i == n_bits_rest else 2.0 + u_i
+        return np.array([f1, g / f1])
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=2,
+        direction=_DIR2.copy(),
+        variables=variables,
+    )
+
+
+def zdt6(n_var: int = 10) -> Problem:
+    """ZDT6 — non-uniform distribution; non-convex Pareto front.
+
+    x_i in [0, 1]. Pareto front formed with g(x) = 1.
+
+    Parameters
+    ----------
+    n_var : int
+        Number of decision variables. Default: 10.
+
+    References
+    ----------
+    Zitzler, Deb & Thiele (2000) EC 8(2), Section 4 Def. 4, Eq. (12).
+    """
+
+    def func(x: np.ndarray) -> np.ndarray:
+        f1 = 1.0 - np.exp(-4.0 * x[0]) * (np.sin(6.0 * np.pi * x[0]) ** 6)
+        g = 1.0 + 9.0 * (np.sum(x[1:]) / (n_var - 1)) ** 0.25
+        h = 1.0 - (f1 / g) ** 2
+        return np.array([f1, g * h])
+
+    return Problem(
+        func=func,
+        dim=n_var,
+        n_obj=2,
+        direction=_DIR2.copy(),
+        lb=[0.0] * n_var,
+        ub=[1.0] * n_var,
+    )

--- a/src/saealib/benchmarks/zdt.py
+++ b/src/saealib/benchmarks/zdt.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import numpy as np
 
 from saealib.problem.problem import Problem
-from saealib.variables import IntegerVariable
+from saealib.variables import IntegerVariable, Variable
 
 __all__ = ["zdt1", "zdt2", "zdt3", "zdt4", "zdt5", "zdt6"]
 
@@ -181,7 +181,7 @@ def zdt5(
     Zitzler, Deb & Thiele (2000) EC 8(2), Section 4 Def. 4, Eq. (11).
     """
     n_var = n_bits_b1 + n_rest * n_bits_rest
-    variables = [IntegerVariable(lb=0, ub=1) for _ in range(n_var)]
+    variables: list[Variable] = [IntegerVariable(lb=0, ub=1) for _ in range(n_var)]
 
     def func(x: np.ndarray) -> np.ndarray:
         xi = np.round(x).astype(int)

--- a/tests/test_benchmarks_dtlz.py
+++ b/tests/test_benchmarks_dtlz.py
@@ -1,0 +1,264 @@
+"""Tests for saealib.benchmarks.dtlz.
+
+Structural checks (shape, bounds, direction) and Pareto-front spot checks
+for DTLZ1-7.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from saealib.benchmarks.dtlz import dtlz1, dtlz2, dtlz3, dtlz4, dtlz5, dtlz6, dtlz7
+from saealib.problem.problem import Problem
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+_FACTORIES = [
+    (dtlz1, 3, 5),  # n_obj, k defaults
+    (dtlz2, 3, 10),
+    (dtlz3, 3, 10),
+    (dtlz4, 3, 10),
+    (dtlz5, 3, 10),
+    (dtlz6, 3, 10),
+    (dtlz7, 3, 20),
+]
+
+
+def _pareto_x_dtlz12(p: Problem) -> np.ndarray:
+    """Return x on global PF for DTLZ2/3/4: position=0.5, distance=0.5."""
+    return np.full(p.dim, 0.5)
+
+
+# ---------------------------------------------------------------------------
+# structural tests (parametrised over all five functions)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factory,n_obj,k", _FACTORIES)
+class TestDTLZStructure:
+    def test_returns_problem(self, factory, n_obj, k):
+        assert isinstance(factory(), Problem)
+
+    def test_default_n_var(self, factory, n_obj, k):
+        assert factory().dim == n_obj - 1 + k
+
+    def test_custom_params(self, factory, n_obj, k):
+        p = factory(n_obj=4, k=3)
+        assert p.dim == 4 - 1 + 3
+
+    def test_n_obj(self, factory, n_obj, k):
+        assert factory().n_obj == n_obj
+
+    def test_direction_minimize_all(self, factory, n_obj, k):
+        d = factory().direction
+        np.testing.assert_array_equal(d, np.full(n_obj, -1.0))
+
+    def test_evaluate_shape(self, factory, n_obj, k):
+        p = factory()
+        f = p.evaluate(np.full(p.dim, 0.5))
+        assert f.shape == (n_obj,)
+
+    def test_bounds_all_unit(self, factory, n_obj, k):
+        p = factory()
+        assert all(lb == pytest.approx(0.0) for lb in p.lb)
+        assert all(ub == pytest.approx(1.0) for ub in p.ub)
+
+    def test_no_constraints(self, factory, n_obj, k):
+        assert factory().n_constraints == 0
+
+
+# ---------------------------------------------------------------------------
+# DTLZ1 -- linear hyperplane sum(f) = 0.5 when g = 0  (Eq. 6.18-6.19)
+# ---------------------------------------------------------------------------
+
+
+class TestDTLZ1ParetoFront:
+    def test_g_zero_at_half(self):
+        # x_M = 0.5 => (xi-0.5)^2 = 0, cos(0) = 1 => g = 100*(k-k) = 0
+        p = dtlz1()
+        x = np.full(p.dim, 0.5)
+        f = p.evaluate(x)
+        assert pytest.approx(sum(f), rel=1e-9) == 0.5
+
+    def test_pareto_sum_arbitrary_position(self):
+        # sum(f) = 0.5*(1+g) = 0.5 when g=0, for any position variables
+        p = dtlz1()
+        x = np.full(p.dim, 0.5)
+        x[0] = 0.2
+        x[1] = 0.7
+        f = p.evaluate(x)
+        assert pytest.approx(sum(f), rel=1e-9) == 0.5
+
+    def test_off_pareto_g_positive(self):
+        # x_M != 0.5 => g > 0 => sum(f) > 0.5
+        p = dtlz1()
+        x = np.full(p.dim, 0.5)
+        x[p.n_obj - 1] = 0.0  # perturb one distance variable
+        f = p.evaluate(x)
+        assert sum(f) > 0.5
+
+
+# ---------------------------------------------------------------------------
+# DTLZ2 -- unit-sphere PF sum(f^2) = 1 when g = 0  (Eq. 6.20)
+# ---------------------------------------------------------------------------
+
+
+class TestDTLZ2ParetoFront:
+    def test_pareto_norm(self):
+        # x_M = 0.5 => g = 0 => sum(f^2) = 1
+        p = dtlz2()
+        f = p.evaluate(_pareto_x_dtlz12(p))
+        assert pytest.approx(float(np.sum(f**2)), rel=1e-9) == 1.0
+
+    def test_pareto_equal_angles(self):
+        # x_pos = pi/4 in angle space => all f equal: (1/sqrt(2))^i * ...
+        p = dtlz2()
+        x = np.full(p.dim, 0.5)
+        x[0] = 1.0 / 3.0  # theta0 = pi/6
+        x[1] = 0.5  # theta1 = pi/4
+        f = p.evaluate(x)
+        assert pytest.approx(float(np.sum(f**2)), rel=1e-9) == 1.0
+
+    def test_off_pareto_norm_greater(self):
+        # g > 0 => sum(f^2) = (1+g)^2 > 1
+        p = dtlz2()
+        x = _pareto_x_dtlz12(p)
+        x[p.n_obj - 1] = 0.0  # g = 0.25 > 0
+        f = p.evaluate(x)
+        assert float(np.sum(f**2)) > 1.0
+
+
+# ---------------------------------------------------------------------------
+# DTLZ3 -- same PF shape as DTLZ2; harder g  (Eq. 6.21)
+# ---------------------------------------------------------------------------
+
+
+class TestDTLZ3ParetoFront:
+    def test_pareto_norm(self):
+        # x_M = 0.5 => g = 0 => sum(f^2) = 1
+        p = dtlz3()
+        f = p.evaluate(_pareto_x_dtlz12(p))
+        assert pytest.approx(float(np.sum(f**2)), rel=1e-9) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# DTLZ4 -- biased density; same PF as DTLZ2  (Eq. 6.22)
+# ---------------------------------------------------------------------------
+
+
+class TestDTLZ4ParetoFront:
+    def test_pareto_norm(self):
+        p = dtlz4()
+        f = p.evaluate(_pareto_x_dtlz12(p))
+        assert pytest.approx(float(np.sum(f**2)), rel=1e-9) == 1.0
+
+    def test_biased_vs_dtlz2(self):
+        # Same x_pos gives different f distributions in DTLZ4 vs DTLZ2 on the PF.
+        # x_pos=0.9: DTLZ2 has theta=81deg → f[0]<<1; DTLZ4 has 0.9^100*pi/2≈0 → f[0]≈1.
+        x_pos = 0.9
+        p2 = dtlz2()
+        p4 = dtlz4(alpha=100.0)
+        x2 = _pareto_x_dtlz12(p2)
+        x2[0] = x_pos
+        x2[1] = x_pos
+        x4 = _pareto_x_dtlz12(p4)
+        x4[0] = x_pos
+        x4[1] = x_pos
+        f2 = p2.evaluate(x2)
+        f4 = p4.evaluate(x4)
+        assert pytest.approx(float(np.sum(f2**2)), rel=1e-9) == 1.0
+        assert pytest.approx(float(np.sum(f4**2)), rel=1e-9) == 1.0
+        assert not np.allclose(f2, f4, atol=0.01)
+
+
+# ---------------------------------------------------------------------------
+# DTLZ5 -- degenerate 1-D PF curve on sphere  (Eq. 6.23)
+# ---------------------------------------------------------------------------
+
+
+class TestDTLZ5ParetoFront:
+    def test_pareto_norm_on_pf(self):
+        # x_M = 0.5 => g=0 => theta_i=pi/4 for i>=1 => sum(f^2) = 1
+        p = dtlz5()
+        x = np.full(p.dim, 0.5)
+        f = p.evaluate(x)
+        assert pytest.approx(float(np.sum(f**2)), rel=1e-9) == 1.0
+
+    def test_pf_parameterized_by_x1(self):
+        # Different x_1 values each give sum(f^2) = 1 on the PF
+        p = dtlz5()
+        for x1 in [0.0, 0.25, 0.5, 0.75, 1.0]:
+            x = np.full(p.dim, 0.5)
+            x[0] = x1
+            f = p.evaluate(x)
+            assert pytest.approx(float(np.sum(f**2)), rel=1e-9) == 1.0
+
+    def test_off_pareto_norm_greater(self):
+        p = dtlz5()
+        x = np.full(p.dim, 0.5)
+        x[p.n_obj - 1] = 0.0  # g > 0
+        f = p.evaluate(x)
+        assert float(np.sum(f**2)) > 1.0
+
+
+# ---------------------------------------------------------------------------
+# DTLZ6 -- harder DTLZ5; g=sum(x_i^0.1), PF at x_M=0  (Eq. 6.24)
+# ---------------------------------------------------------------------------
+
+
+class TestDTLZ6ParetoFront:
+    def test_pareto_norm_on_pf(self):
+        # x_M = 0 => g=0 => same structure as DTLZ5 => sum(f^2) = 1
+        p = dtlz6()
+        x = np.zeros(p.dim)
+        x[0] = 0.5  # position variable
+        f = p.evaluate(x)
+        assert pytest.approx(float(np.sum(f**2)), rel=1e-9) == 1.0
+
+    def test_g_at_zeros(self):
+        # x_M = 0 => g = sum(0^0.1) = 0
+        p = dtlz6()
+        x = np.zeros(p.dim)
+        x[0] = 0.3
+        f_on = p.evaluate(x)
+        # x_M != 0 => g > 0 => larger norm
+        x_off = x.copy()
+        x_off[p.n_obj - 1] = 0.5
+        f_off = p.evaluate(x_off)
+        assert float(np.sum(f_off**2)) > float(np.sum(f_on**2))
+
+
+# ---------------------------------------------------------------------------
+# DTLZ7 -- disconnected fronts  (Eq. 6.25)
+# ---------------------------------------------------------------------------
+
+
+class TestDTLZ7:
+    def test_g_at_zeros(self):
+        # x_M = 0 => g = 1 + 9/k * 0 = 1
+        p = dtlz7()
+        x = np.zeros(p.dim)
+        f = p.evaluate(x)
+        # f[:M-1] = 0, g = 1; h = M => f_M = (1+1)*M = 2*M
+        assert f[p.n_obj - 1] == pytest.approx(2.0 * p.n_obj)
+
+    def test_g_at_ones(self):
+        # x_M = 1 => g = 1 + 9/k * k = 10
+        p = dtlz7()
+        x = np.ones(p.dim)
+        f = p.evaluate(x)
+        # f[:M-1] = 1, g=10; h = M - sum[1/11*(1+sin(3pi))] = M - 0 = M
+        # sin(3*pi) = ~0, so h ≈ M - sum[1/11 * 1] = M - (M-1)/11
+        expected_h = p.n_obj - np.sum(
+            np.ones(p.n_obj - 1) / 11.0 * (1.0 + np.sin(3.0 * np.pi))
+        )
+        assert f[p.n_obj - 1] == pytest.approx(11.0 * expected_h, rel=1e-9)
+
+    def test_f_position_equals_x(self):
+        p = dtlz7()
+        x = np.full(p.dim, 0.3)
+        f = p.evaluate(x)
+        np.testing.assert_allclose(f[: p.n_obj - 1], x[: p.n_obj - 1])

--- a/tests/test_benchmarks_singleobj.py
+++ b/tests/test_benchmarks_singleobj.py
@@ -1,0 +1,154 @@
+"""Tests for saealib.benchmarks.singleobj.
+
+Structural checks and global-minimum spot checks for Sphere, Rosenbrock,
+Ackley, and Rastrigin.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from saealib.benchmarks.singleobj import ackley, rastrigin, rosenbrock, sphere
+from saealib.problem.problem import Problem
+
+_FACTORIES = [
+    (sphere, 10),
+    (rosenbrock, 10),
+    (ackley, 10),
+    (rastrigin, 10),
+]
+
+
+# ---------------------------------------------------------------------------
+# structural tests (parametrised)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factory,n_var", _FACTORIES)
+class TestSingleObjStructure:
+    def test_returns_problem(self, factory, n_var):
+        assert isinstance(factory(), Problem)
+
+    def test_default_n_var(self, factory, n_var):
+        assert factory().dim == n_var
+
+    def test_custom_n_var(self, factory, n_var):
+        p = factory(n_var=5)
+        assert p.dim == 5
+
+    def test_n_obj(self, factory, n_var):
+        assert factory().n_obj == 1
+
+    def test_direction_minimize(self, factory, n_var):
+        np.testing.assert_array_equal(factory().direction, [-1.0])
+
+    def test_evaluate_shape(self, factory, n_var):
+        p = factory()
+        f = p.evaluate(np.zeros(p.dim))
+        assert f.shape == (1,)
+
+    def test_bounds_length(self, factory, n_var):
+        p = factory()
+        assert len(p.lb) == p.dim
+        assert len(p.ub) == p.dim
+
+    def test_no_constraints(self, factory, n_var):
+        assert factory().n_constraints == 0
+
+
+# ---------------------------------------------------------------------------
+# Sphere: f(x) = sum(xi^2)
+# ---------------------------------------------------------------------------
+
+
+class TestSphere:
+    def test_global_min_at_origin(self):
+        p = sphere()
+        f = p.evaluate(np.zeros(p.dim))
+        assert f[0] == pytest.approx(0.0)
+
+    def test_positive_elsewhere(self):
+        p = sphere()
+        x = np.ones(p.dim)
+        assert p.evaluate(x)[0] == pytest.approx(float(p.dim))
+
+    def test_separable(self):
+        p = sphere(n_var=3)
+        x = np.array([1.0, 2.0, 3.0])
+        assert p.evaluate(x)[0] == pytest.approx(1.0 + 4.0 + 9.0)
+
+
+# ---------------------------------------------------------------------------
+# Rosenbrock: f(x) = sum 100*(x_{i+1}-xi^2)^2 + (xi-1)^2
+# ---------------------------------------------------------------------------
+
+
+class TestRosenbrock:
+    def test_global_min_at_ones(self):
+        p = rosenbrock()
+        f = p.evaluate(np.ones(p.dim))
+        assert f[0] == pytest.approx(0.0)
+
+    def test_two_var_spot(self):
+        # n_var=2: f(1,1) = 100*(1-1)^2 + (1-1)^2 = 0
+        p = rosenbrock(n_var=2)
+        assert p.evaluate(np.array([1.0, 1.0]))[0] == pytest.approx(0.0)
+        # f(0,0) = 100*(0-0)^2 + (0-1)^2 = 1
+        assert p.evaluate(np.array([0.0, 0.0]))[0] == pytest.approx(1.0)
+
+    def test_increases_away_from_ones(self):
+        p = rosenbrock(n_var=5)
+        assert p.evaluate(np.zeros(p.dim))[0] > 0
+
+
+# ---------------------------------------------------------------------------
+# Ackley: f(x) = -20*exp(-0.2*sqrt(mean(xi^2))) - exp(mean(cos(2pi*xi))) + 20 + e
+# ---------------------------------------------------------------------------
+
+
+class TestAckley:
+    def test_global_min_at_origin(self):
+        p = ackley()
+        f = p.evaluate(np.zeros(p.dim))
+        assert f[0] == pytest.approx(0.0, abs=1e-12)
+
+    def test_positive_elsewhere(self):
+        p = ackley(n_var=2)
+        x = np.array([1.0, 1.0])
+        assert p.evaluate(x)[0] > 0.0
+
+    def test_bounded_above(self):
+        # Max value ≈ 20 + e + 1 ~ 24; function is bounded
+        p = ackley(n_var=5)
+        x = np.array([35.0] * 5)  # near corner of domain
+        assert p.evaluate(x)[0] < 25.0
+
+
+# ---------------------------------------------------------------------------
+# Rastrigin: f(x) = A*D + sum(xi^2 - A*cos(2pi*xi))
+# ---------------------------------------------------------------------------
+
+
+class TestRastrigin:
+    def test_global_min_at_origin(self):
+        p = rastrigin()
+        f = p.evaluate(np.zeros(p.dim))
+        assert f[0] == pytest.approx(0.0)
+
+    def test_local_minima_at_integers(self):
+        # f(1,0,...,0) = A*D + (1 - A*1) + 0*... = 10*D + 1 - 10 = 10*D - 9
+        p = rastrigin(n_var=5)
+        x = np.zeros(p.dim)
+        x[0] = 1.0
+        rest = (p.dim - 1) * (0.0 - 10.0)  # xi=0 terms: 0 - 10*cos(0)
+        expected = 10.0 * p.dim + (1.0 - 10.0 * np.cos(0.0)) + rest
+        assert p.evaluate(x)[0] == pytest.approx(expected, rel=1e-9)
+
+    def test_custom_amplitude(self):
+        p = rastrigin(n_var=3, amplitude=5.0)
+        f = p.evaluate(np.zeros(p.dim))
+        assert f[0] == pytest.approx(0.0)
+        x = np.ones(p.dim)
+        expected = 5.0 * 3 + np.sum(np.ones(3) - 5.0 * np.cos(2 * np.pi * np.ones(3)))
+        assert p.evaluate(x)[0] == pytest.approx(float(expected), rel=1e-9)

--- a/tests/test_benchmarks_zdt.py
+++ b/tests/test_benchmarks_zdt.py
@@ -1,0 +1,246 @@
+"""Tests for saealib.benchmarks.zdt.
+
+Structural checks (shape, bounds, direction) and Pareto-front spot checks
+for ZDT1-4, ZDT6. Pareto-optimal solutions are identified by setting all
+non-primary variables to 0, which yields g = 1 for ZDT1-4 and g = 1 for
+ZDT6 when the rest-variables sum to 0.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from saealib.benchmarks.zdt import zdt1, zdt2, zdt3, zdt4, zdt5, zdt6
+from saealib.problem.problem import Problem
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _pareto_x(problem: Problem, x1: float) -> np.ndarray:
+    """Return x with x[0]=x1 and remaining variables = lower bound."""
+    x = np.array(problem.lb, dtype=float)
+    x[0] = x1
+    return x
+
+
+# ---------------------------------------------------------------------------
+# structural tests (parametrised over all five functions)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "factory,n_var",
+    [
+        (zdt1, 30),
+        (zdt2, 30),
+        (zdt3, 30),
+        (zdt4, 10),
+        (zdt6, 10),
+    ],
+)
+class TestZDTStructure:
+    def test_returns_problem(self, factory, n_var):
+        assert isinstance(factory(), Problem)
+
+    def test_default_n_var(self, factory, n_var):
+        p = factory()
+        assert p.dim == n_var
+
+    def test_custom_n_var(self, factory, n_var):
+        p = factory(n_var=5)
+        assert p.dim == 5
+
+    def test_n_obj(self, factory, n_var):
+        assert factory().n_obj == 2
+
+    def test_direction_minimize_both(self, factory, n_var):
+        d = factory().direction
+        np.testing.assert_array_equal(d, [-1.0, -1.0])
+
+    def test_evaluate_shape(self, factory, n_var):
+        p = factory()
+        x = (np.array(p.lb) + np.array(p.ub)) / 2.0
+        f = p.evaluate(x)
+        assert f.shape == (2,)
+
+    def test_bounds_length(self, factory, n_var):
+        p = factory()
+        assert len(p.lb) == p.dim
+        assert len(p.ub) == p.dim
+
+    def test_no_constraints(self, factory, n_var):
+        assert factory().n_constraints == 0
+
+
+# ---------------------------------------------------------------------------
+# ZDT1 — Pareto front: f2 = 1 - sqrt(f1)  (Eq. 7)
+# ---------------------------------------------------------------------------
+
+
+class TestZDT1ParetoFront:
+    def test_pareto_point_f1_half(self):
+        p = zdt1()
+        x = _pareto_x(p, 0.5)
+        f = p.evaluate(x)
+        assert f[0] == pytest.approx(0.5)
+        assert f[1] == pytest.approx(1.0 - np.sqrt(0.5), rel=1e-9)
+
+    def test_pareto_point_f1_zero(self):
+        p = zdt1()
+        x = _pareto_x(p, 0.0)
+        f = p.evaluate(x)
+        assert f[0] == pytest.approx(0.0)
+        assert f[1] == pytest.approx(1.0)
+
+    def test_off_pareto_increases_f2(self):
+        p = zdt1()
+        x_on = _pareto_x(p, 0.5)
+        x_off = x_on.copy()
+        x_off[1] = 0.5  # g > 1 → f2 increases
+        assert p.evaluate(x_off)[1] > p.evaluate(x_on)[1]
+
+
+# ---------------------------------------------------------------------------
+# ZDT2 — Pareto front: f2 = 1 - f1**2  (Eq. 8)
+# ---------------------------------------------------------------------------
+
+
+class TestZDT2ParetoFront:
+    def test_pareto_point_f1_half(self):
+        p = zdt2()
+        x = _pareto_x(p, 0.5)
+        f = p.evaluate(x)
+        assert f[0] == pytest.approx(0.5)
+        assert f[1] == pytest.approx(1.0 - 0.5**2, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# ZDT3 — Pareto front: f2 = 1 - sqrt(f1) - f1*sin(10*pi*f1)  (Eq. 9)
+# ---------------------------------------------------------------------------
+
+
+class TestZDT3ParetoFront:
+    def test_pareto_point_f1_half(self):
+        p = zdt3()
+        x = _pareto_x(p, 0.5)
+        f = p.evaluate(x)
+        expected_f2 = 1.0 - np.sqrt(0.5) - 0.5 * np.sin(10.0 * np.pi * 0.5)
+        assert f[0] == pytest.approx(0.5)
+        assert f[1] == pytest.approx(expected_f2, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# ZDT4 — mixed bounds; global front at g=1  (Eq. 10)
+# ---------------------------------------------------------------------------
+
+
+class TestZDT4:
+    def test_bounds_x1(self):
+        p = zdt4()
+        assert p.lb[0] == pytest.approx(0.0)
+        assert p.ub[0] == pytest.approx(1.0)
+
+    def test_bounds_rest(self):
+        p = zdt4()
+        assert all(p.lb[i] == pytest.approx(-5.0) for i in range(1, p.dim))
+        assert all(p.ub[i] == pytest.approx(5.0) for i in range(1, p.dim))
+
+    def test_global_pareto_point(self):
+        # x[1:] = 0 → g = 1 + 10*(m-1) + sum(0 - 10*cos(0)) = 1+90-90 = 1
+        p = zdt4()
+        x = _pareto_x(p, 0.5)  # lb for x[1:] is -5; need 0 explicitly
+        x[1:] = 0.0
+        f = p.evaluate(x)
+        assert f[0] == pytest.approx(0.5)
+        assert f[1] == pytest.approx(1.0 - np.sqrt(0.5), rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# ZDT5 — deceptive binary problem  (Eq. 11)
+# ---------------------------------------------------------------------------
+
+
+class TestZDT5Structure:
+    def test_returns_problem(self):
+        assert isinstance(zdt5(), Problem)
+
+    def test_default_n_var(self):
+        assert zdt5().dim == 80  # 30 + 10*5
+
+    def test_custom_params(self):
+        p = zdt5(n_bits_b1=10, n_bits_rest=3, n_rest=4)
+        assert p.dim == 10 + 4 * 3
+
+    def test_n_obj(self):
+        assert zdt5().n_obj == 2
+
+    def test_direction_minimize_both(self):
+        np.testing.assert_array_equal(zdt5().direction, [-1.0, -1.0])
+
+    def test_evaluate_shape(self):
+        p = zdt5()
+        f = p.evaluate(np.zeros(p.dim))
+        assert f.shape == (2,)
+
+    def test_bounds_all_binary(self):
+        p = zdt5()
+        assert all(lb == pytest.approx(0.0) for lb in p.lb)
+        assert all(ub == pytest.approx(1.0) for ub in p.ub)
+
+    def test_no_constraints(self):
+        assert zdt5().n_constraints == 0
+
+
+class TestZDT5ParetoFront:
+    def test_global_pareto_b1_all_zero(self):
+        # u(b1)=0 → f1=1; all rest bits=1 → u_i=5 → v=1 → g=10; f2=10
+        p = zdt5()
+        x = np.zeros(p.dim)
+        x[30:] = 1
+        f = p.evaluate(x)
+        assert f[0] == pytest.approx(1.0)
+        assert f[1] == pytest.approx(10.0)
+
+    def test_global_pareto_b1_all_one(self):
+        # u(b1)=30 → f1=31; all rest bits=1 → g=10; f2=10/31
+        p = zdt5()
+        x = np.ones(p.dim)
+        f = p.evaluate(x)
+        assert f[0] == pytest.approx(31.0)
+        assert f[1] == pytest.approx(10.0 / 31.0, rel=1e-9)
+
+    def test_off_pareto_rest_all_zero(self):
+        # all bits=0 → u_i=0 → v=2 for each → g=20; f2=20/1=20
+        p = zdt5()
+        x = np.zeros(p.dim)
+        f = p.evaluate(x)
+        assert f[0] == pytest.approx(1.0)
+        assert f[1] == pytest.approx(20.0)
+
+
+# ---------------------------------------------------------------------------
+# ZDT6 — non-uniform distribution; front at g=1  (Eq. 12)
+# ---------------------------------------------------------------------------
+
+
+class TestZDT6ParetoFront:
+    def test_pareto_point_x1_zero(self):
+        # x1=0 → f1 = 1 - exp(0)*sin^6(0) = 1 - 0 = 1; g=1 → f2=0
+        p = zdt6()
+        x = _pareto_x(p, 0.0)
+        f = p.evaluate(x)
+        assert f[0] == pytest.approx(1.0)
+        assert f[1] == pytest.approx(0.0, abs=1e-12)
+
+    def test_pareto_point_nonzero(self):
+        p = zdt6()
+        x1 = 0.5
+        x = _pareto_x(p, x1)
+        f = p.evaluate(x)
+        expected_f1 = 1.0 - np.exp(-4.0 * x1) * np.sin(6.0 * np.pi * x1) ** 6
+        expected_f2 = 1.0 - (expected_f1 / 1.0) ** 2
+        assert f[0] == pytest.approx(expected_f1, rel=1e-9)
+        assert f[1] == pytest.approx(expected_f2, rel=1e-9)


### PR DESCRIPTION
## Related Issue
#99

## Overview
Introduces the `saealib.benchmarks` module with factory functions that return `Problem` instances for ZDT, DTLZ, and single-objective benchmark suites. Each function corresponds to the equation numbers in its reference paper and has been numerically validated against pymoo (atol=1e-12).

## Changes
- `src/saealib/benchmarks/zdt.py` — ZDT1–6 (Zitzler et al. 2000); ZDT5 implemented as a binary-variable problem using `IntegerVariable`
- `src/saealib/benchmarks/dtlz.py` — DTLZ1–7 (Deb et al. 2005); spherical objective computation shared via `_sphere_objectives` helper across DTLZ2/3/4/5/6
- `src/saealib/benchmarks/singleobj.py` — Sphere, Rosenbrock, Ackley, Rastrigin (Jamil & Yang 2013)
- `src/saealib/benchmarks/__init__.py` — exports all 18 functions as the public API
- `tests/test_benchmarks_{zdt,dtlz,singleobj}.py` — structural tests, Pareto-front checks, and global-minimum spot checks

## Verification Steps
- `pytest tests/` — 1503 tests passed (including existing tests)
- `ruff format src/ tests/` / `ruff check src/ tests/` — no issues
- `ty check src/` — no diagnostics
- Numerical comparison against pymoo confirmed agreement within atol=1e-12 for all 13 multi-objective functions (ZDT1–6, DTLZ1–7) and 3 single-objective functions (Rosenbrock, Ackley, Rastrigin)

## Concerns
- pymoo defines Sphere as `sum((xi-0.5)^2)` on [0, 1] (minimum at x=0.5), which differs from the Jamil & Yang f137 definition used here (`sum(xi^2)`, minimum at origin); excluded from pymoo comparison
- Convergence tests, CI integration, and constrained problems (G01, MW, etc.) are part of issue #99 but not addressed in this PR

## Other