### PR TITLE
fix: [#182] align bounded SBX with official Deb NSGA-II reference implementation

### DIFF
--- a/src/saealib/operators/crossover.py
+++ b/src/saealib/operators/crossover.py
@@ -178,10 +178,9 @@ class CrossoverSBX(Crossover):
     """
     Simulated Binary Crossover (SBX) operator.
 
-    When *bounds* are provided and finite, the bounded variant from
-    Deb & Agrawal (1995, Section 2.2) is used, which constrains offspring
-    to ``[lb, ub]``.  When *bounds* is ``None`` or contains infinite values,
-    the unbounded variant is used.
+    When *bounds* are provided and finite, the bounded variant is used,
+    which constrains offspring to ``[lb, ub]``.  When *bounds* is ``None``
+    or contains infinite values, the unbounded variant is used.
 
     Attributes
     ----------
@@ -226,7 +225,7 @@ class CrossoverSBX(Crossover):
             Parent individuals. shape = (2, dim)
         bounds : tuple of (np.ndarray, np.ndarray) or None
             Lower and upper bounds. When provided and finite, the bounded
-            SBX variant (Deb & Agrawal, 1995, §2.2) is applied.
+            SBX variant is applied.
         rng : np.random.Generator, optional
             Random number generator, by default np.random.default_rng()
 
@@ -251,24 +250,27 @@ class CrossoverSBX(Crossover):
             y2 = np.maximum(p1, p2)
             diff = y2 - y1
             separated = diff > 1e-14
-
-            beta_limit = np.where(
-                separated,
-                1.0
-                + 2.0 * np.minimum(y1 - lb, ub - y2) / np.where(separated, diff, 1.0),
-                1.0,
-            )
-            alpha = 2.0 - beta_limit ** (-(self.eta + 1))
+            safe_diff = np.where(separated, diff, 1.0)
             u = rng.uniform(0.0, 1.0, size=dim)
-            beta_q = np.where(
-                u <= 1.0 / alpha,
-                (alpha * u) ** (1.0 / (self.eta + 1)),
-                (1.0 / (2.0 - alpha * u)) ** (1.0 / (self.eta + 1)),
-            )
-            mid = 0.5 * (y1 + y2)
-            half_diff = 0.5 * beta_q * diff
-            c1_sbx = np.clip(mid - half_diff, lb, ub)
-            c2_sbx = np.clip(mid + half_diff, lb, ub)
+
+            def _beta_q(beta_limit: np.ndarray) -> np.ndarray:
+                alpha = 2.0 - beta_limit ** (-(self.eta + 1))
+                return np.where(
+                    u <= 1.0 / alpha,
+                    (alpha * u) ** (1.0 / (self.eta + 1)),
+                    (1.0 / (2.0 - alpha * u)) ** (1.0 / (self.eta + 1)),
+                )
+
+            beta_q1 = _beta_q(1.0 + 2.0 * (y1 - lb) / safe_diff)
+            beta_q2 = _beta_q(1.0 + 2.0 * (ub - y2) / safe_diff)
+            o1 = np.clip(0.5 * ((y1 + y2) - beta_q1 * diff), lb, ub)
+            o2 = np.clip(0.5 * ((y1 + y2) + beta_q2 * diff), lb, ub)
+            # assign the lower/upper-side offspring to c1/c2 with a fresh
+            # 50/50 draw per dimension, independent of parent identity
+            # (matches DEAP's cxSimulatedBinaryBounded and pymoo's net effect)
+            swap = rng.random(size=dim) < 0.5
+            c1_sbx = np.where(swap, o2, o1)
+            c2_sbx = np.where(swap, o1, o2)
             # skip crossover where parents are identical
             c1_sbx = np.where(separated, c1_sbx, p1)
             c2_sbx = np.where(separated, c2_sbx, p2)
@@ -534,24 +536,24 @@ class CrossoverIntegerSBX(Crossover):
             y2 = np.maximum(p1, p2)
             diff = y2 - y1
             separated = diff > 1e-14
-
-            beta_limit = np.where(
-                separated,
-                1.0
-                + 2.0 * np.minimum(y1 - lb, ub - y2) / np.where(separated, diff, 1.0),
-                1.0,
-            )
-            alpha = 2.0 - beta_limit ** (-(self.eta + 1))
+            safe_diff = np.where(separated, diff, 1.0)
             u = rng.uniform(0.0, 1.0, size=dim)
-            beta_q = np.where(
-                u <= 1.0 / alpha,
-                (alpha * u) ** (1.0 / (self.eta + 1)),
-                (1.0 / (2.0 - alpha * u)) ** (1.0 / (self.eta + 1)),
-            )
-            mid = 0.5 * (y1 + y2)
-            half_diff = 0.5 * beta_q * diff
-            c1_sbx = np.clip(np.round(mid - half_diff), lb, ub)
-            c2_sbx = np.clip(np.round(mid + half_diff), lb, ub)
+
+            def _beta_q(beta_limit: np.ndarray) -> np.ndarray:
+                alpha = 2.0 - beta_limit ** (-(self.eta + 1))
+                return np.where(
+                    u <= 1.0 / alpha,
+                    (alpha * u) ** (1.0 / (self.eta + 1)),
+                    (1.0 / (2.0 - alpha * u)) ** (1.0 / (self.eta + 1)),
+                )
+
+            beta_q1 = _beta_q(1.0 + 2.0 * (y1 - lb) / safe_diff)
+            beta_q2 = _beta_q(1.0 + 2.0 * (ub - y2) / safe_diff)
+            o1 = np.clip(np.round(0.5 * ((y1 + y2) - beta_q1 * diff)), lb, ub)
+            o2 = np.clip(np.round(0.5 * ((y1 + y2) + beta_q2 * diff)), lb, ub)
+            swap = rng.random(size=dim) < 0.5
+            c1_sbx = np.where(swap, o2, o1)
+            c2_sbx = np.where(swap, o1, o2)
             c1_sbx = np.where(separated, c1_sbx, p1)
             c2_sbx = np.where(separated, c2_sbx, p2)
         else:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -781,16 +781,41 @@ class TestCrossoverSBXBounded:
         np.testing.assert_array_equal(c[0], p[0])
         np.testing.assert_array_equal(c[1], p[1])
 
-    def test_bounded_center_preserved(self):
+    def test_symmetric_margins_preserve_center(self):
+        # Equal margins to lb/ub make beta_q identical for both children,
+        # so the offspring center matches the parent center (special case
+        # of the asymmetric formula, not a general guarantee).
         op = CrossoverSBX(prob=1.0, eta=20.0, prob_var=1.0)
-        lb, ub = self._bounds()
         rng = np.random.default_rng(3)
         for _ in range(30):
-            p = rng.uniform(0.1, 0.9, size=(2, 3))
+            p = rng.uniform(0.4, 0.6, size=(2, 3))
+            margin = rng.uniform(0.05, 0.3, size=3)
+            y1 = np.minimum(p[0], p[1])
+            y2 = np.maximum(p[0], p[1])
+            lb = y1 - margin
+            ub = y2 + margin
             c = op.crossover(p, (lb, ub), rng=rng)
             mid_p = 0.5 * (p[0] + p[1])
             mid_c = 0.5 * (c[0] + c[1])
-            np.testing.assert_allclose(mid_c, mid_p, atol=1e-10)
+            np.testing.assert_allclose(mid_c, mid_p, atol=1e-9)
+
+    def test_asymmetric_bounds_produce_unequal_offsets(self):
+        # With lb close to the parents and ub far away, beta_q must differ
+        # between c1 (constrained by lb) and c2 (constrained by ub), so the
+        # offspring are not symmetric about the parent center.
+        op = CrossoverSBX(prob=1.0, eta=20.0, prob_var=1.0)
+        lb = np.array([0.0])
+        ub = np.array([1.0])
+        p = np.array([[0.01], [0.5]])
+        rng = np.random.default_rng(3)
+        max_gap = 0.0
+        for _ in range(30):
+            c = op.crossover(p, (lb, ub), rng=rng)
+            mid = 0.5 * (p[0] + p[1])
+            offset1 = mid - c[0]
+            offset2 = c[1] - mid
+            max_gap = max(max_gap, np.abs(offset1 - offset2).max())
+        assert max_gap > 1e-6
 
     def test_identical_parents_unchanged(self):
         op = CrossoverSBX(prob=1.0, eta=20.0, prob_var=1.0)


### PR DESCRIPTION
## Related Issue
Closes #182

## Overview
The bounded branching for CrossoverSBX and CrossoverIntegerSBX has been modified to an asymmetric form in accordance with nsga2-gnuplot-v1.1.6 (KanGAL Official 2005).

## Changes
- The bounded branching for CrossoverSBX and CrossoverIntegerSBX has been modified to an asymmetric form in accordance with nsga2-gnuplot-v1.1.6 (KanGAL Official 2005)
- Randomly change the assignment of children

## Verification Steps
- pytest
- ruff format
- ruff check --fix
- ty check


## Concerns


## Other
An issue that occurred in the implementation by Claude Code. 
I will continue to use it, but caution is still required.