### PR TITLE
feat: symmetrize crossover/mutation interfaces, implement bounded SBX and prob/prob_var

### DIFF
--- a/src/saealib/algorithms/ga.py
+++ b/src/saealib/algorithms/ga.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 
 def _route_crossover(
     parent: np.ndarray,
+    lb: np.ndarray,
+    ub: np.ndarray,
     rng: np.random.Generator,
     problem: Problem,
     cont_op: Crossover,
@@ -35,7 +37,7 @@ def _route_crossover(
     i_mask = problem.integer_mask
     cat_mask = problem.categorical_mask
     if not i_mask.any() and not cat_mask.any():
-        return cont_op.crossover(parent, rng=rng)
+        return cont_op.crossover(parent, (lb, ub), rng=rng)
 
     n_children = cont_op.n_children
     dim = parent.shape[1]
@@ -43,11 +45,17 @@ def _route_crossover(
     c_mask = problem.continuous_mask
 
     if c_mask.any():
-        offspring[:, c_mask] = cont_op.crossover(parent[:, c_mask], rng=rng)
+        offspring[:, c_mask] = cont_op.crossover(
+            parent[:, c_mask], (lb[c_mask], ub[c_mask]), rng=rng
+        )
     if i_mask.any():
-        offspring[:, i_mask] = int_op.crossover(parent[:, i_mask], rng=rng)
+        offspring[:, i_mask] = int_op.crossover(
+            parent[:, i_mask], (lb[i_mask], ub[i_mask]), rng=rng
+        )
     if cat_mask.any():
-        offspring[:, cat_mask] = cat_op.crossover(parent[:, cat_mask], rng=rng)
+        offspring[:, cat_mask] = cat_op.crossover(
+            parent[:, cat_mask], (lb[cat_mask], ub[cat_mask]), rng=rng
+        )
 
     return offspring
 
@@ -151,7 +159,7 @@ class GA(Algorithm):
         self.parent_selection = parent_selection
         self.survivor_selection = survivor_selection
 
-        _cr = getattr(crossover, "crossover_rate", 1.0)
+        _cr = getattr(crossover, "prob", 1.0)
         _mr = getattr(mutation, "mutation_rate", 0.1)
         self.integer_crossover: Crossover = (
             integer_crossover
@@ -287,9 +295,11 @@ class GA(Algorithm):
         cand = np.empty((n_pair * n_children, ctx.dim))
         for i in range(n_pair):
             parent = pop[parent_idx_m[i]]
-            if ctx.rng.random() < self.crossover.crossover_rate:
+            if ctx.rng.random() < self.crossover.prob:
                 c = _route_crossover(
                     parent,
+                    lb,
+                    ub,
                     ctx.rng,
                     ctx.problem,
                     self.crossover,

--- a/src/saealib/algorithms/ga.py
+++ b/src/saealib/algorithms/ga.py
@@ -160,7 +160,7 @@ class GA(Algorithm):
         self.survivor_selection = survivor_selection
 
         _cr = getattr(crossover, "prob", 1.0)
-        _mr = getattr(mutation, "mutation_rate", 0.1)
+        _pv = getattr(mutation, "prob_var", None)
         self.integer_crossover: Crossover = (
             integer_crossover
             if integer_crossover is not None
@@ -169,7 +169,7 @@ class GA(Algorithm):
         self.integer_mutation: Mutation = (
             integer_mutation
             if integer_mutation is not None
-            else MutationIntegerUniform(_mr)
+            else MutationIntegerUniform(prob_var=_pv)
         )
         self.categorical_crossover: Crossover = (
             categorical_crossover
@@ -179,7 +179,7 @@ class GA(Algorithm):
         self.categorical_mutation: Mutation = (
             categorical_mutation
             if categorical_mutation is not None
-            else MutationCategorical(_mr)
+            else MutationCategorical(prob_var=_pv)
         )
 
         for _name, _op in [

--- a/src/saealib/api.py
+++ b/src/saealib/api.py
@@ -106,7 +106,7 @@ def _resolve_algorithm(algorithm: str | Algorithm) -> Algorithm:
         name = algorithm.upper()
         if name == "GA":
             return GA(
-                crossover=CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4),
+                crossover=CrossoverBLXAlpha(prob=0.7, alpha=0.4),
                 mutation=MutationUniform(mutation_rate=0.3),
                 parent_selection=SequentialSelection(),
                 survivor_selection=TruncationSelection(),

--- a/src/saealib/api.py
+++ b/src/saealib/api.py
@@ -107,7 +107,7 @@ def _resolve_algorithm(algorithm: str | Algorithm) -> Algorithm:
         if name == "GA":
             return GA(
                 crossover=CrossoverBLXAlpha(prob=0.7, alpha=0.4),
-                mutation=MutationUniform(mutation_rate=0.3),
+                mutation=MutationUniform(prob_var=0.3),
                 parent_selection=SequentialSelection(),
                 survivor_selection=TruncationSelection(),
             )

--- a/src/saealib/operators/crossover.py
+++ b/src/saealib/operators/crossover.py
@@ -26,15 +26,20 @@ class Crossover(ABC):
         Number of offspring produced per crossover call. Default is 2.
         Subclasses may override this class attribute if they produce a
         different number of offspring.
+    prob : float
+        Individual-level crossover probability.
     """
 
     n_parents: int = 2
     n_children: int = 2
-    crossover_rate: float = 1.0
+    prob: float = 1.0
 
     @abstractmethod
     def crossover(
-        self, parent: np.ndarray, rng: np.random.Generator = np.random.default_rng()
+        self,
+        parent: np.ndarray,
+        bounds: tuple[np.ndarray, np.ndarray] | None = None,
+        rng: np.random.Generator = np.random.default_rng(),
     ) -> np.ndarray:
         """
         Execute crossover.
@@ -43,6 +48,8 @@ class Crossover(ABC):
         ----------
         parent : np.ndarray
             Parent individuals. shape = (n_parents, dim)
+        bounds : tuple of (np.ndarray, np.ndarray) or None
+            Lower and upper bounds for each variable. ``None`` means unbounded.
         rng : np.random.Generator, optional
             Random number generator, by default np.random.default_rng()
 
@@ -113,30 +120,33 @@ class CrossoverBLXAlpha(Crossover):
 
     Attributes
     ----------
-    crossover_rate : float
-        Crossover rate.
+    prob : float
+        Individual-level crossover probability.
     alpha : float
         Alpha parameter for BLX-alpha crossover. Controls how far outside
         the parents' range offspring can be generated.
     """
 
-    def __init__(self, crossover_rate: float, alpha: float):
+    def __init__(self, prob: float, alpha: float):
         """
         Initialize BLX-alpha crossover operator.
 
         Parameters
         ----------
-        crossover_rate : float
-            Crossover rate.
+        prob : float
+            Individual-level crossover probability.
         alpha : float
             Alpha parameter for BLX-alpha crossover.
         """
         super().__init__()
-        self.crossover_rate = crossover_rate
+        self.prob = prob
         self.alpha = alpha
 
     def crossover(
-        self, parent: np.ndarray, rng: np.random.Generator = np.random.default_rng()
+        self,
+        parent: np.ndarray,
+        bounds: tuple[np.ndarray, np.ndarray] | None = None,
+        rng: np.random.Generator = np.random.default_rng(),
     ) -> np.ndarray:
         """
         Execute BLX-alpha crossover.
@@ -145,6 +155,8 @@ class CrossoverBLXAlpha(Crossover):
         ----------
         parent : np.ndarray
             Parent individuals. shape = (2, dim)
+        bounds : tuple of (np.ndarray, np.ndarray) or None
+            Ignored; BLX-alpha is inherently unbounded.
         rng : np.random.Generator, optional
             Random number generator, by default np.random.default_rng()
 
@@ -166,31 +178,44 @@ class CrossoverSBX(Crossover):
     """
     Simulated Binary Crossover (SBX) operator.
 
+    When *bounds* are provided and finite, the bounded variant from
+    Deb & Agrawal (1995, Section 2.2) is used, which constrains offspring
+    to ``[lb, ub]``.  When *bounds* is ``None`` or contains infinite values,
+    the unbounded variant is used.
+
     Attributes
     ----------
-    crossover_rate : float
-        Crossover rate.
+    prob : float
+        Individual-level crossover probability.
     eta : float
         Distribution index. Larger values produce offspring closer to parents.
+    prob_var : float
+        Per-variable crossover probability. Default is 0.5.
     """
 
-    def __init__(self, crossover_rate: float, eta: float):
+    def __init__(self, prob: float, eta: float, *, prob_var: float = 0.5):
         """
         Initialize SBX crossover operator.
 
         Parameters
         ----------
-        crossover_rate : float
-            Crossover rate.
+        prob : float
+            Individual-level crossover probability.
         eta : float
             Distribution index.
+        prob_var : float, optional
+            Per-variable crossover probability, by default 0.5.
         """
         super().__init__()
-        self.crossover_rate = crossover_rate
+        self.prob = prob
         self.eta = eta
+        self.prob_var = prob_var
 
     def crossover(
-        self, parent: np.ndarray, rng: np.random.Generator = np.random.default_rng()
+        self,
+        parent: np.ndarray,
+        bounds: tuple[np.ndarray, np.ndarray] | None = None,
+        rng: np.random.Generator = np.random.default_rng(),
     ) -> np.ndarray:
         """
         Execute SBX crossover.
@@ -199,6 +224,9 @@ class CrossoverSBX(Crossover):
         ----------
         parent : np.ndarray
             Parent individuals. shape = (2, dim)
+        bounds : tuple of (np.ndarray, np.ndarray) or None
+            Lower and upper bounds. When provided and finite, the bounded
+            SBX variant (Deb & Agrawal, 1995, §2.2) is applied.
         rng : np.random.Generator, optional
             Random number generator, by default np.random.default_rng()
 
@@ -210,16 +238,55 @@ class CrossoverSBX(Crossover):
         p1 = parent[0]
         p2 = parent[1]
         dim = len(p1)
-        u = rng.uniform(0.0, 1.0, size=dim)
-        beta_q = np.where(
-            u <= 0.5,
-            (2.0 * u) ** (1.0 / (self.eta + 1)),
-            (1.0 / (2.0 * (1.0 - u))) ** (1.0 / (self.eta + 1)),
+
+        use_bounded = (
+            bounds is not None
+            and np.all(np.isfinite(bounds[0]))
+            and np.all(np.isfinite(bounds[1]))
         )
-        mid = 0.5 * (p1 + p2)
-        half_diff = 0.5 * beta_q * (p2 - p1)
-        c1 = mid - half_diff
-        c2 = mid + half_diff
+
+        if use_bounded:
+            lb, ub = bounds  # type: ignore[misc]
+            y1 = np.minimum(p1, p2)
+            y2 = np.maximum(p1, p2)
+            diff = y2 - y1
+            separated = diff > 1e-14
+
+            beta_limit = np.where(
+                separated,
+                1.0
+                + 2.0 * np.minimum(y1 - lb, ub - y2) / np.where(separated, diff, 1.0),
+                1.0,
+            )
+            alpha = 2.0 - beta_limit ** (-(self.eta + 1))
+            u = rng.uniform(0.0, 1.0, size=dim)
+            beta_q = np.where(
+                u <= 1.0 / alpha,
+                (alpha * u) ** (1.0 / (self.eta + 1)),
+                (1.0 / (2.0 - alpha * u)) ** (1.0 / (self.eta + 1)),
+            )
+            mid = 0.5 * (y1 + y2)
+            half_diff = 0.5 * beta_q * diff
+            c1_sbx = np.clip(mid - half_diff, lb, ub)
+            c2_sbx = np.clip(mid + half_diff, lb, ub)
+            # skip crossover where parents are identical
+            c1_sbx = np.where(separated, c1_sbx, p1)
+            c2_sbx = np.where(separated, c2_sbx, p2)
+        else:
+            u = rng.uniform(0.0, 1.0, size=dim)
+            beta_q = np.where(
+                u <= 0.5,
+                (2.0 * u) ** (1.0 / (self.eta + 1)),
+                (1.0 / (2.0 * (1.0 - u))) ** (1.0 / (self.eta + 1)),
+            )
+            mid = 0.5 * (p1 + p2)
+            half_diff = 0.5 * beta_q * (p2 - p1)
+            c1_sbx = mid - half_diff
+            c2_sbx = mid + half_diff
+
+        do_cross = rng.random(size=dim) < self.prob_var
+        c1 = np.where(do_cross, c1_sbx, p1)
+        c2 = np.where(do_cross, c2_sbx, p2)
         return np.array([c1, c2])
 
 
@@ -232,29 +299,32 @@ class CrossoverUniform(Crossover):
 
     Attributes
     ----------
-    crossover_rate : float
-        Crossover rate.
+    prob : float
+        Individual-level crossover probability.
     swap_rate : float
         Per-dimension swap probability. Default is 0.5.
     """
 
-    def __init__(self, crossover_rate: float, swap_rate: float = 0.5):
+    def __init__(self, prob: float, swap_rate: float = 0.5):
         """
         Initialize uniform crossover operator.
 
         Parameters
         ----------
-        crossover_rate : float
-            Crossover rate.
+        prob : float
+            Individual-level crossover probability.
         swap_rate : float, optional
             Per-dimension swap probability, by default 0.5.
         """
         super().__init__()
-        self.crossover_rate = crossover_rate
+        self.prob = prob
         self.swap_rate = swap_rate
 
     def crossover(
-        self, parent: np.ndarray, rng: np.random.Generator = np.random.default_rng()
+        self,
+        parent: np.ndarray,
+        bounds: tuple[np.ndarray, np.ndarray] | None = None,
+        rng: np.random.Generator = np.random.default_rng(),
     ) -> np.ndarray:
         """
         Execute uniform crossover.
@@ -263,6 +333,8 @@ class CrossoverUniform(Crossover):
         ----------
         parent : np.ndarray
             Parent individuals. shape = (2, dim)
+        bounds : tuple of (np.ndarray, np.ndarray) or None
+            Ignored.
         rng : np.random.Generator, optional
             Random number generator, by default np.random.default_rng()
 
@@ -285,24 +357,27 @@ class CrossoverOnePoint(Crossover):
 
     Attributes
     ----------
-    crossover_rate : float
-        Crossover rate.
+    prob : float
+        Individual-level crossover probability.
     """
 
-    def __init__(self, crossover_rate: float):
+    def __init__(self, prob: float):
         """
         Initialize one-point crossover operator.
 
         Parameters
         ----------
-        crossover_rate : float
-            Crossover rate.
+        prob : float
+            Individual-level crossover probability.
         """
         super().__init__()
-        self.crossover_rate = crossover_rate
+        self.prob = prob
 
     def crossover(
-        self, parent: np.ndarray, rng: np.random.Generator = np.random.default_rng()
+        self,
+        parent: np.ndarray,
+        bounds: tuple[np.ndarray, np.ndarray] | None = None,
+        rng: np.random.Generator = np.random.default_rng(),
     ) -> np.ndarray:
         """
         Execute one-point crossover.
@@ -311,6 +386,8 @@ class CrossoverOnePoint(Crossover):
         ----------
         parent : np.ndarray
             Parent individuals. shape = (2, dim)
+        bounds : tuple of (np.ndarray, np.ndarray) or None
+            Ignored.
         rng : np.random.Generator, optional
             Random number generator, by default np.random.default_rng()
 
@@ -334,24 +411,27 @@ class CrossoverTwoPoint(Crossover):
 
     Attributes
     ----------
-    crossover_rate : float
-        Crossover rate.
+    prob : float
+        Individual-level crossover probability.
     """
 
-    def __init__(self, crossover_rate: float):
+    def __init__(self, prob: float):
         """
         Initialize two-point crossover operator.
 
         Parameters
         ----------
-        crossover_rate : float
-            Crossover rate.
+        prob : float
+            Individual-level crossover probability.
         """
         super().__init__()
-        self.crossover_rate = crossover_rate
+        self.prob = prob
 
     def crossover(
-        self, parent: np.ndarray, rng: np.random.Generator = np.random.default_rng()
+        self,
+        parent: np.ndarray,
+        bounds: tuple[np.ndarray, np.ndarray] | None = None,
+        rng: np.random.Generator = np.random.default_rng(),
     ) -> np.ndarray:
         """
         Execute two-point crossover.
@@ -360,6 +440,8 @@ class CrossoverTwoPoint(Crossover):
         ----------
         parent : np.ndarray
             Parent individuals. shape = (2, dim)
+        bounds : tuple of (np.ndarray, np.ndarray) or None
+            Ignored.
         rng : np.random.Generator, optional
             Random number generator, by default np.random.default_rng()
 
@@ -386,29 +468,37 @@ class CrossoverIntegerSBX(Crossover):
 
     Attributes
     ----------
-    crossover_rate : float
-        Crossover rate.
+    prob : float
+        Individual-level crossover probability.
     eta : float
         Distribution index. Larger values produce offspring closer to parents.
+    prob_var : float
+        Per-variable crossover probability. Default is 0.5.
     """
 
-    def __init__(self, crossover_rate: float, eta: float):
+    def __init__(self, prob: float, eta: float, *, prob_var: float = 0.5):
         """
         Initialize integer SBX crossover operator.
 
         Parameters
         ----------
-        crossover_rate : float
-            Crossover rate.
+        prob : float
+            Individual-level crossover probability.
         eta : float
             Distribution index.
+        prob_var : float, optional
+            Per-variable crossover probability, by default 0.5.
         """
         super().__init__()
-        self.crossover_rate = crossover_rate
+        self.prob = prob
         self.eta = eta
+        self.prob_var = prob_var
 
     def crossover(
-        self, parent: np.ndarray, rng: np.random.Generator = np.random.default_rng()
+        self,
+        parent: np.ndarray,
+        bounds: tuple[np.ndarray, np.ndarray] | None = None,
+        rng: np.random.Generator = np.random.default_rng(),
     ) -> np.ndarray:
         """
         Execute integer SBX crossover.
@@ -417,6 +507,9 @@ class CrossoverIntegerSBX(Crossover):
         ----------
         parent : np.ndarray
             Parent individuals. shape = (2, dim)
+        bounds : tuple of (np.ndarray, np.ndarray) or None
+            Lower and upper bounds. When provided and finite, the bounded
+            SBX variant is applied before rounding.
         rng : np.random.Generator, optional
             Random number generator, by default np.random.default_rng()
 
@@ -428,16 +521,54 @@ class CrossoverIntegerSBX(Crossover):
         p1 = parent[0]
         p2 = parent[1]
         dim = len(p1)
-        u = rng.uniform(0.0, 1.0, size=dim)
-        beta_q = np.where(
-            u <= 0.5,
-            (2.0 * u) ** (1.0 / (self.eta + 1)),
-            (1.0 / (2.0 * (1.0 - u))) ** (1.0 / (self.eta + 1)),
+
+        use_bounded = (
+            bounds is not None
+            and np.all(np.isfinite(bounds[0]))
+            and np.all(np.isfinite(bounds[1]))
         )
-        mid = 0.5 * (p1 + p2)
-        half_diff = 0.5 * beta_q * (p2 - p1)
-        c1 = np.round(mid - half_diff)
-        c2 = np.round(mid + half_diff)
+
+        if use_bounded:
+            lb, ub = bounds  # type: ignore[misc]
+            y1 = np.minimum(p1, p2)
+            y2 = np.maximum(p1, p2)
+            diff = y2 - y1
+            separated = diff > 1e-14
+
+            beta_limit = np.where(
+                separated,
+                1.0
+                + 2.0 * np.minimum(y1 - lb, ub - y2) / np.where(separated, diff, 1.0),
+                1.0,
+            )
+            alpha = 2.0 - beta_limit ** (-(self.eta + 1))
+            u = rng.uniform(0.0, 1.0, size=dim)
+            beta_q = np.where(
+                u <= 1.0 / alpha,
+                (alpha * u) ** (1.0 / (self.eta + 1)),
+                (1.0 / (2.0 - alpha * u)) ** (1.0 / (self.eta + 1)),
+            )
+            mid = 0.5 * (y1 + y2)
+            half_diff = 0.5 * beta_q * diff
+            c1_sbx = np.clip(np.round(mid - half_diff), lb, ub)
+            c2_sbx = np.clip(np.round(mid + half_diff), lb, ub)
+            c1_sbx = np.where(separated, c1_sbx, p1)
+            c2_sbx = np.where(separated, c2_sbx, p2)
+        else:
+            u = rng.uniform(0.0, 1.0, size=dim)
+            beta_q = np.where(
+                u <= 0.5,
+                (2.0 * u) ** (1.0 / (self.eta + 1)),
+                (1.0 / (2.0 * (1.0 - u))) ** (1.0 / (self.eta + 1)),
+            )
+            mid = 0.5 * (p1 + p2)
+            half_diff = 0.5 * beta_q * (p2 - p1)
+            c1_sbx = np.round(mid - half_diff)
+            c2_sbx = np.round(mid + half_diff)
+
+        do_cross = rng.random(size=dim) < self.prob_var
+        c1 = np.where(do_cross, c1_sbx, p1)
+        c2 = np.where(do_cross, c2_sbx, p2)
         return np.array([c1, c2])
 
 
@@ -451,24 +582,27 @@ class CrossoverCategorical(Crossover):
 
     Attributes
     ----------
-    crossover_rate : float
-        Crossover rate.
+    prob : float
+        Individual-level crossover probability.
     """
 
-    def __init__(self, crossover_rate: float):
+    def __init__(self, prob: float):
         """
         Initialize categorical crossover operator.
 
         Parameters
         ----------
-        crossover_rate : float
-            Crossover rate.
+        prob : float
+            Individual-level crossover probability.
         """
         super().__init__()
-        self.crossover_rate = crossover_rate
+        self.prob = prob
 
     def crossover(
-        self, parent: np.ndarray, rng: np.random.Generator = np.random.default_rng()
+        self,
+        parent: np.ndarray,
+        bounds: tuple[np.ndarray, np.ndarray] | None = None,
+        rng: np.random.Generator = np.random.default_rng(),
     ) -> np.ndarray:
         """
         Execute categorical crossover.
@@ -477,6 +611,8 @@ class CrossoverCategorical(Crossover):
         ----------
         parent : np.ndarray
             Parent individuals. shape = (2, dim)
+        bounds : tuple of (np.ndarray, np.ndarray) or None
+            Ignored.
         rng : np.random.Generator, optional
             Random number generator, by default np.random.default_rng()
 

--- a/src/saealib/operators/mutation.py
+++ b/src/saealib/operators/mutation.py
@@ -14,7 +14,20 @@ if TYPE_CHECKING:
 
 
 class Mutation(ABC):
-    """Base class for mutation operators."""
+    """Base class for mutation operators.
+
+    Attributes
+    ----------
+    prob : float
+        Individual-level mutation probability. When ``rng.random() >= prob``,
+        the individual is returned unchanged.
+    prob_var : float or None
+        Per-variable mutation probability. ``None`` means the effective value
+        is resolved at call time as ``min(0.5, 1 / dim)``.
+    """
+
+    prob: float = 1.0
+    prob_var: float | None = None
 
     @abstractmethod
     def mutate(
@@ -102,21 +115,27 @@ class MutationUniform(Mutation):
 
     Attributes
     ----------
-    mutation_rate : float
-        The probability of mutating each dimension.
+    prob : float
+        Individual-level mutation probability.
+    prob_var : float or None
+        Per-variable mutation probability. Defaults to ``min(0.5, 1/dim)``
+        when ``None``.
     """
 
-    def __init__(self, mutation_rate: float):
+    def __init__(self, prob: float = 1.0, *, prob_var: float | None = None):
         """
         Initialize uniform mutation operator.
 
         Parameters
         ----------
-        mutation_rate : float
-            The probability of mutating each dimension.
+        prob : float, optional
+            Individual-level mutation probability, by default 1.0.
+        prob_var : float or None, optional
+            Per-variable mutation probability. ``None`` uses ``min(0.5, 1/dim)``.
         """
         super().__init__()
-        self.mutation_rate = mutation_rate
+        self.prob = prob
+        self.prob_var = prob_var
 
     def mutate(
         self,
@@ -141,11 +160,14 @@ class MutationUniform(Mutation):
         np.ndarray
             Mutated individual.
         """
+        if rng.random() >= self.prob:
+            return p.copy()
         dim = len(p)
+        p_var = self.prob_var if self.prob_var is not None else min(0.5, 1.0 / dim)
         c = p.copy()
         lb, ub = mutate_range
         for i in range(dim):
-            if rng.random() < self.mutation_rate:
+            if rng.random() < p_var:
                 c[i] = rng.uniform(lb[i], ub[i])
         return c
 
@@ -156,26 +178,32 @@ class MutationPolynomial(Mutation):
 
     Attributes
     ----------
-    mutation_rate : float
-        The probability of mutating each dimension.
+    prob : float
+        Individual-level mutation probability.
     eta : float
         Distribution index. Larger values produce smaller perturbations.
+    prob_var : float or None
+        Per-variable mutation probability. Defaults to ``min(0.5, 1/dim)``
+        when ``None``.
     """
 
-    def __init__(self, mutation_rate: float, eta: float):
+    def __init__(self, prob: float = 1.0, *, eta: float, prob_var: float | None = None):
         """
         Initialize polynomial mutation operator.
 
         Parameters
         ----------
-        mutation_rate : float
-            The probability of mutating each dimension.
+        prob : float, optional
+            Individual-level mutation probability, by default 1.0.
         eta : float
             Distribution index.
+        prob_var : float or None, optional
+            Per-variable mutation probability. ``None`` uses ``min(0.5, 1/dim)``.
         """
         super().__init__()
-        self.mutation_rate = mutation_rate
+        self.prob = prob
         self.eta = eta
+        self.prob_var = prob_var
 
     def mutate(
         self,
@@ -200,10 +228,14 @@ class MutationPolynomial(Mutation):
         np.ndarray
             Mutated individual.
         """
+        if rng.random() >= self.prob:
+            return p.copy()
+        dim = len(p)
+        p_var = self.prob_var if self.prob_var is not None else min(0.5, 1.0 / dim)
         c = p.copy()
         lb, ub = mutate_range
-        for i in range(len(p)):
-            if rng.random() < self.mutation_rate:
+        for i in range(dim):
+            if rng.random() < p_var:
                 delta = min(c[i] - lb[i], ub[i] - c[i]) / (ub[i] - lb[i])
                 u = rng.random()
                 if u <= 0.5:
@@ -225,26 +257,34 @@ class MutationGaussian(Mutation):
 
     Attributes
     ----------
-    mutation_rate : float
-        The probability of mutating each dimension.
+    prob : float
+        Individual-level mutation probability.
     sigma : float
         Standard deviation of the Gaussian perturbation.
+    prob_var : float or None
+        Per-variable mutation probability. Defaults to ``min(0.5, 1/dim)``
+        when ``None``.
     """
 
-    def __init__(self, mutation_rate: float, sigma: float):
+    def __init__(
+        self, prob: float = 1.0, *, sigma: float, prob_var: float | None = None
+    ):
         """
         Initialize Gaussian mutation operator.
 
         Parameters
         ----------
-        mutation_rate : float
-            The probability of mutating each dimension.
+        prob : float, optional
+            Individual-level mutation probability, by default 1.0.
         sigma : float
             Standard deviation of the Gaussian perturbation.
+        prob_var : float or None, optional
+            Per-variable mutation probability. ``None`` uses ``min(0.5, 1/dim)``.
         """
         super().__init__()
-        self.mutation_rate = mutation_rate
+        self.prob = prob
         self.sigma = sigma
+        self.prob_var = prob_var
 
     def mutate(
         self,
@@ -269,9 +309,13 @@ class MutationGaussian(Mutation):
         np.ndarray
             Mutated individual.
         """
+        if rng.random() >= self.prob:
+            return p.copy()
+        dim = len(p)
+        p_var = self.prob_var if self.prob_var is not None else min(0.5, 1.0 / dim)
         c = p.copy()
-        for i in range(len(p)):
-            if rng.random() < self.mutation_rate:
+        for i in range(dim):
+            if rng.random() < p_var:
                 c[i] = c[i] + rng.normal(0.0, self.sigma)
         return c
 
@@ -283,9 +327,10 @@ class _MutationDiscreteUniform(Mutation):
     from ``[lb[i], ub[i]]`` (both inclusive).
     """
 
-    def __init__(self, mutation_rate: float):
+    def __init__(self, prob: float = 1.0, *, prob_var: float | None = None):
         super().__init__()
-        self.mutation_rate = mutation_rate
+        self.prob = prob
+        self.prob_var = prob_var
 
     def mutate(
         self,
@@ -310,10 +355,14 @@ class _MutationDiscreteUniform(Mutation):
         np.ndarray
             Mutated individual.
         """
+        if rng.random() >= self.prob:
+            return p.copy()
+        dim = len(p)
+        p_var = self.prob_var if self.prob_var is not None else min(0.5, 1.0 / dim)
         c = p.copy()
         lb, ub = mutate_range
-        for i in range(len(p)):
-            if rng.random() < self.mutation_rate:
+        for i in range(dim):
+            if rng.random() < p_var:
                 c[i] = float(rng.integers(int(lb[i]), int(ub[i]) + 1))
         return c
 
@@ -327,20 +376,25 @@ class MutationIntegerUniform(_MutationDiscreteUniform):
 
     Attributes
     ----------
-    mutation_rate : float
-        The probability of mutating each dimension.
+    prob : float
+        Individual-level mutation probability.
+    prob_var : float or None
+        Per-variable mutation probability. Defaults to ``min(0.5, 1/dim)``
+        when ``None``.
     """
 
-    def __init__(self, mutation_rate: float):
+    def __init__(self, prob: float = 1.0, *, prob_var: float | None = None):
         """
         Initialize integer uniform mutation operator.
 
         Parameters
         ----------
-        mutation_rate : float
-            The probability of mutating each dimension.
+        prob : float, optional
+            Individual-level mutation probability, by default 1.0.
+        prob_var : float or None, optional
+            Per-variable mutation probability. ``None`` uses ``min(0.5, 1/dim)``.
         """
-        super().__init__(mutation_rate)
+        super().__init__(prob, prob_var=prob_var)
 
 
 class MutationCategorical(_MutationDiscreteUniform):
@@ -353,17 +407,22 @@ class MutationCategorical(_MutationDiscreteUniform):
 
     Attributes
     ----------
-    mutation_rate : float
-        The probability of mutating each dimension.
+    prob : float
+        Individual-level mutation probability.
+    prob_var : float or None
+        Per-variable mutation probability. Defaults to ``min(0.5, 1/dim)``
+        when ``None``.
     """
 
-    def __init__(self, mutation_rate: float):
+    def __init__(self, prob: float = 1.0, *, prob_var: float | None = None):
         """
         Initialize categorical mutation operator.
 
         Parameters
         ----------
-        mutation_rate : float
-            The probability of mutating each dimension.
+        prob : float, optional
+            Individual-level mutation probability, by default 1.0.
+        prob_var : float or None, optional
+            Per-variable mutation probability. ``None`` uses ``min(0.5, 1/dim)``.
         """
-        super().__init__(mutation_rate)
+        super().__init__(prob, prob_var=prob_var)

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -465,7 +465,7 @@ class TestPostEvaluationDispatch:
             )
             .set_algorithm(
                 GA(
-                    crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.5),
+                    crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.5),
                     mutation=MutationUniform(mutation_rate=0.1),
                     parent_selection=SequentialSelection(),
                     survivor_selection=TruncationSelection(),

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -466,7 +466,7 @@ class TestPostEvaluationDispatch:
             .set_algorithm(
                 GA(
                     crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.5),
-                    mutation=MutationUniform(mutation_rate=0.1),
+                    mutation=MutationUniform(prob_var=0.1),
                     parent_selection=SequentialSelection(),
                     survivor_selection=TruncationSelection(),
                 )

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -59,7 +59,7 @@ def _make_optimizer(
         .set_initializer(LHSInitializer(N_INIT_ARCHIVE, N_INIT_POP))
         .set_algorithm(
             GA(
-                crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.5),
+                crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.5),
                 mutation=MutationUniform(mutation_rate=0.1),
                 parent_selection=SequentialSelection(),
                 survivor_selection=TruncationSelection(),
@@ -106,7 +106,7 @@ def test_lhs_uses_optimizer_seed_over_own():
         .set_initializer(LHSInitializer(N_INIT_ARCHIVE, N_INIT_POP, seed=999))
         .set_algorithm(
             GA(
-                crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.5),
+                crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.5),
                 mutation=MutationUniform(mutation_rate=0.1),
                 parent_selection=SequentialSelection(),
                 survivor_selection=TruncationSelection(),

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -60,7 +60,7 @@ def _make_optimizer(
         .set_algorithm(
             GA(
                 crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.5),
-                mutation=MutationUniform(mutation_rate=0.1),
+                mutation=MutationUniform(prob_var=0.1),
                 parent_selection=SequentialSelection(),
                 survivor_selection=TruncationSelection(),
             )
@@ -107,7 +107,7 @@ def test_lhs_uses_optimizer_seed_over_own():
         .set_algorithm(
             GA(
                 crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.5),
-                mutation=MutationUniform(mutation_rate=0.1),
+                mutation=MutationUniform(prob_var=0.1),
                 parent_selection=SequentialSelection(),
                 survivor_selection=TruncationSelection(),
             )

--- a/tests/test_constraint_surrogate.py
+++ b/tests/test_constraint_surrogate.py
@@ -75,7 +75,7 @@ def _make_g01_problem() -> Problem:
 def _make_ga() -> GA:
     return GA(
         crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
-        mutation=MutationUniform(mutation_rate=0.1),
+        mutation=MutationUniform(prob_var=0.1),
         parent_selection=SequentialSelection(),
         survivor_selection=TruncationSelection(),
     )

--- a/tests/test_constraint_surrogate.py
+++ b/tests/test_constraint_surrogate.py
@@ -74,7 +74,7 @@ def _make_g01_problem() -> Problem:
 
 def _make_ga() -> GA:
     return GA(
-        crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4),
+        crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
         mutation=MutationUniform(mutation_rate=0.1),
         parent_selection=SequentialSelection(),
         survivor_selection=TruncationSelection(),

--- a/tests/test_direct_strategy.py
+++ b/tests/test_direct_strategy.py
@@ -73,7 +73,7 @@ def _make_ctx(rng_seed: int = 0) -> OptimizationState:
 
 def _make_ga() -> GA:
     return GA(
-        crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4),
+        crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
         mutation=MutationUniform(mutation_rate=0.1),
         parent_selection=SequentialSelection(),
         survivor_selection=TruncationSelection(),

--- a/tests/test_direct_strategy.py
+++ b/tests/test_direct_strategy.py
@@ -74,7 +74,7 @@ def _make_ctx(rng_seed: int = 0) -> OptimizationState:
 def _make_ga() -> GA:
     return GA(
         crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
-        mutation=MutationUniform(mutation_rate=0.1),
+        mutation=MutationUniform(prob_var=0.1),
         parent_selection=SequentialSelection(),
         survivor_selection=TruncationSelection(),
     )

--- a/tests/test_epsilon_constraint_handler.py
+++ b/tests/test_epsilon_constraint_handler.py
@@ -211,7 +211,7 @@ def _make_optimizer(problem, n_gen: int):
         .set_initializer(LHSInitializer(n_init_archive=8, n_init_population=6, seed=0))
         .set_algorithm(
             GA(
-                crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4),
+                crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
                 mutation=MutationUniform(mutation_rate=0.1),
                 parent_selection=SequentialSelection(),
                 survivor_selection=TruncationSelection(),

--- a/tests/test_epsilon_constraint_handler.py
+++ b/tests/test_epsilon_constraint_handler.py
@@ -212,7 +212,7 @@ def _make_optimizer(problem, n_gen: int):
         .set_algorithm(
             GA(
                 crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
-                mutation=MutationUniform(mutation_rate=0.1),
+                mutation=MutationUniform(prob_var=0.1),
                 parent_selection=SequentialSelection(),
                 survivor_selection=TruncationSelection(),
             )

--- a/tests/test_ga_mixed.py
+++ b/tests/test_ga_mixed.py
@@ -76,7 +76,7 @@ class _CrossoverN1C(Crossover):
     def __init__(self):
         self.prob = 1.0
 
-    def crossover(self, parent, rng=np.random.default_rng()):
+    def crossover(self, parent, bounds=None, rng=np.random.default_rng()):
         return parent[:1].copy()
 
 
@@ -88,7 +88,7 @@ class _CrossoverP3(Crossover):
     def __init__(self):
         self.prob = 1.0
 
-    def crossover(self, parent, rng=np.random.default_rng()):
+    def crossover(self, parent, bounds=None, rng=np.random.default_rng()):
         return parent[:2].copy()
 
 

--- a/tests/test_ga_mixed.py
+++ b/tests/test_ga_mixed.py
@@ -30,7 +30,7 @@ from saealib.operators.crossover import Crossover
 def _make_ga(**kwargs):
     return GA(
         crossover=CrossoverSBX(1.0, eta=20.0),
-        mutation=MutationPolynomial(0.1, eta=20.0),
+        mutation=MutationPolynomial(eta=20.0, prob_var=0.1),
         parent_selection=TournamentSelection(2),
         survivor_selection=TruncationSelection(),
         **kwargs,
@@ -124,11 +124,11 @@ class TestGADefaults:
 
     def test_default_integer_mutation_rate_inherits(self):
         ga = _make_ga()
-        assert ga.integer_mutation.mutation_rate == pytest.approx(0.1)
+        assert ga.integer_mutation.prob_var == pytest.approx(0.1)
 
     def test_default_categorical_mutation_rate_inherits(self):
         ga = _make_ga()
-        assert ga.categorical_mutation.mutation_rate == pytest.approx(0.1)
+        assert ga.categorical_mutation.prob_var == pytest.approx(0.1)
 
     def test_custom_integer_crossover(self):
         custom = CrossoverIntegerSBX(0.5, eta=5.0)

--- a/tests/test_ga_mixed.py
+++ b/tests/test_ga_mixed.py
@@ -74,7 +74,7 @@ class _CrossoverN1C(Crossover):
     n_children = 1
 
     def __init__(self):
-        self.crossover_rate = 1.0
+        self.prob = 1.0
 
     def crossover(self, parent, rng=np.random.default_rng()):
         return parent[:1].copy()
@@ -86,7 +86,7 @@ class _CrossoverP3(Crossover):
     n_parents = 3
 
     def __init__(self):
-        self.crossover_rate = 1.0
+        self.prob = 1.0
 
     def crossover(self, parent, rng=np.random.default_rng()):
         return parent[:2].copy()
@@ -116,11 +116,11 @@ class TestGADefaults:
 
     def test_default_integer_crossover_rate_inherits(self):
         ga = _make_ga()
-        assert ga.integer_crossover.crossover_rate == pytest.approx(1.0)
+        assert ga.integer_crossover.prob == pytest.approx(1.0)
 
     def test_default_categorical_crossover_rate_inherits(self):
         ga = _make_ga()
-        assert ga.categorical_crossover.crossover_rate == pytest.approx(1.0)
+        assert ga.categorical_crossover.prob == pytest.approx(1.0)
 
     def test_default_integer_mutation_rate_inherits(self):
         ga = _make_ga()
@@ -179,16 +179,30 @@ class TestRouteCrossover:
         rng1 = np.random.default_rng(42)
         rng2 = np.random.default_rng(42)
         result = _route_crossover(
-            parent, rng1, problem, self.cont_op, self.int_op, self.cat_op
+            parent,
+            problem.lb,
+            problem.ub,
+            rng1,
+            problem,
+            self.cont_op,
+            self.int_op,
+            self.cat_op,
         )
-        expected = self.cont_op.crossover(parent, rng=rng2)
+        expected = self.cont_op.crossover(parent, (problem.lb, problem.ub), rng=rng2)
         np.testing.assert_array_equal(result, expected)
 
     def test_mixed_output_shape(self):
         problem = _make_problem_mixed()
         parent = np.array([[0.5, 3.0, 1.0], [0.8, 7.0, 2.0]])
         result = _route_crossover(
-            parent, self.rng, problem, self.cont_op, self.int_op, self.cat_op
+            parent,
+            problem.lb,
+            problem.ub,
+            self.rng,
+            problem,
+            self.cont_op,
+            self.int_op,
+            self.cat_op,
         )
         assert result.shape == (2, 3)
 
@@ -198,7 +212,14 @@ class TestRouteCrossover:
         for _ in range(20):
             parent = np.array([[0.5, 3.0, 1.0], [0.8, 7.0, 2.0]])
             result = _route_crossover(
-                parent, rng, problem, self.cont_op, self.int_op, self.cat_op
+                parent,
+                problem.lb,
+                problem.ub,
+                rng,
+                problem,
+                self.cont_op,
+                self.int_op,
+                self.cat_op,
             )
             assert result[0, 1] == round(result[0, 1])
             assert result[1, 1] == round(result[1, 1])
@@ -209,7 +230,14 @@ class TestRouteCrossover:
         for _ in range(20):
             parent = np.array([[0.5, 3.0, 0.0], [0.8, 7.0, 2.0]])
             result = _route_crossover(
-                parent, rng, problem, self.cont_op, self.int_op, self.cat_op
+                parent,
+                problem.lb,
+                problem.ub,
+                rng,
+                problem,
+                self.cont_op,
+                self.int_op,
+                self.cat_op,
             )
             assert result[0, 2] in {0.0, 2.0}
             assert result[1, 2] in {0.0, 2.0}
@@ -220,7 +248,14 @@ class TestRouteCrossover:
         parent = np.array([[0.1, 3.0, 1.0], [0.9, 7.0, 0.0]])
         results = [
             _route_crossover(
-                parent, rng, problem, self.cont_op, self.int_op, self.cat_op
+                parent,
+                problem.lb,
+                problem.ub,
+                rng,
+                problem,
+                self.cont_op,
+                self.int_op,
+                self.cat_op,
             )
             for _ in range(30)
         ]

--- a/tests/test_initial_evaluation_event.py
+++ b/tests/test_initial_evaluation_event.py
@@ -66,7 +66,7 @@ def _make_optimizer(problem: Problem | None = None) -> Optimizer:
         )
         .set_algorithm(
             GA(
-                crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.5),
+                crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.5),
                 mutation=MutationUniform(mutation_rate=0.1),
                 parent_selection=SequentialSelection(),
                 survivor_selection=TruncationSelection(),
@@ -310,7 +310,7 @@ class TestInitialEvaluationEndEventMutation:
             )
             .set_algorithm(
                 GA(
-                    crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.5),
+                    crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.5),
                     mutation=MutationUniform(mutation_rate=0.1),
                     parent_selection=SequentialSelection(),
                     survivor_selection=TruncationSelection(),

--- a/tests/test_initial_evaluation_event.py
+++ b/tests/test_initial_evaluation_event.py
@@ -67,7 +67,7 @@ def _make_optimizer(problem: Problem | None = None) -> Optimizer:
         .set_algorithm(
             GA(
                 crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.5),
-                mutation=MutationUniform(mutation_rate=0.1),
+                mutation=MutationUniform(prob_var=0.1),
                 parent_selection=SequentialSelection(),
                 survivor_selection=TruncationSelection(),
             )
@@ -311,7 +311,7 @@ class TestInitialEvaluationEndEventMutation:
             .set_algorithm(
                 GA(
                     crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.5),
-                    mutation=MutationUniform(mutation_rate=0.1),
+                    mutation=MutationUniform(prob_var=0.1),
                     parent_selection=SequentialSelection(),
                     survivor_selection=TruncationSelection(),
                 )

--- a/tests/test_initializers.py
+++ b/tests/test_initializers.py
@@ -65,7 +65,7 @@ class _MockProvider:
 
         self.algorithm = GA(
             crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
-            mutation=MutationUniform(mutation_rate=0.1),
+            mutation=MutationUniform(prob_var=0.1),
             parent_selection=SequentialSelection(),
             survivor_selection=TruncationSelection(),
         )

--- a/tests/test_initializers.py
+++ b/tests/test_initializers.py
@@ -64,7 +64,7 @@ class _MockProvider:
         from saealib.callback import CallbackManager
 
         self.algorithm = GA(
-            crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4),
+            crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
             mutation=MutationUniform(mutation_rate=0.1),
             parent_selection=SequentialSelection(),
             survivor_selection=TruncationSelection(),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -63,7 +63,7 @@ def test_integration():
     )
     algorithm = GA(
         crossover=CrossoverBLXAlpha(prob=0.7, alpha=0.4),
-        mutation=MutationUniform(mutation_rate=0.3),
+        mutation=MutationUniform(prob_var=0.3),
         parent_selection=SequentialSelection(),
         survivor_selection=TruncationSelection(),
     )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -62,7 +62,7 @@ def test_integration():
         seed=42,
     )
     algorithm = GA(
-        crossover=CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4),
+        crossover=CrossoverBLXAlpha(prob=0.7, alpha=0.4),
         mutation=MutationUniform(mutation_rate=0.3),
         parent_selection=SequentialSelection(),
         survivor_selection=TruncationSelection(),

--- a/tests/test_moo.py
+++ b/tests/test_moo.py
@@ -783,7 +783,7 @@ class TestMOOIntegration:
             seed=seed,
         )
         algorithm = GA(
-            crossover=CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4),
+            crossover=CrossoverBLXAlpha(prob=0.7, alpha=0.4),
             mutation=MutationUniform(mutation_rate=0.3),
             parent_selection=SequentialSelection(),
             survivor_selection=TruncationSelection(),

--- a/tests/test_moo.py
+++ b/tests/test_moo.py
@@ -784,7 +784,7 @@ class TestMOOIntegration:
         )
         algorithm = GA(
             crossover=CrossoverBLXAlpha(prob=0.7, alpha=0.4),
-            mutation=MutationUniform(mutation_rate=0.3),
+            mutation=MutationUniform(prob_var=0.3),
             parent_selection=SequentialSelection(),
             survivor_selection=TruncationSelection(),
         )

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -740,3 +740,106 @@ class TestMutationCategorical:
         c1 = op.mutate(p, (self._lb, self._ub), rng=np.random.default_rng(9))
         c2 = op.mutate(p, (self._lb, self._ub), rng=np.random.default_rng(9))
         np.testing.assert_array_equal(c1, c2)
+
+
+# ---------------------------------------------------------------------------
+# CrossoverSBX: bounded variant and prob_var
+# ---------------------------------------------------------------------------
+
+
+class TestCrossoverSBXBounded:
+    def _parents(self):
+        return np.array([[0.1, 0.2, 0.5], [0.8, 0.9, 0.6]])
+
+    def _bounds(self):
+        lb = np.zeros(3)
+        ub = np.ones(3)
+        return lb, ub
+
+    def test_bounded_offspring_within_bounds(self):
+        op = CrossoverSBX(prob=1.0, eta=20.0, prob_var=1.0)
+        lb, ub = self._bounds()
+        rng = np.random.default_rng(0)
+        for _ in range(50):
+            c = op.crossover(self._parents(), (lb, ub), rng=rng)
+            assert np.all(c >= lb) and np.all(c <= ub)
+
+    def test_unbounded_fallback_when_bounds_none(self):
+        op = CrossoverSBX(prob=1.0, eta=2.0, prob_var=1.0)
+        rng1 = np.random.default_rng(7)
+        rng2 = np.random.default_rng(7)
+        p = self._parents()
+        c_none = op.crossover(p, None, rng=rng1)
+        c_default = op.crossover(p, rng=rng2)
+        np.testing.assert_array_equal(c_none, c_default)
+
+    def test_prob_var_zero_returns_parents(self):
+        op = CrossoverSBX(prob=1.0, eta=20.0, prob_var=0.0)
+        lb, ub = self._bounds()
+        p = self._parents()
+        c = op.crossover(p, (lb, ub), rng=np.random.default_rng(0))
+        np.testing.assert_array_equal(c[0], p[0])
+        np.testing.assert_array_equal(c[1], p[1])
+
+    def test_bounded_center_preserved(self):
+        op = CrossoverSBX(prob=1.0, eta=20.0, prob_var=1.0)
+        lb, ub = self._bounds()
+        rng = np.random.default_rng(3)
+        for _ in range(30):
+            p = rng.uniform(0.1, 0.9, size=(2, 3))
+            c = op.crossover(p, (lb, ub), rng=rng)
+            mid_p = 0.5 * (p[0] + p[1])
+            mid_c = 0.5 * (c[0] + c[1])
+            np.testing.assert_allclose(mid_c, mid_p, atol=1e-10)
+
+    def test_identical_parents_unchanged(self):
+        op = CrossoverSBX(prob=1.0, eta=20.0, prob_var=1.0)
+        lb, ub = self._bounds()
+        p = np.array([[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]])
+        c = op.crossover(p, (lb, ub), rng=np.random.default_rng(0))
+        np.testing.assert_array_equal(c[0], p[0])
+        np.testing.assert_array_equal(c[1], p[1])
+
+
+# ---------------------------------------------------------------------------
+# Mutation: individual-level prob gate
+# ---------------------------------------------------------------------------
+
+
+class TestMutationProbGate:
+    def _range(self):
+        lb = np.zeros(5)
+        ub = np.ones(5)
+        return lb, ub
+
+    def test_prob_zero_returns_parent_unchanged(self):
+        op = MutationPolynomial(prob=0.0, eta=20.0, prob_var=1.0)
+        rng = np.random.default_rng(0)
+        p = rng.uniform(0.1, 0.9, size=5)
+        for _ in range(20):
+            c = op.mutate(p, self._range(), rng=rng)
+            np.testing.assert_array_equal(c, p)
+
+    def test_prob_zero_uniform(self):
+        op = MutationUniform(prob=0.0, prob_var=1.0)
+        rng = np.random.default_rng(0)
+        p = rng.uniform(0.1, 0.9, size=5)
+        for _ in range(20):
+            c = op.mutate(p, self._range(), rng=rng)
+            np.testing.assert_array_equal(c, p)
+
+    def test_prob_var_none_uses_adaptive_default(self):
+        dim = 10
+        op = MutationPolynomial(prob=1.0, eta=20.0, prob_var=None)
+        lb = np.zeros(dim)
+        ub = np.ones(dim)
+        p = np.full(dim, 0.5)
+        changed = np.zeros(dim)
+        rng = np.random.default_rng(1)
+        n_trials = 500
+        for _ in range(n_trials):
+            c = op.mutate(p, (lb, ub), rng=rng)
+            changed += (c != p).astype(float)
+        expected_rate = min(0.5, 1.0 / dim)
+        observed_rate = changed / n_trials
+        np.testing.assert_allclose(observed_rate, expected_rate, atol=0.05)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -268,14 +268,14 @@ class TestMutationPolynomial:
         return lb, ub
 
     def test_output_shape(self):
-        op = MutationPolynomial(mutation_rate=0.5, eta=20.0)
+        op = MutationPolynomial(prob_var=0.5, eta=20.0)
         rng = np.random.default_rng(0)
         p = rng.uniform(-2.0, 2.0, size=DIM)
         c = op.mutate(p, self._range(), rng=rng)
         assert c.shape == (DIM,)
 
     def test_within_bounds(self):
-        op = MutationPolynomial(mutation_rate=1.0, eta=20.0)
+        op = MutationPolynomial(prob_var=1.0, eta=20.0)
         lb, ub = self._range()
         rng = np.random.default_rng(0)
         for _ in range(20):
@@ -284,7 +284,7 @@ class TestMutationPolynomial:
             assert np.all(c >= lb) and np.all(c <= ub)
 
     def test_zero_rate_no_change(self):
-        op = MutationPolynomial(mutation_rate=0.0, eta=20.0)
+        op = MutationPolynomial(prob_var=0.0, eta=20.0)
         rng = np.random.default_rng(0)
         p = rng.uniform(-2.0, 2.0, size=DIM)
         c = op.mutate(p, self._range(), rng=rng)
@@ -303,21 +303,21 @@ class TestMutationGaussian:
         return lb, ub
 
     def test_output_shape(self):
-        op = MutationGaussian(mutation_rate=0.5, sigma=0.1)
+        op = MutationGaussian(prob_var=0.5, sigma=0.1)
         rng = np.random.default_rng(0)
         p = rng.uniform(-2.0, 2.0, size=DIM)
         c = op.mutate(p, self._range(), rng=rng)
         assert c.shape == (DIM,)
 
     def test_zero_rate_no_change(self):
-        op = MutationGaussian(mutation_rate=0.0, sigma=1.0)
+        op = MutationGaussian(prob_var=0.0, sigma=1.0)
         rng = np.random.default_rng(0)
         p = rng.uniform(-2.0, 2.0, size=DIM)
         c = op.mutate(p, self._range(), rng=rng)
         np.testing.assert_array_equal(c, p)
 
     def test_zero_sigma_no_change(self):
-        op = MutationGaussian(mutation_rate=1.0, sigma=0.0)
+        op = MutationGaussian(prob_var=1.0, sigma=0.0)
         rng = np.random.default_rng(0)
         p = rng.uniform(-2.0, 2.0, size=DIM)
         c = op.mutate(p, self._range(), rng=rng)
@@ -442,7 +442,7 @@ class TestCrossoverHooks:
 
 class TestMutationHooks:
     def _op(self):
-        return MutationPolynomial(mutation_rate=1.0, eta=20.0)
+        return MutationPolynomial(prob_var=1.0, eta=20.0)
 
     def _individual(self, rng=None):
         rng = rng if rng is not None else np.random.default_rng(0)
@@ -533,7 +533,7 @@ class TestGAHookInvocation:
         crossover = CrossoverBLXAlpha(prob=1.0, alpha=0.4).with_post(hook)
         ga = GA(
             crossover=crossover,
-            mutation=MutationUniform(mutation_rate=0.0),
+            mutation=MutationUniform(prob_var=0.0),
             parent_selection=SequentialSelection(),
             survivor_selection=TruncationSelection(),
         )
@@ -549,7 +549,7 @@ class TestGAHookInvocation:
             call_count[0] += 1
             return offspring
 
-        mutation = MutationUniform(mutation_rate=0.0).with_post(hook)
+        mutation = MutationUniform(prob_var=0.0).with_post(hook)
         ga = GA(
             crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
             mutation=mutation,
@@ -653,13 +653,13 @@ class TestMutationIntegerUniform:
     _ub = np.array([5.0, 4.0, 8.0])
 
     def test_output_shape(self):
-        op = MutationIntegerUniform(mutation_rate=1.0)
+        op = MutationIntegerUniform(prob_var=1.0)
         p = np.array([2.0, 2.0, 5.0])
         c = op.mutate(p, (self._lb, self._ub), rng=np.random.default_rng(0))
         assert c.shape == (3,)
 
     def test_offspring_are_integers(self):
-        op = MutationIntegerUniform(mutation_rate=1.0)
+        op = MutationIntegerUniform(prob_var=1.0)
         rng = np.random.default_rng(0)
         p = np.array([2.0, 2.0, 5.0])
         for _ in range(30):
@@ -667,7 +667,7 @@ class TestMutationIntegerUniform:
             assert np.all(c == np.round(c))
 
     def test_values_within_bounds(self):
-        op = MutationIntegerUniform(mutation_rate=1.0)
+        op = MutationIntegerUniform(prob_var=1.0)
         rng = np.random.default_rng(1)
         p = np.array([2.0, 2.0, 5.0])
         for _ in range(50):
@@ -676,13 +676,13 @@ class TestMutationIntegerUniform:
             assert np.all(c <= self._ub)
 
     def test_zero_rate_unchanged(self):
-        op = MutationIntegerUniform(mutation_rate=0.0)
+        op = MutationIntegerUniform(prob_var=0.0)
         p = np.array([2.0, 3.0, 6.0])
         c = op.mutate(p, (self._lb, self._ub), rng=np.random.default_rng(0))
         np.testing.assert_array_equal(c, p)
 
     def test_determinism(self):
-        op = MutationIntegerUniform(mutation_rate=0.5)
+        op = MutationIntegerUniform(prob_var=0.5)
         p = np.array([2.0, 2.0, 5.0])
         c1 = op.mutate(p, (self._lb, self._ub), rng=np.random.default_rng(5))
         c2 = op.mutate(p, (self._lb, self._ub), rng=np.random.default_rng(5))
@@ -700,13 +700,13 @@ class TestMutationCategorical:
     _ub = np.array([2.0, 1.0, 3.0])
 
     def test_output_shape(self):
-        op = MutationCategorical(mutation_rate=1.0)
+        op = MutationCategorical(prob_var=1.0)
         p = np.array([1.0, 0.0, 2.0])
         c = op.mutate(p, (self._lb, self._ub), rng=np.random.default_rng(0))
         assert c.shape == (3,)
 
     def test_offspring_are_valid_indices(self):
-        op = MutationCategorical(mutation_rate=1.0)
+        op = MutationCategorical(prob_var=1.0)
         rng = np.random.default_rng(0)
         p = np.array([1.0, 0.0, 2.0])
         for _ in range(50):
@@ -716,7 +716,7 @@ class TestMutationCategorical:
             assert np.all(c == np.round(c))
 
     def test_uniform_distribution(self):
-        op = MutationCategorical(mutation_rate=1.0)
+        op = MutationCategorical(prob_var=1.0)
         rng = np.random.default_rng(0)
         p = np.array([0.0])
         lb = np.array([0.0])
@@ -729,13 +729,13 @@ class TestMutationCategorical:
         assert np.all(counts > 800), f"distribution not uniform: {counts}"
 
     def test_zero_rate_unchanged(self):
-        op = MutationCategorical(mutation_rate=0.0)
+        op = MutationCategorical(prob_var=0.0)
         p = np.array([1.0, 0.0, 2.0])
         c = op.mutate(p, (self._lb, self._ub), rng=np.random.default_rng(0))
         np.testing.assert_array_equal(c, p)
 
     def test_determinism(self):
-        op = MutationCategorical(mutation_rate=0.5)
+        op = MutationCategorical(prob_var=0.5)
         p = np.array([1.0, 0.0, 2.0])
         c1 = op.mutate(p, (self._lb, self._ub), rng=np.random.default_rng(9))
         c2 = op.mutate(p, (self._lb, self._ub), rng=np.random.default_rng(9))

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -96,18 +96,18 @@ def _make_ctx(n_pop: int = 10, rng_seed: int = 0) -> OptimizationState:
 
 class TestCrossoverBLXAlpha:
     def test_alpha_attribute(self):
-        op = CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4)
+        op = CrossoverBLXAlpha(prob=0.7, alpha=0.4)
         assert op.alpha == pytest.approx(0.4)
 
     def test_output_shape(self):
-        op = CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4)
+        op = CrossoverBLXAlpha(prob=0.7, alpha=0.4)
         rng = np.random.default_rng(0)
         p = _make_parents(rng)
         c = op.crossover(p, rng=rng)
         assert c.shape == (2, DIM)
 
     def test_deterministic_with_seed(self):
-        op = CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4)
+        op = CrossoverBLXAlpha(prob=0.7, alpha=0.4)
         p = _make_parents(np.random.default_rng(1))
         c1 = op.crossover(p, rng=np.random.default_rng(42))
         c2 = op.crossover(p, rng=np.random.default_rng(42))
@@ -121,7 +121,7 @@ class TestCrossoverBLXAlpha:
 
 class TestCrossoverSBX:
     def test_output_shape(self):
-        op = CrossoverSBX(crossover_rate=0.9, eta=2.0)
+        op = CrossoverSBX(prob=0.9, eta=2.0)
         rng = np.random.default_rng(0)
         p = _make_parents(rng)
         c = op.crossover(p, rng=rng)
@@ -129,14 +129,14 @@ class TestCrossoverSBX:
 
     def test_center_preservation(self):
         """Mid-point of children equals mid-point of parents (SBX property)."""
-        op = CrossoverSBX(crossover_rate=0.9, eta=2.0)
+        op = CrossoverSBX(prob=0.9, eta=2.0)
         rng = np.random.default_rng(5)
         p = _make_parents(rng)
         c = op.crossover(p, rng=rng)
         np.testing.assert_allclose((c[0] + c[1]) / 2, (p[0] + p[1]) / 2, atol=1e-10)
 
     def test_deterministic_with_seed(self):
-        op = CrossoverSBX(crossover_rate=0.9, eta=2.0)
+        op = CrossoverSBX(prob=0.9, eta=2.0)
         p = _make_parents(np.random.default_rng(1))
         c1 = op.crossover(p, rng=np.random.default_rng(42))
         c2 = op.crossover(p, rng=np.random.default_rng(42))
@@ -150,7 +150,7 @@ class TestCrossoverSBX:
 
 class TestCrossoverUniform:
     def test_output_shape(self):
-        op = CrossoverUniform(crossover_rate=0.8)
+        op = CrossoverUniform(prob=0.8)
         rng = np.random.default_rng(0)
         p = _make_parents(rng)
         c = op.crossover(p, rng=rng)
@@ -158,7 +158,7 @@ class TestCrossoverUniform:
 
     def test_swap_rate_zero(self):
         """swap_rate=0: c1==p1 and c2==p2."""
-        op = CrossoverUniform(crossover_rate=0.8, swap_rate=0.0)
+        op = CrossoverUniform(prob=0.8, swap_rate=0.0)
         rng = np.random.default_rng(0)
         p = _make_parents(rng)
         c = op.crossover(p, rng=rng)
@@ -167,7 +167,7 @@ class TestCrossoverUniform:
 
     def test_swap_rate_one(self):
         """swap_rate=1: c1==p2 and c2==p1."""
-        op = CrossoverUniform(crossover_rate=0.8, swap_rate=1.0)
+        op = CrossoverUniform(prob=0.8, swap_rate=1.0)
         rng = np.random.default_rng(0)
         p = _make_parents(rng)
         c = op.crossover(p, rng=rng)
@@ -182,7 +182,7 @@ class TestCrossoverUniform:
 
 class TestCrossoverOnePoint:
     def test_output_shape(self):
-        op = CrossoverOnePoint(crossover_rate=0.8)
+        op = CrossoverOnePoint(prob=0.8)
         rng = np.random.default_rng(0)
         p = _make_parents(rng)
         c = op.crossover(p, rng=rng)
@@ -190,7 +190,7 @@ class TestCrossoverOnePoint:
 
     def test_segment_intact(self):
         """Before cut point, c1 == p1; from cut point onward, c1 == p2."""
-        op = CrossoverOnePoint(crossover_rate=0.8)
+        op = CrossoverOnePoint(prob=0.8)
         rng = np.random.default_rng(0)
         p = _make_parents(rng)
         # Fix cut point by seeding: integers(1, DIM) with seed=7 gives a known value
@@ -211,7 +211,7 @@ class TestCrossoverOnePoint:
 
 class TestCrossoverTwoPoint:
     def test_output_shape(self):
-        op = CrossoverTwoPoint(crossover_rate=0.8)
+        op = CrossoverTwoPoint(prob=0.8)
         rng = np.random.default_rng(0)
         p = _make_parents(rng)
         c = op.crossover(p, rng=rng)
@@ -219,7 +219,7 @@ class TestCrossoverTwoPoint:
 
     def test_segment_intact(self):
         """Between the two cut points, c1 == p2; outside, c1 == p1."""
-        op = CrossoverTwoPoint(crossover_rate=0.8)
+        op = CrossoverTwoPoint(prob=0.8)
         rng2 = np.random.default_rng(3)
         pts = np.sort(rng2.choice(DIM + 1, size=2, replace=False))
         pt1, pt2 = pts[0], pts[1]
@@ -239,11 +239,11 @@ class TestCrossoverTwoPoint:
 @pytest.mark.parametrize(
     "op",
     [
-        CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4),
-        CrossoverSBX(crossover_rate=0.9, eta=2.0),
-        CrossoverUniform(crossover_rate=0.9),
-        CrossoverOnePoint(crossover_rate=0.9),
-        CrossoverTwoPoint(crossover_rate=0.9),
+        CrossoverBLXAlpha(prob=0.9, alpha=0.4),
+        CrossoverSBX(prob=0.9, eta=2.0),
+        CrossoverUniform(prob=0.9),
+        CrossoverOnePoint(prob=0.9),
+        CrossoverTwoPoint(prob=0.9),
     ],
 )
 class TestCrossoverNChildren:
@@ -371,7 +371,7 @@ class TestRouletteWheelSelection:
 
 class TestCrossoverHooks:
     def _op(self):
-        return CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4)
+        return CrossoverBLXAlpha(prob=0.9, alpha=0.4)
 
     def _parents(self, rng=None):
         rng = rng if rng is not None else np.random.default_rng(0)
@@ -530,7 +530,7 @@ class TestGAHookInvocation:
             call_count[0] += 1
             return offspring
 
-        crossover = CrossoverBLXAlpha(crossover_rate=1.0, alpha=0.4).with_post(hook)
+        crossover = CrossoverBLXAlpha(prob=1.0, alpha=0.4).with_post(hook)
         ga = GA(
             crossover=crossover,
             mutation=MutationUniform(mutation_rate=0.0),
@@ -551,7 +551,7 @@ class TestGAHookInvocation:
 
         mutation = MutationUniform(mutation_rate=0.0).with_post(hook)
         ga = GA(
-            crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4),
+            crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
             mutation=mutation,
             parent_selection=SequentialSelection(),
             survivor_selection=TruncationSelection(),
@@ -572,26 +572,26 @@ class TestCrossoverIntegerSBX:
     _parents = np.array([[1.0, 3.0, 5.0], [3.0, 7.0, 9.0]])
 
     def test_output_shape(self):
-        op = CrossoverIntegerSBX(crossover_rate=1.0, eta=2.0)
+        op = CrossoverIntegerSBX(prob=1.0, eta=2.0)
         c = op.crossover(self._parents, rng=np.random.default_rng(0))
         assert c.shape == (2, 3)
 
     def test_offspring_are_integers(self):
-        op = CrossoverIntegerSBX(crossover_rate=1.0, eta=2.0)
+        op = CrossoverIntegerSBX(prob=1.0, eta=2.0)
         rng = np.random.default_rng(42)
         for _ in range(20):
             c = op.crossover(self._parents, rng=rng)
             assert np.all(c == np.round(c)), "offspring must be integers"
 
     def test_crossover_rate_attribute(self):
-        op = CrossoverIntegerSBX(crossover_rate=0.8, eta=5.0)
-        assert op.crossover_rate == 0.8
+        op = CrossoverIntegerSBX(prob=0.8, eta=5.0)
+        assert op.prob == 0.8
 
     def test_n_children(self):
-        assert CrossoverIntegerSBX(crossover_rate=1.0, eta=2.0).n_children == 2
+        assert CrossoverIntegerSBX(prob=1.0, eta=2.0).n_children == 2
 
     def test_determinism(self):
-        op = CrossoverIntegerSBX(crossover_rate=1.0, eta=2.0)
+        op = CrossoverIntegerSBX(prob=1.0, eta=2.0)
         c1 = op.crossover(self._parents, rng=np.random.default_rng(7))
         c2 = op.crossover(self._parents, rng=np.random.default_rng(7))
         np.testing.assert_array_equal(c1, c2)
@@ -606,12 +606,12 @@ class TestCrossoverCategorical:
     _parents = np.array([[0.0, 2.0, 1.0], [2.0, 0.0, 2.0]])
 
     def test_output_shape(self):
-        op = CrossoverCategorical(crossover_rate=1.0)
+        op = CrossoverCategorical(prob=1.0)
         c = op.crossover(self._parents, rng=np.random.default_rng(0))
         assert c.shape == (2, 3)
 
     def test_offspring_values_from_parents(self):
-        op = CrossoverCategorical(crossover_rate=1.0)
+        op = CrossoverCategorical(prob=1.0)
         rng = np.random.default_rng(0)
         for _ in range(50):
             c = op.crossover(self._parents, rng=rng)
@@ -621,7 +621,7 @@ class TestCrossoverCategorical:
                 assert c[1, dim] in valid
 
     def test_complementary_swap(self):
-        op = CrossoverCategorical(crossover_rate=1.0)
+        op = CrossoverCategorical(prob=1.0)
         rng = np.random.default_rng(0)
         for _ in range(50):
             c = op.crossover(self._parents, rng=rng)
@@ -631,13 +631,13 @@ class TestCrossoverCategorical:
                 assert c[0, dim] + c[1, dim] == p_sum
 
     def test_crossover_rate_attribute(self):
-        assert CrossoverCategorical(crossover_rate=0.9).crossover_rate == 0.9
+        assert CrossoverCategorical(prob=0.9).prob == 0.9
 
     def test_n_children(self):
-        assert CrossoverCategorical(crossover_rate=1.0).n_children == 2
+        assert CrossoverCategorical(prob=1.0).n_children == 2
 
     def test_determinism(self):
-        op = CrossoverCategorical(crossover_rate=1.0)
+        op = CrossoverCategorical(prob=1.0)
         c1 = op.crossover(self._parents, rng=np.random.default_rng(3))
         c2 = op.crossover(self._parents, rng=np.random.default_rng(3))
         np.testing.assert_array_equal(c1, c2)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -73,7 +73,7 @@ class _MockProvider:
     def __init__(self):
         self.algorithm = GA(
             crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
-            mutation=MutationUniform(mutation_rate=0.1),
+            mutation=MutationUniform(prob_var=0.1),
             parent_selection=SequentialSelection(),
             survivor_selection=TruncationSelection(),
         )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -72,7 +72,7 @@ class _MockSurrogateManager:
 class _MockProvider:
     def __init__(self):
         self.algorithm = GA(
-            crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4),
+            crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
             mutation=MutationUniform(mutation_rate=0.1),
             parent_selection=SequentialSelection(),
             survivor_selection=TruncationSelection(),

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -77,7 +77,7 @@ def _make_state() -> OptimizationState:
 def _make_ga() -> GA:
     return GA(
         crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
-        mutation=MutationUniform(mutation_rate=0.1),
+        mutation=MutationUniform(prob_var=0.1),
         parent_selection=SequentialSelection(),
         survivor_selection=TruncationSelection(),
     )

--- a/tests/test_stages.py
+++ b/tests/test_stages.py
@@ -76,7 +76,7 @@ def _make_state() -> OptimizationState:
 
 def _make_ga() -> GA:
     return GA(
-        crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4),
+        crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
         mutation=MutationUniform(mutation_rate=0.1),
         parent_selection=SequentialSelection(),
         survivor_selection=TruncationSelection(),

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -93,7 +93,7 @@ def _make_ctx(n_pop: int = N_POP, rng_seed: int = 0) -> OptimizationState:
 def _make_ga() -> GA:
     return GA(
         crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
-        mutation=MutationUniform(mutation_rate=0.1),
+        mutation=MutationUniform(prob_var=0.1),
         parent_selection=SequentialSelection(),
         survivor_selection=TruncationSelection(),
     )

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -92,7 +92,7 @@ def _make_ctx(n_pop: int = N_POP, rng_seed: int = 0) -> OptimizationState:
 
 def _make_ga() -> GA:
     return GA(
-        crossover=CrossoverBLXAlpha(crossover_rate=0.9, alpha=0.4),
+        crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
         mutation=MutationUniform(mutation_rate=0.1),
         parent_selection=SequentialSelection(),
         survivor_selection=TruncationSelection(),


### PR DESCRIPTION
## Related Issue
Closes #182

## Overview

This is a breaking change that resolves three design asymmetries between `Crossover` and `Mutation`:

- `Crossover.crossover()` did not receive variable bounds, unlike `Mutation.mutate(p, (lb, ub), rng)`.
- `CrossoverSBX` implemented only the unbounded variant, causing significantly worse IGD on box-constrained problems (ZDT, DTLZ) compared to pymoo.
- Probability design was asymmetric: `Crossover` had an individual-level `crossover_rate` only; `Mutation` had a variable-level `mutation_rate` only.

This PR resolves all three together by introducing symmetrical `prob` (individual level) and `prob_var` (variable level) for both operator types.

## Changes

- `Crossover` ABC: rename `crossover_rate` to `prob`; add `bounds: tuple[np.ndarray, np.ndarray] | None = None` to `crossover(parent, bounds, rng)`.
- `CrossoverSBX`: add `prob_var=0.5`; apply bounded SBX (Deb & Agrawal, 1995, §2.2) when `bounds` is finite, fall back to unbounded when `bounds=None` or infinite.
- `CrossoverIntegerSBX`: same — `prob_var` and bounded variant (before rounding).
- Other `Crossover` subclasses (`BLXAlpha`, `Uniform`, `OnePoint`, `TwoPoint`, `Categorical`): rename to `prob`; accept and ignore `bounds`.
- `Mutation` ABC: add `prob: float = 1.0` (individual-level gate) and `prob_var: float | None = None` (variable-level probability).
- All `Mutation` subclasses (`Uniform`, `Polynomial`, `Gaussian`, `IntegerUniform`, `Categorical`): rename `mutation_rate` to `prob_var`; skip mutation when `rng.random() >= prob`; use `min(0.5, 1/dim)` when `prob_var=None`.
- `ga.py`: pass sliced `(lb, ub)` in `_route_crossover`; update `crossover_rate` → `prob` and `mutation_rate` → `prob_var` references; default integer/categorical mutations now inherit `prob_var`.
- Tests: update all existing tests to the new signatures; add `TestCrossoverSBXBounded` (within-bounds, center preservation, identical parents) and `TestMutationProbGate` (`prob=0` gate, adaptive `prob_var=None` default).

## Verification Steps

- pytest
- ruff format
- ruff check --fix
- ty check

## Concerns

- **Breaking change**: `crossover_rate` and `mutation_rate` constructor arguments are removed. Migration: `crossover_rate=X` → `prob=X`, `mutation_rate=X` → `prob_var=X`.
- **`MutationPolynomial` signature**: `eta` is now keyword-only (`MutationPolynomial(eta=20.0, ...)`).
- **`CrossoverSBX` default behavior change**: direct calls without `bounds` still use the unbounded variant, but calls through `_route_crossover` (i.e., inside GA) now use the bounded variant, which changes the offspring distribution on box-constrained problems.

## Other

- Bounded SBX reference: Deb, K., & Agrawal, R. B. (1995). Simulated binary crossover for continuous search space. *Complex Systems*, 9(2), 115–148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)