### PR TITLE
feat: [#190] add DuplicateElimination operator and integrate into GA.ask()

### DIFF
--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -36,6 +36,7 @@ from saealib.execution.initializer import (
 from saealib.operators import (
     Crossover,
     CrossoverSBX,
+    DuplicateElimination,
     Mutation,
     MutationPolynomial,
     ParentSelection,
@@ -118,6 +119,7 @@ __all__ = [
     "Crossover",
     "CrossoverSBX",
     "DirectStrategy",
+    "DuplicateElimination",
     "EpsilonConstraintHandler",
     "EqualityConstraint",
     "EvaluationResult",

--- a/src/saealib/algorithms/ga.py
+++ b/src/saealib/algorithms/ga.py
@@ -12,6 +12,7 @@ from saealib.callback import PostAskEvent, PostCrossoverEvent, PostMutationEvent
 from saealib.context import OptimizationState
 from saealib.exceptions import ConfigurationError
 from saealib.operators.crossover import CrossoverCategorical, CrossoverIntegerSBX
+from saealib.operators.dedup import DuplicateElimination
 from saealib.operators.mutation import MutationCategorical, MutationIntegerUniform
 from saealib.population import Archive, Population, PopulationAttribute
 from saealib.problem import Problem
@@ -113,6 +114,10 @@ class GA(Algorithm):
         Crossover operator for categorical dimensions.
     categorical_mutation : Mutation
         Mutation operator for categorical dimensions.
+    duplicate_elimination : DuplicateElimination or None
+        When set, offspring that duplicate any member of the current population
+        are replaced by re-generated candidates (up to ``max_retries`` attempts).
+        ``None`` disables duplicate elimination (default behaviour).
     """
 
     def __init__(
@@ -122,6 +127,7 @@ class GA(Algorithm):
         parent_selection: ParentSelection,
         survivor_selection: SurvivorSelection,
         *,
+        duplicate_elimination: DuplicateElimination | None = None,
         integer_crossover: Crossover | None = None,
         integer_mutation: Mutation | None = None,
         categorical_crossover: Crossover | None = None,
@@ -140,6 +146,10 @@ class GA(Algorithm):
             Parent selection operator.
         survivor_selection : SurvivorSelection
             Survivor selection operator.
+        duplicate_elimination : DuplicateElimination, optional
+            When provided, offspring that duplicate any member of the current
+            population are replaced by re-generated candidates.  ``None``
+            (default) disables duplicate elimination.
         integer_crossover : Crossover, optional
             Crossover operator for integer dimensions.
             Defaults to ``CrossoverIntegerSBX`` with the same rate as *crossover*.
@@ -158,6 +168,7 @@ class GA(Algorithm):
         self.mutation = mutation
         self.parent_selection = parent_selection
         self.survivor_selection = survivor_selection
+        self.duplicate_elimination = duplicate_elimination
 
         _cr = getattr(crossover, "prob", 1.0)
         _pv = getattr(mutation, "prob_var", None)
@@ -332,11 +343,89 @@ class GA(Algorithm):
             cand[i] = ctx.problem.repair(cand[i])
         provider.dispatch(PostMutationEvent(ctx=ctx, candidates=cand))
 
+        if self.duplicate_elimination is not None:
+            pop_x = ctx.population.get_array("x")
+            de = self.duplicate_elimination
+            for _ in range(de.max_retries):
+                dup = de.find_duplicates(cand[:target], pop_x)
+                if not dup.any():
+                    break
+                dup_idx = np.where(dup)[0]
+                repl = self._make_offspring(
+                    ctx, len(dup_idx), pop, popsize, lb, ub, handler, constraints
+                )
+                cand[dup_idx] = repl[: len(dup_idx)]
+
         provider.dispatch(PostAskEvent(ctx=ctx, candidates=cand))
 
         cand_pop = ctx.population.empty_like(capacity=target)
         cand_pop.extend({"x": cand[:target]})
         return cand_pop
+
+    def _make_offspring(
+        self,
+        ctx: OptimizationState,
+        n_target: int,
+        pop: np.ndarray,
+        popsize: int,
+        lb: np.ndarray,
+        ub: np.ndarray,
+        handler,
+        constraints,
+    ) -> np.ndarray:
+        """Generate *n_target* offspring without dispatching events.
+
+        Used exclusively by the duplicate-elimination retry loop in
+        :meth:`ask` to silently replace duplicate candidates.
+        """
+        n_children = self.crossover.n_children
+        n_pair = math.ceil(n_target / n_children)
+        parent_idx = (
+            self.parent_selection.select(
+                ctx,
+                ctx.population,
+                n_pair=n_pair,
+                n_parents=self.crossover.n_parents,
+                rng=ctx.rng,
+            )
+            % popsize
+        )
+        batch = np.empty((n_pair * n_children, ctx.dim))
+        for i in range(n_pair):
+            parent = pop[parent_idx[i]]
+            if ctx.rng.random() < self.crossover.prob:
+                c = _route_crossover(
+                    parent,
+                    lb,
+                    ub,
+                    ctx.rng,
+                    ctx.problem,
+                    self.crossover,
+                    self.integer_crossover,
+                    self.categorical_crossover,
+                )
+            else:
+                c = parent[:n_children].copy()
+            c = self.crossover.post_crossover(c, parent, ctx.rng, ctx)
+            batch[i * n_children : (i + 1) * n_children] = c
+        for i in range(len(batch)):
+            batch[i] = handler.repair(batch[i], constraints, lb, ub)
+            batch[i] = ctx.problem.repair(batch[i])
+        for i in range(len(batch)):
+            batch[i] = _route_mutation(
+                batch[i],
+                lb,
+                ub,
+                ctx.rng,
+                ctx.problem,
+                self.mutation,
+                self.integer_mutation,
+                self.categorical_mutation,
+            )
+            batch[i] = self.mutation.post_mutation(batch[i], (lb, ub), ctx.rng, ctx)
+            batch[i] = handler.repair(batch[i], constraints, lb, ub)
+            batch[i] = ctx.problem.repair(batch[i])
+        return batch
 
     def tell(
         self,

--- a/src/saealib/operators/__init__.py
+++ b/src/saealib/operators/__init__.py
@@ -8,6 +8,7 @@ from saealib.operators.crossover import (
     CrossoverTwoPoint,
     CrossoverUniform,
 )
+from saealib.operators.dedup import DuplicateElimination
 from saealib.operators.mutation import (
     Mutation,
     MutationCategorical,
@@ -35,6 +36,7 @@ __all__ = [
     "CrossoverSBX",
     "CrossoverTwoPoint",
     "CrossoverUniform",
+    "DuplicateElimination",
     "Mutation",
     "MutationCategorical",
     "MutationGaussian",

--- a/src/saealib/operators/dedup.py
+++ b/src/saealib/operators/dedup.py
@@ -1,0 +1,54 @@
+"""Duplicate elimination operator for offspring filtering."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class DuplicateElimination:
+    """Filter offspring that duplicate any member of the current population.
+
+    Parameters
+    ----------
+    atol : float
+        Absolute tolerance passed to ``numpy.isclose``.
+        Matches the ``atol`` semantics of
+        :class:`~saealib.population.archive.ArchiveMixin`.
+    rtol : float
+        Relative tolerance passed to ``numpy.isclose``.
+        Matches the ``rtol`` semantics of
+        :class:`~saealib.population.archive.ArchiveMixin`.
+    max_retries : int
+        Maximum number of regeneration attempts per
+        :meth:`~saealib.algorithms.ga.GA.ask` call.
+    """
+
+    atol: float = 1e-16
+    rtol: float = 0.0
+    max_retries: int = 100
+
+    def find_duplicates(self, off_x: np.ndarray, pop_x: np.ndarray) -> np.ndarray:
+        """Return a boolean mask of offspring that duplicate the population.
+
+        Parameters
+        ----------
+        off_x : numpy.ndarray of shape (N, dim)
+            Offspring decision vectors.
+        pop_x : numpy.ndarray of shape (M, dim)
+            Current population decision vectors.
+
+        Returns
+        -------
+        numpy.ndarray of shape (N,), dtype bool
+            ``True`` where ``off_x[i]`` is element-wise close to any row of
+            ``pop_x``, using the same ``atol`` / ``rtol`` as
+            :meth:`~saealib.population.archive.ArchiveMixin._find_idx`.
+        """
+        close = np.all(
+            np.isclose(pop_x[None], off_x[:, None], atol=self.atol, rtol=self.rtol),
+            axis=2,
+        )
+        return np.any(close, axis=1)

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -993,3 +993,121 @@ class TestMutationProbGate:
         expected_rate = min(0.5, 1.0 / dim)
         observed_rate = changed / n_trials
         np.testing.assert_allclose(observed_rate, expected_rate, atol=0.05)
+
+
+# ---------------------------------------------------------------------------
+# DuplicateElimination
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateElimination:
+    def test_exact_duplicate_detected(self):
+        from saealib.operators.dedup import DuplicateElimination
+
+        de = DuplicateElimination(atol=1e-16, rtol=0.0)
+        pop = np.array([[0.1, 0.2], [0.3, 0.4]])
+        off = np.array([[0.1, 0.2], [0.5, 0.6]])
+        mask = de.find_duplicates(off, pop)
+        assert mask[0]
+        assert not mask[1]
+
+    def test_within_tolerance_detected(self):
+        from saealib.operators.dedup import DuplicateElimination
+
+        de = DuplicateElimination(atol=1e-6, rtol=0.0)
+        pop = np.array([[0.1, 0.2]])
+        off = np.array([[0.1 + 1e-7, 0.2]])
+        mask = de.find_duplicates(off, pop)
+        assert mask[0]
+
+    def test_outside_tolerance_not_detected(self):
+        from saealib.operators.dedup import DuplicateElimination
+
+        de = DuplicateElimination(atol=1e-10, rtol=0.0)
+        pop = np.array([[0.1, 0.2]])
+        off = np.array([[0.1 + 1e-9, 0.2]])
+        mask = de.find_duplicates(off, pop)
+        assert not mask[0]
+
+    def test_empty_offspring_returns_empty_mask(self):
+        from saealib.operators.dedup import DuplicateElimination
+
+        de = DuplicateElimination()
+        pop = np.array([[0.1, 0.2]])
+        off = np.empty((0, 2))
+        mask = de.find_duplicates(off, pop)
+        assert mask.shape == (0,)
+        assert mask.dtype == bool
+
+    def test_no_duplicates_all_false(self):
+        from saealib.operators.dedup import DuplicateElimination
+
+        de = DuplicateElimination()
+        pop = np.array([[0.1, 0.2], [0.3, 0.4]])
+        off = np.array([[0.5, 0.6], [0.7, 0.8]])
+        mask = de.find_duplicates(off, pop)
+        assert not mask.any()
+
+    def test_ga_stores_duplicate_elimination_attribute(self):
+        from saealib.operators.dedup import DuplicateElimination
+
+        de = DuplicateElimination(atol=1e-10, rtol=0.0, max_retries=5)
+        ga = GA(
+            crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
+            mutation=MutationPolynomial(prob=1.0, eta=20.0, prob_var=1.0),
+            parent_selection=SequentialSelection(),
+            survivor_selection=TruncationSelection(),
+            duplicate_elimination=de,
+        )
+        assert ga.duplicate_elimination is de
+
+    def test_ga_with_dedup_returns_correct_count(self):
+        """GA with duplicate_elimination set produces expected offspring count."""
+        from saealib.operators.dedup import DuplicateElimination
+
+        de = DuplicateElimination()
+        ga = GA(
+            crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
+            mutation=MutationPolynomial(prob=1.0, eta=20.0, prob_var=1.0),
+            parent_selection=SequentialSelection(),
+            survivor_selection=TruncationSelection(),
+            duplicate_elimination=de,
+        )
+        provider = _DispatchOnlyProvider()
+        ctx = _make_ctx(n_pop=10)
+        candidates = ga.ask(ctx, provider)
+        assert len(candidates) == 10
+
+    def test_ga_dedup_retries_when_offspring_are_copies(self):
+        """With no-op crossover and no-op mutation, retries exhaust without crash."""
+        from saealib.operators.dedup import DuplicateElimination
+
+        # prob=0.0 crossover → offspring = parent copies (always duplicates)
+        # prob_var=0.0 mutation → no variables mutated → still copies after each retry
+        # dedup exhausts max_retries without fixing any, but must not raise
+        de = DuplicateElimination(atol=1e-14, rtol=0.0, max_retries=3)
+        ga = GA(
+            crossover=CrossoverBLXAlpha(prob=0.0, alpha=0.4),
+            mutation=MutationUniform(prob_var=0.0),
+            parent_selection=SequentialSelection(),
+            survivor_selection=TruncationSelection(),
+            duplicate_elimination=de,
+        )
+        provider = _DispatchOnlyProvider()
+        ctx = _make_ctx(n_pop=10)
+        candidates = ga.ask(ctx, provider)
+        assert len(candidates) == 10
+
+    def test_ga_none_dedup_preserves_behavior(self):
+        """GA with duplicate_elimination=None must not raise."""
+        ga = GA(
+            crossover=CrossoverBLXAlpha(prob=0.9, alpha=0.4),
+            mutation=MutationPolynomial(prob=1.0, eta=20.0, prob_var=1.0),
+            parent_selection=SequentialSelection(),
+            survivor_selection=TruncationSelection(),
+            duplicate_elimination=None,
+        )
+        provider = _DispatchOnlyProvider()
+        ctx = _make_ctx(n_pop=10)
+        candidates = ga.ask(ctx, provider)
+        assert len(candidates) == 10


### PR DESCRIPTION
## Related Issue
Closes #190

## Overview
The `ask` method in GA generates `offspring` objects, but it did not perform duplicate elimination, which was causing a performance degradation. We added an optional parameter to enable duplicate elimination and implemented the `DuplicateElimination` class to handle it.

## Changes
- Addition of Duplicate Elimination
- Added duplicate elimination processing to GA.ask

## verification step
- pytest
- ruff format
- ruff check --fix
- ty check