### PR TITLE
docs: [#194] fix README Quick Start API mismatches and align CONTRIBUTING testing policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,38 +114,10 @@ pytest
 
 1. **Smoke Tests**: Checks if the example code runs without errors.
 2. **Unit Tests**: Verifies data structures (`Population`) and deterministic logic (`Repair`, `Constraints`).
-3. **Regression Tests (Fixed Seed)**: Checks if the optimization results exactly match the recorded snapshots using a fixed random seed.
-
-#### Handling Regression Test Failures
-
-`test_integration` serves as both regression testing and integration testing.
-If `test_integration` fails, check the following:
-
-* **Case A: Refactoring (No logic change)**
-    * **Goal**: The results must match bit-for-bit.
-    * **Action**: If the test fails, you likely introduced a bug. Fix your code. **Do not update the snapshot.**
-
-
-* **Case B: Logic Change / Feature Addition**
-    * **Goal**: The results are expected to change.
-    * **Action**:
-        1. Run the snapshot generation script:
-        ```bash
-        python scripts/generate_test_integration.py
-        ```
-        2. Check the diff of `tests/data/test_integration.json`.
-        3. Verify if the performance has improved (lower objective value) or stayed within an acceptable range. **Significant degradation is not allowed.**
-        4. Commit the updated snapshot file along with your code changes.
+3. **Fixed-Seed Integration Tests**: Runs a full optimization with a fixed random seed and asserts the result stays within an acceptable threshold (e.g., `test_integration`). If this fails, check whether your change unintentionally degraded optimization performance.
 
 
 ### 5. Pull Request Guidelines
 
 1. Ensure all tests pass locally.
-2. If you updated the regression snapshots, please include a summary of the changes in the PR description:
-> **Regression Update**
-> * Seed 0: `1.234` -> `0.987` (Improved)
-> * Seed 1: `2.345` -> `2.350` (Neutral)
-> 
-
-
-3. Use the provided Pull Request Template.
+2. Use the provided Pull Request Template.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ from saealib import (
     GA,
     Optimizer,
     Problem,
-    RBFsurrogate,
+    RBFSurrogate,
     LHSInitializer,
     CrossoverBLXAlpha,
     MutationUniform,
@@ -105,7 +105,7 @@ problem = Problem(
     func=sphere,
     dim=dim,
     n_obj=1,
-    weight=np.array([-1.0]),  # -1.0 implies minimization
+    direction=np.array([-1.0]),  # -1.0 implies minimization
     lb=[-5.0] * dim,          # Lower bounds
     ub=[5.0] * dim,           # Upper bounds
 )
@@ -121,14 +121,14 @@ initializer = LHSInitializer(
 
 # Algorithm: Genetic Algorithm
 algorithm = GA(
-    crossover=CrossoverBLXAlpha(crossover_rate=0.7, alpha=0.4),
-    mutation=MutationUniform(mutation_rate=0.3),
+    crossover=CrossoverBLXAlpha(prob=0.7, alpha=0.4),
+    mutation=MutationUniform(prob_var=0.3),
     parent_selection=SequentialSelection(),
     survivor_selection=TruncationSelection(),
 )
 
 # Surrogate Model: RBF with Gaussian Kernel
-surrogate = RBFsurrogate(gaussian_kernel, dim)
+surrogate = RBFSurrogate(gaussian_kernel, dim)
 
 # Strategy: Individual-Based Management
 # evaluation_ratio=0.1: Ratio of offspring selected for true objective evaluation


### PR DESCRIPTION
## Related Issue
Closes #194

## Overview

## Changes
- Fix `RBFsurrogate` typo and outdated parameter names (`weight`, `crossover_rate`, `mutation_rate`) in the README Quick Start example so it actually runs against the current API
- Simplify CONTRIBUTING.md's Testing Policy section to match the actual fixed-seed smoke test (`test_integration`); remove the description of a JSON snapshot regeneration workflow that does not exist in the repo

## Verification Steps
- Extracted and ran the README Quick Start code block directly; it completes without error
- pytest tests/ — 1667 passed

## Concerns

## Other