### PR TITLE
fix: bug fix bundle: direction handling, pipeline rebuild, RNG/eps_cv sync

### DIFF
--- a/src/saealib/acquisition/base.py
+++ b/src/saealib/acquisition/base.py
@@ -17,6 +17,31 @@ if TYPE_CHECKING:
     from saealib.surrogate.prediction import SurrogatePrediction
 
 
+def direction_to_minimize_sign(direction: np.ndarray | None) -> np.ndarray | float:
+    """Return the multiplicative sign converting objectives to minimize-space.
+
+    Every direction-sensitive acquisition function's formulas are written
+    assuming minimization. Multiplying a raw-objective-space quantity
+    (``archive.f``, ``prediction.value``, a user-supplied ``reference``) by
+    this sign converts it into minimize-space before the formula runs.
+    Uncertainty magnitudes (``prediction.std``, ``sigma``) must never be
+    multiplied by this sign.
+
+    Parameters
+    ----------
+    direction : np.ndarray or None
+        Per-objective optimization direction (+1 = maximize, -1 = minimize).
+        shape: (n_obj,). ``None`` means already-minimize.
+
+    Returns
+    -------
+    np.ndarray or float
+        ``-direction`` if *direction* is given, else the scalar ``1.0``.
+        Both broadcast correctly against ``(n_obj,)`` or ``(n, n_obj)`` arrays.
+    """
+    return -direction if direction is not None else 1.0
+
+
 class AcquisitionFunction(ABC):
     """
     Abstract base class for acquisition functions (infill criteria).
@@ -30,6 +55,10 @@ class AcquisitionFunction(ABC):
 
     # Optimizer.validate() cross-checks this with surrogate.provides_uncertainty.
     requires_uncertainty: bool = False
+
+    # Optimizer._inject_acquisition_directions() only auto-injects
+    # problem.direction into acquisition functions that opt in via this flag.
+    direction_sensitive: bool = True
 
     @abstractmethod
     def compute_reference(

--- a/src/saealib/acquisition/ehvi.py
+++ b/src/saealib/acquisition/ehvi.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import numpy.typing as npt
 
-from saealib.acquisition.base import AcquisitionFunction
+from saealib.acquisition.base import AcquisitionFunction, direction_to_minimize_sign
 from saealib.surrogate.prediction import SurrogatePrediction
 from saealib.utils.indicators import _non_dominated, hypervolume
 
@@ -27,15 +27,26 @@ class EHVIAcquisition(AcquisitionFunction):
 
     where HVI(y, P, r) = HV(P u {y}, r) - HV(P, r).
 
+    ``archive.f``, ``reference_point``, and the predicted mean are internally
+    converted to minimisation convention via ``direction_to_minimize_sign``
+    (see ``direction`` below) before the formula above runs.
+
     Parameters
     ----------
     n_samples : int
         Number of MC samples per candidate.  Default: 256.
     reference_point : array-like or None
-        Hypervolume reference point (minimisation convention).  If None,
-        auto-computed from the archive nadir with a 10 % margin.
+        Hypervolume reference point, given in raw objective space (i.e. in
+        the same convention as ``problem.direction``, not necessarily
+        minimisation).  If None, auto-computed from the archive nadir with
+        a 10 % margin.
     rng : np.random.Generator or None
         Random number generator for MC sampling.
+    direction : np.ndarray or None
+        Per-objective optimization direction (+1 = maximize, -1 = minimize).
+        shape: (n_obj,). ``None`` (default) means already-minimize, so
+        behaviour for existing minimize-only callers is unchanged; when
+        unset, it is auto-injected from ``problem.direction`` at run start.
     """
 
     requires_uncertainty: bool = True
@@ -45,6 +56,7 @@ class EHVIAcquisition(AcquisitionFunction):
         n_samples: int = 256,
         reference_point: npt.ArrayLike | None = None,
         rng: np.random.Generator | None = None,
+        direction: np.ndarray | None = None,
     ) -> None:
         self.n_samples = n_samples
         self.reference_point = (
@@ -53,6 +65,7 @@ class EHVIAcquisition(AcquisitionFunction):
             else None
         )
         self._rng = rng if rng is not None else np.random.default_rng()
+        self.direction = direction
 
     def compute_reference(
         self,
@@ -73,11 +86,12 @@ class EHVIAcquisition(AcquisitionFunction):
             ``(pareto_f, ref_point, base_hv)`` — non-dominated objective
             matrix, hypervolume reference point, and current hypervolume.
         """
-        f = archive.f
+        s = direction_to_minimize_sign(self.direction)
+        f = archive.f * s
         pareto_f = _non_dominated(f)
 
         if self.reference_point is not None:
-            ref = self.reference_point
+            ref = self.reference_point * s
         else:
             nadir = f.max(axis=0)
             span = nadir - f.min(axis=0)
@@ -123,14 +137,15 @@ class EHVIAcquisition(AcquisitionFunction):
             )
         pareto_f, ref_point, base_hv = reference
         assert prediction.std is not None
-        mu = prediction.value  # (n_cand, n_obj)
+        s = direction_to_minimize_sign(self.direction)
+        mu_conv = prediction.value * s  # (n_cand, n_obj)
         sigma = prediction.std  # (n_cand, n_obj)
-        n_cand, n_obj = mu.shape
+        n_cand, n_obj = mu_conv.shape
 
         # Draw all MC samples at once: (n_samples, n_cand, n_obj)
         _rng = rng if rng is not None else self._rng
         eps = _rng.standard_normal((self.n_samples, n_cand, n_obj))
-        mc_samples = mu[np.newaxis] + sigma[np.newaxis] * eps
+        mc_samples = mu_conv[np.newaxis] + sigma[np.newaxis] * eps
 
         ehvi = np.zeros(n_cand)
         for i in range(n_cand):

--- a/src/saealib/acquisition/ei.py
+++ b/src/saealib/acquisition/ei.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from scipy.stats import norm
 
-from saealib.acquisition.base import AcquisitionFunction
+from saealib.acquisition.base import AcquisitionFunction, direction_to_minimize_sign
 from saealib.surrogate.prediction import SurrogatePrediction
 
 if TYPE_CHECKING:
@@ -37,22 +37,39 @@ class ExpectedImprovement(AcquisitionFunction):
     obj_idx : int
         Index of the objective to optimize. Used for multi-objective
         problems where EI is applied to a single objective. Default: 0.
+    direction : np.ndarray or None
+        Per-objective optimization direction (+1 = maximize, -1 = minimize).
+        shape: (n_obj,). ``archive.f``, a user-supplied ``reference``, and
+        the predicted mean are converted to minimize-space via
+        ``direction_to_minimize_sign`` before the (minimize-only) EI formula
+        above runs. ``None`` (default) means already-minimize; when unset,
+        it is auto-injected from ``problem.direction`` at run start.
     """
 
     requires_uncertainty: bool = True
 
-    def __init__(self, xi: float = 0.01, obj_idx: int = 0, reference: Any = None):
+    def __init__(
+        self,
+        xi: float = 0.01,
+        obj_idx: int = 0,
+        reference: Any = None,
+        direction: np.ndarray | None = None,
+    ):
         self.xi = xi
         self.obj_idx = obj_idx
         self.reference = reference
+        self.direction = direction
 
     def compute_reference(
         self, archive: Archive, rng: np.random.Generator | None = None
     ) -> np.ndarray:
         """Return fixed reference if set, otherwise component-wise best from archive."""
         if self.reference is not None:
-            return self.reference
-        return archive.f.min(axis=0)
+            return np.asarray(self.reference, dtype=float) * direction_to_minimize_sign(
+                self.direction
+            )
+        s = direction_to_minimize_sign(self.direction)
+        return (archive.f * s).min(axis=0)
 
     def score(
         self,
@@ -87,7 +104,13 @@ class ExpectedImprovement(AcquisitionFunction):
                 "estimates (prediction.std must not be None)."
             )
         assert prediction.std is not None
-        mu = prediction.value[:, self.obj_idx]  # (n_samples,)
+        s = direction_to_minimize_sign(self.direction)
+        s_idx = (
+            s[self.obj_idx]  # type: ignore  # ty narrows bare np.ndarray isinstance to object dtype; s is float ndarray at runtime
+            if isinstance(s, np.ndarray)
+            else s
+        )
+        mu = prediction.value[:, self.obj_idx] * s_idx  # (n_samples,)
         sigma = prediction.std[:, self.obj_idx]  # (n_samples,)
 
         ref = np.asarray(reference, dtype=float)

--- a/src/saealib/acquisition/lcb.py
+++ b/src/saealib/acquisition/lcb.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from saealib.acquisition.base import AcquisitionFunction
+from saealib.acquisition.base import AcquisitionFunction, direction_to_minimize_sign
 from saealib.surrogate.prediction import SurrogatePrediction
 
 if TYPE_CHECKING:
@@ -36,14 +36,27 @@ class LowerConfidenceBound(AcquisitionFunction):
     obj_idx : int
         Index of the objective to optimize. Used for multi-objective
         problems where LCB is applied to a single objective. Default: 0.
+    direction : np.ndarray or None
+        Per-objective optimization direction (+1 = maximize, -1 = minimize).
+        shape: (n_obj,). The predicted mean is converted to minimize-space
+        via ``direction_to_minimize_sign`` before the (minimize-only) LCB
+        formula above runs. ``None`` (default) means already-minimize; when
+        unset, it is auto-injected from ``problem.direction`` at run start.
     """
 
     requires_uncertainty: bool = True
 
-    def __init__(self, kappa: float = 2.0, obj_idx: int = 0, reference: Any = None):
+    def __init__(
+        self,
+        kappa: float = 2.0,
+        obj_idx: int = 0,
+        reference: Any = None,
+        direction: np.ndarray | None = None,
+    ):
         self.kappa = kappa
         self.obj_idx = obj_idx
         self.reference = reference
+        self.direction = direction
 
     def compute_reference(
         self, archive: Archive, rng: np.random.Generator | None = None
@@ -83,6 +96,12 @@ class LowerConfidenceBound(AcquisitionFunction):
                 "estimates (prediction.std must not be None)."
             )
         assert prediction.std is not None
-        mu = prediction.value[:, self.obj_idx]  # (n_samples,)
+        s = direction_to_minimize_sign(self.direction)
+        s_idx = (
+            s[self.obj_idx]  # type: ignore  # ty narrows bare np.ndarray isinstance to object dtype; s is float ndarray at runtime
+            if isinstance(s, np.ndarray)
+            else s
+        )
+        mu = prediction.value[:, self.obj_idx] * s_idx  # (n_samples,)
         sigma = prediction.std[:, self.obj_idx]  # (n_samples,)
         return -(mu - self.kappa * sigma)  # negate: higher = better

--- a/src/saealib/acquisition/mean.py
+++ b/src/saealib/acquisition/mean.py
@@ -37,7 +37,8 @@ class MeanPrediction(AcquisitionFunction):
     direction : np.ndarray or None
         Per-objective optimization directions (+1 = maximize, -1 = minimize).
         Used for direction-only scalarization when magnitude does not matter.
-        Takes precedence over weights when both are provided.
+        Takes precedence over weights when both are provided. When unset,
+        it is auto-injected from ``problem.direction`` at run start.
     """
 
     def __init__(

--- a/src/saealib/acquisition/parego.py
+++ b/src/saealib/acquisition/parego.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 from scipy.stats import norm
 
-from saealib.acquisition.base import AcquisitionFunction
+from saealib.acquisition.base import AcquisitionFunction, direction_to_minimize_sign
 from saealib.surrogate.prediction import SurrogatePrediction
 
 if TYPE_CHECKING:
@@ -46,6 +46,13 @@ class ParEGOAcquisition(AcquisitionFunction):
         Default: 0.05 (mlr3mbo convention).
     rng : np.random.Generator or None
         Random number generator for weight sampling.
+    direction : np.ndarray or None
+        Per-objective optimization direction (+1 = maximize, -1 = minimize).
+        shape: (n_obj,). ``archive.f`` and the predicted mean are converted
+        to minimize-space via ``direction_to_minimize_sign`` before the
+        (minimize-only) scalarisation above runs. ``None`` (default) means
+        already-minimize; when unset, it is auto-injected from
+        ``problem.direction`` at run start.
     """
 
     requires_uncertainty: bool = True
@@ -54,9 +61,11 @@ class ParEGOAcquisition(AcquisitionFunction):
         self,
         alpha: float = 0.05,
         rng: np.random.Generator | None = None,
+        direction: np.ndarray | None = None,
     ) -> None:
         self.alpha = alpha
         self._rng = rng if rng is not None else np.random.default_rng()
+        self.direction = direction
 
     def _scalarize(
         self,
@@ -95,9 +104,11 @@ class ParEGOAcquisition(AcquisitionFunction):
             these weights.
         """
         n_obj = archive.f.shape[1]
-        z_star = archive.f.min(axis=0)
+        s = direction_to_minimize_sign(self.direction)
+        f_conv = archive.f * s
+        z_star = f_conv.min(axis=0)
         weights = (rng if rng is not None else self._rng).dirichlet(np.ones(n_obj))
-        f_best = float(self._scalarize(archive.f, weights, z_star).min())
+        f_best = float(self._scalarize(f_conv, weights, z_star).min())
         return z_star, weights, f_best
 
     def score(
@@ -133,7 +144,9 @@ class ParEGOAcquisition(AcquisitionFunction):
             )
         z_star, weights, f_best = reference
 
-        mu_s = self._scalarize(prediction.value, weights, z_star)  # (n,)
+        s = direction_to_minimize_sign(self.direction)
+        mu_conv = prediction.value * s
+        mu_s = self._scalarize(mu_conv, weights, z_star)  # (n,)
         sigma_s = (weights * prediction.std).sum(axis=-1)  # (n,)
         sigma_s = np.maximum(sigma_s, 1e-9)
 

--- a/src/saealib/acquisition/pof.py
+++ b/src/saealib/acquisition/pof.py
@@ -35,6 +35,8 @@ class ProbabilityOfFeasibility(AcquisitionFunction):
     """
 
     requires_uncertainty: bool = True
+    # Feasibility probability has no notion of objective direction.
+    direction_sensitive: bool = False
 
     def __init__(self, obj_idx: int = 0, reference: Any = None):
         self.obj_idx = obj_idx
@@ -128,6 +130,8 @@ class ProductOfFeasibility(AcquisitionFunction):
     """
 
     requires_uncertainty: bool = True
+    # Feasibility probability has no notion of objective direction.
+    direction_sensitive: bool = False
 
     def compute_reference(
         self, archive: Archive, rng: np.random.Generator | None = None

--- a/src/saealib/acquisition/smsego.py
+++ b/src/saealib/acquisition/smsego.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import numpy.typing as npt
 
-from saealib.acquisition.base import AcquisitionFunction
+from saealib.acquisition.base import AcquisitionFunction, direction_to_minimize_sign
 from saealib.surrogate.prediction import SurrogatePrediction
 from saealib.utils.indicators import _non_dominated, hypervolume
 
@@ -31,13 +31,24 @@ class SMSEGOAcquisition(AcquisitionFunction):
 
         SMS(x) = HV(P u {y_hat(x)}, r) - HV(P, r)
 
+    ``archive.f``, ``reference_point``, and the predicted mean are internally
+    converted to minimisation convention via ``direction_to_minimize_sign``
+    (see ``direction`` below) before the formulas above run.
+
     Parameters
     ----------
     lam : float
         LCB width parameter λ.  Default: 1.0 (mlr3mbo convention).
     reference_point : array-like or None
-        Hypervolume reference point (minimisation convention).  If None,
-        auto-computed from the archive nadir with a 10 % margin.
+        Hypervolume reference point, given in raw objective space (i.e. in
+        the same convention as ``problem.direction``, not necessarily
+        minimisation).  If None, auto-computed from the archive nadir with
+        a 10 % margin.
+    direction : np.ndarray or None
+        Per-objective optimization direction (+1 = maximize, -1 = minimize).
+        shape: (n_obj,). ``None`` (default) means already-minimize, so
+        behaviour for existing minimize-only callers is unchanged; when
+        unset, it is auto-injected from ``problem.direction`` at run start.
     """
 
     requires_uncertainty: bool = True
@@ -46,6 +57,7 @@ class SMSEGOAcquisition(AcquisitionFunction):
         self,
         lam: float = 1.0,
         reference_point: npt.ArrayLike | None = None,
+        direction: np.ndarray | None = None,
     ) -> None:
         self.lam = lam
         self.reference_point = (
@@ -53,6 +65,7 @@ class SMSEGOAcquisition(AcquisitionFunction):
             if reference_point is not None
             else None
         )
+        self.direction = direction
 
     def compute_reference(
         self,
@@ -73,11 +86,12 @@ class SMSEGOAcquisition(AcquisitionFunction):
             ``(pareto_f, ref_point, base_hv)`` — non-dominated objective
             matrix, hypervolume reference point, and current hypervolume.
         """
-        f = archive.f
+        s = direction_to_minimize_sign(self.direction)
+        f = archive.f * s
         pareto_f = _non_dominated(f)
 
         if self.reference_point is not None:
-            ref = self.reference_point
+            ref = self.reference_point * s
         else:
             nadir = f.max(axis=0)
             span = nadir - f.min(axis=0)
@@ -119,7 +133,8 @@ class SMSEGOAcquisition(AcquisitionFunction):
             )
         pareto_f, ref_point, base_hv = reference
         assert prediction.std is not None
-        lcb = prediction.value - self.lam * prediction.std  # (n, n_obj)
+        s = direction_to_minimize_sign(self.direction)
+        lcb = prediction.value * s - self.lam * prediction.std  # (n, n_obj)
         n = lcb.shape[0]
         hvi = np.zeros(n)
 

--- a/src/saealib/acquisition/uncertainty.py
+++ b/src/saealib/acquisition/uncertainty.py
@@ -31,6 +31,8 @@ class MaxUncertainty(AcquisitionFunction):
     """
 
     requires_uncertainty: bool = True
+    # Uncertainty magnitude has no notion of objective direction.
+    direction_sensitive: bool = False
 
     def __init__(self, weights: np.ndarray | None = None, reference: Any = None):
         self.weights = weights

--- a/src/saealib/comparators/comparators.py
+++ b/src/saealib/comparators/comparators.py
@@ -144,7 +144,7 @@ class SingleObjectiveComparator(Comparator):
     @deprecated_param("weight", "direction", "0.1.0")
     def __init__(
         self,
-        direction: float = 1.0,
+        direction: float | None = None,
         eps: float | None = None,
         *,
         eps_cv: float = 1e-6,
@@ -153,9 +153,9 @@ class SingleObjectiveComparator(Comparator):
         if eps is not None:
             warn_deprecated("eps", "eps_cv and eps_obj", "0.1.0")
             eps_cv = eps_obj = eps
-        super().__init__(
-            np.array([direction]), eps_cv, eps_obj, direction=np.array([direction])
-        )
+        direction_arr = np.array([direction]) if direction is not None else None
+        weights = direction_arr if direction_arr is not None else np.empty(0)
+        super().__init__(weights, eps_cv, eps_obj, direction=direction_arr)
 
     def sort_population(self, population: Population) -> np.ndarray:
         """
@@ -201,9 +201,12 @@ class SingleObjectiveComparator(Comparator):
         elif cv_a <= self.eps_cv and cv_b > self.eps_cv:
             return -1
         else:
-            if fitness_a[0] < fitness_b[0] - self.eps_obj:
+            d = self.direction[0] if self.direction is not None else -1.0
+            sa = fitness_a[0] * d
+            sb = fitness_b[0] * d
+            if sa > sb + self.eps_obj:
                 return -1
-            elif fitness_a[0] > fitness_b[0] + self.eps_obj:
+            elif sa < sb - self.eps_obj:
                 return 1
             else:
                 return 0
@@ -224,9 +227,9 @@ class SingleObjectiveComparator(Comparator):
         np.ndarray
             Sorted indices of the solutions.
         """
-        assert self.direction is not None
+        d = self.direction[0] if self.direction is not None else -1.0
         cv_key = np.where(cv > self.eps_cv, cv, 0)
-        obj_key = fitness.flatten() * self.direction[0]
+        obj_key = fitness.flatten() * d
         return np.lexsort((-obj_key, cv_key))
 
 
@@ -1095,6 +1098,8 @@ def _normalize_objectives(
         Shape ``(n, n_obj)``.
     direction : np.ndarray or None
         ``+1`` maximize, ``-1`` minimize. ``None`` means all-minimize.
+        Maximize objectives are internally converted to minimize-space
+        (negated) before computing the ideal point and intercepts.
 
     Returns
     -------
@@ -1105,6 +1110,7 @@ def _normalize_objectives(
     intercepts : np.ndarray
         Shape ``(n_obj,)``. Hyperplane intercepts used for scaling.
     """
+    f = f * (-direction) if direction is not None else f
     ideal = f.min(axis=0)
     f_trans = f - ideal
 

--- a/src/saealib/comparators/comparators.py
+++ b/src/saealib/comparators/comparators.py
@@ -43,7 +43,10 @@ class Comparator(ABC):
     weights : np.ndarray
         Weights for objectives. shape = (n_obj, )
     eps_cv : float
-        Epsilon for constraint violation feasibility threshold.
+        Epsilon for constraint violation feasibility threshold. Under
+        ``Optimizer`` execution this value is overwritten every generation
+        from ``problem.handler.feasibility_threshold``; the constructor
+        argument only matters for standalone (non-``Optimizer``) use.
     eps_obj : float
         Epsilon for objective value equality comparison.
     direction : np.ndarray or None

--- a/src/saealib/comparators/comparators.py
+++ b/src/saealib/comparators/comparators.py
@@ -1304,12 +1304,37 @@ class NSGA3Comparator(ParetoComparator):
             dominator=dominator,
         )
         self._reference_points = np.asarray(reference_points, dtype=float)
-        self._rng = np.random.default_rng(seed)
+        self._rng = np.random.default_rng(seed) if seed is not None else None
 
     @property
     def reference_points(self) -> np.ndarray:
         """Reference points used for niche preservation."""
         return self._reference_points
+
+    @property
+    def rng(self) -> np.random.Generator:
+        """
+        Random number generator used for niche tie-breaking.
+
+        Lazily created on first access if no seed was supplied at
+        construction time, so a run-time owner (e.g.
+        :class:`~saealib.execution.runner.Runner`) can inject a generator
+        spawned from the master ``ctx.rng`` before this property is ever
+        read.
+
+        This generator is owned privately by the comparator once injected or
+        lazily created: it advances independently of ``ctx.rng`` and is not
+        part of :meth:`~saealib.context.OptimizationState.save`'s serialized
+        state, so checkpoint resume re-spawns a fresh one rather than
+        continuing this generator's own draw sequence.
+        """
+        if self._rng is None:
+            self._rng = np.random.default_rng()
+        return self._rng
+
+    @rng.setter
+    def rng(self, value: np.random.Generator) -> None:
+        self._rng = value
 
     def sort_population(self, population: Population) -> np.ndarray:
         """Sort by Pareto front rank then NSGA-III niche preservation."""
@@ -1338,7 +1363,7 @@ class NSGA3Comparator(ParetoComparator):
             for front_list in fronts:
                 front_local = np.array(front_list, dtype=int)
                 ordered = _niche_count_select(
-                    front_local, assoc, dist, niche_count, len(front_local), self._rng
+                    front_local, assoc, dist, niche_count, len(front_local), self.rng
                 )
                 sorted_feasible.extend(feasible[ordered].tolist())
 

--- a/src/saealib/context.py
+++ b/src/saealib/context.py
@@ -163,6 +163,12 @@ class OptimizationState:
         the same NumPy version and environment, but not guaranteed across
         versions.
 
+        Only ``self.rng`` is saved. Components that own a private RNG spawned
+        from ``self.rng`` (e.g. :class:`~saealib.comparators.NSGA3Comparator`'s
+        niche tie-breaking generator) are not serialized; on resume, such a
+        component gets a fresh spawn from the restored ``rng`` rather than a
+        continuation of its own pre-checkpoint draw sequence.
+
         Parameters
         ----------
         path : str or Path

--- a/src/saealib/execution/initializer.py
+++ b/src/saealib/execution/initializer.py
@@ -8,6 +8,7 @@ import numpy as np
 import scipy.stats
 
 from saealib.callback import InitialEvaluationEndEvent, InitialEvaluationStartEvent
+from saealib.comparators import NSGA3Comparator
 from saealib.context import OptimizationState
 from saealib.optimizer import ComponentProvider
 from saealib.population import Archive, ParetoArchive, Population, PopulationAttribute
@@ -78,6 +79,12 @@ class Initializer(ABC):
         OptimizationState
             The optimization context.
         """
+        if (
+            isinstance(problem.comparator, NSGA3Comparator)
+            and problem.comparator._rng is None
+        ):
+            problem.comparator.rng = rng.spawn(1)[0]
+
         return OptimizationState(
             problem=problem,
             population=population,

--- a/src/saealib/execution/runner.py
+++ b/src/saealib/execution/runner.py
@@ -11,6 +11,7 @@ from saealib.callback import (
     RunEndEvent,
     RunStartEvent,
 )
+from saealib.comparators import NSGA3Comparator
 from saealib.context import OptimizationState
 
 if TYPE_CHECKING:
@@ -74,6 +75,8 @@ class Runner:
         """
         opt = self.optimizer
         ctx.comparator.eps_cv = ctx.problem.handler.feasibility_threshold
+        if isinstance(ctx.comparator, NSGA3Comparator) and ctx.comparator._rng is None:
+            ctx.comparator.rng = ctx.rng.spawn(1)[0]
 
         opt.dispatch(RunStartEvent(ctx=ctx))
         yield ctx

--- a/src/saealib/execution/runner.py
+++ b/src/saealib/execution/runner.py
@@ -31,6 +31,12 @@ class Runner:
     def __init__(self, optimizer: Optimizer):
         self.optimizer = optimizer
 
+    def _sync_eps_cv(self, ctx: OptimizationState) -> None:
+        """Sync ``eps_cv`` on ``comparator`` and ``pareto_archive`` from the handler."""
+        threshold = ctx.problem.handler.feasibility_threshold
+        ctx.comparator.eps_cv = threshold
+        ctx.pareto_archive.eps_cv = threshold
+
     def run(self) -> OptimizationState:
         """Run to completion and return the final context."""
         for ctx in self.iterate():
@@ -74,7 +80,7 @@ class Runner:
         Generator[OptimizationState, None, None]
         """
         opt = self.optimizer
-        ctx.comparator.eps_cv = ctx.problem.handler.feasibility_threshold
+        self._sync_eps_cv(ctx)
         if isinstance(ctx.comparator, NSGA3Comparator) and ctx.comparator._rng is None:
             ctx.comparator.rng = ctx.rng.spawn(1)[0]
 
@@ -88,7 +94,7 @@ class Runner:
                 ctx = result
             handler = ctx.problem.handler
             handler.on_generation_end(ctx.gen, ctx.population)
-            ctx.comparator.eps_cv = handler.feasibility_threshold
+            self._sync_eps_cv(ctx)
             sm = getattr(opt, "surrogate_manager", None)
             if sm is not None:
                 sm.on_generation_end(ctx.gen, ctx.archive, ctx)

--- a/src/saealib/optimizer.py
+++ b/src/saealib/optimizer.py
@@ -339,6 +339,19 @@ class Optimizer:
                     "(provides_uncertainty=False)"
                 )
 
+            for acq in surrogate_manager.iter_acquisitions():
+                _adir = getattr(acq, "direction", None)
+                if (
+                    _adir is not None
+                    and hasattr(_adir, "__len__")
+                    and len(_adir) > 0
+                    and len(_adir) != self.problem.n_obj
+                ):
+                    issues.append(
+                        f"{type(acq).__name__} direction length ({len(_adir)}) does "
+                        f"not match problem.n_obj ({self.problem.n_obj})"
+                    )
+
         return issues
 
     def _resolve_defaults(self) -> None:
@@ -413,6 +426,24 @@ class Optimizer:
 
         if getattr(self, "termination", None) is None:
             self.termination = Termination(max_fe_cond(200 * self.problem.dim))
+
+    def _inject_acquisition_directions(self) -> None:
+        """Auto-inject ``problem.direction`` into unset acquisition directions.
+
+        Mirrors the "inherit from problem unless explicitly set" contract used
+        for ``NSGA3Comparator.rng`` and ``SingleObjectiveComparator.direction``:
+        an acquisition function that already has an explicit ``direction`` (or
+        opts out via ``direction_sensitive = False``) is left untouched.
+        """
+        surrogate_manager = getattr(self, "surrogate_manager", None)
+        if surrogate_manager is None:
+            return
+        for acq in surrogate_manager.iter_acquisitions():
+            if (
+                getattr(acq, "direction_sensitive", True)
+                and getattr(acq, "direction", None) is None
+            ):
+                acq.direction = self.problem.direction
 
     def _select_preset_name(self, defaults: dict, algorithm: Algorithm | None) -> str:
         if algorithm is not None:
@@ -507,6 +538,7 @@ class Optimizer:
             raise ConfigurationError(
                 "Optimizer misconfigured:\n" + "\n".join(f"  - {m}" for m in issues)
             )
+        self._inject_acquisition_directions()
         if checkpoint_path is not None:
             self._register_checkpoint(
                 checkpoint_path,
@@ -549,6 +581,7 @@ class Optimizer:
             raise ConfigurationError(
                 "Optimizer misconfigured:\n" + "\n".join(f"  - {m}" for m in issues)
             )
+        self._inject_acquisition_directions()
         if checkpoint_path is not None:
             self._register_checkpoint(
                 checkpoint_path,
@@ -580,6 +613,7 @@ class Optimizer:
             raise ConfigurationError(
                 "Optimizer misconfigured:\n" + "\n".join(f"  - {m}" for m in issues)
             )
+        self._inject_acquisition_directions()
         return Runner(self).iterate_from(ctx)
 
     def run_from(self, ctx: OptimizationState) -> OptimizationState:
@@ -601,6 +635,7 @@ class Optimizer:
             raise ConfigurationError(
                 "Optimizer misconfigured:\n" + "\n".join(f"  - {m}" for m in issues)
             )
+        self._inject_acquisition_directions()
         return Runner(self).run_from(ctx)
 
     # ------------------------------------------------------------------

--- a/src/saealib/population/archive.py
+++ b/src/saealib/population/archive.py
@@ -218,6 +218,10 @@ class ParetoMixin:
         Dominance predicate.  ``None`` defaults to ``ParetoDominator()``.
     eps_cv : float, optional
         Feasibility threshold for constraint violation, by default 0.0.
+        Under ``Optimizer`` execution this value is overwritten every
+        generation from ``problem.handler.feasibility_threshold``; the
+        default of 0.0 (strictly feasible only) is only meaningful for
+        standalone (non-``Optimizer``) use of ``ParetoArchive``.
     """
 
     def __init__(

--- a/src/saealib/problem/problem.py
+++ b/src/saealib/problem/problem.py
@@ -49,7 +49,12 @@ class Problem:
     comparator : Comparator
         Comparator instance to compare solutions.
     eps_cv : float
-        Epsilon for constraint violation feasibility threshold.
+        Epsilon for constraint violation feasibility threshold. Only used to
+        seed the default ``handler``/``comparator`` at construction time;
+        mutating this attribute afterwards has no runtime effect. The actual
+        running threshold is ``handler.feasibility_threshold``, which the
+        ``Runner`` syncs into ``comparator``/``pareto_archive`` every
+        generation.
     eps_obj : float
         Epsilon for objective value equality comparison.
     func : callable -> float

--- a/src/saealib/problem/problem.py
+++ b/src/saealib/problem/problem.py
@@ -174,6 +174,8 @@ class Problem:
         )
 
         if comparator is not None:
+            if comparator.direction is None:
+                comparator.direction = direction
             self.comparator = comparator
         elif n_obj == 1:
             self.comparator = SingleObjectiveComparator(

--- a/src/saealib/strategies/base.py
+++ b/src/saealib/strategies/base.py
@@ -36,7 +36,18 @@ def assign_tell_f(
 
 
 class OptimizationStrategy(ABC):
-    """Base class for optimization strategies."""
+    """Base class for optimization strategies.
+
+    Built-in strategies compose their generation logic from ``Pipeline``
+    stages and rebuild that pipeline on every :meth:`step` call, so
+    reassigning components on the provider (e.g. ``provider.algorithm``,
+    ``provider.surrogate_manager``) or mutating a strategy's own parameters
+    mid-run takes effect from the next call onward. This is a convention
+    followed by each built-in strategy via a ``_build_pipeline`` method
+    (not part of this ABC) rather than an enforced contract; a subclass
+    wanting to customize stage composition should override
+    ``_build_pipeline`` following the same pattern.
+    """
 
     # Optimizer.validate() checks this to ensure surrogate_manager is configured.
     requires_surrogate: bool = False

--- a/src/saealib/strategies/direct.py
+++ b/src/saealib/strategies/direct.py
@@ -49,6 +49,9 @@ class DirectStrategy(OptimizationStrategy):
     ) -> OptimizationState:
         """Evaluate all offspring with the true objective function.
 
+        Rebuilds the pipeline each call so component/parameter changes take
+        effect immediately.
+
         Parameters
         ----------
         ctx : OptimizationState
@@ -56,6 +59,5 @@ class DirectStrategy(OptimizationStrategy):
         provider : ComponentProvider
             Component provider.
         """
-        if self.pipeline is None:
-            self.pipeline = self._build_pipeline(provider)
+        self.pipeline = self._build_pipeline(provider)
         return self.pipeline.execute(ctx)

--- a/src/saealib/strategies/gb.py
+++ b/src/saealib/strategies/gb.py
@@ -66,6 +66,9 @@ class GenerationBasedStrategy(OptimizationStrategy):
     ) -> OptimizationState:
         """Run ``gen_ctrl`` surrogate-only generations, then one true-evaluation step.
 
+        Rebuilds the pipeline each call so component/parameter changes take
+        effect immediately.
+
         Parameters
         ----------
         ctx : OptimizationState
@@ -73,6 +76,5 @@ class GenerationBasedStrategy(OptimizationStrategy):
         provider : ComponentProvider
             Component provider.
         """
-        if self.pipeline is None:
-            self.pipeline = self._build_pipeline(provider)
+        self.pipeline = self._build_pipeline(provider)
         return self.pipeline.execute(ctx)

--- a/src/saealib/strategies/ib.py
+++ b/src/saealib/strategies/ib.py
@@ -82,6 +82,9 @@ class IndividualBasedStrategy(OptimizationStrategy):
         """
         Score all offspring with the surrogate, then true-evaluate the top fraction.
 
+        Rebuilds the pipeline each call so component/parameter changes take
+        effect immediately.
+
         Parameters
         ----------
         ctx : OptimizationState
@@ -89,6 +92,5 @@ class IndividualBasedStrategy(OptimizationStrategy):
         provider : ComponentProvider
             Component provider.
         """
-        if self.pipeline is None:
-            self.pipeline = self._build_pipeline(provider)
+        self.pipeline = self._build_pipeline(provider)
         return self.pipeline.execute(ctx)

--- a/src/saealib/strategies/ps.py
+++ b/src/saealib/strategies/ps.py
@@ -84,6 +84,9 @@ class PreSelectionStrategy(OptimizationStrategy):
         """
         Generate a large candidate pool, screen with surrogate, true-evaluate top-k.
 
+        Rebuilds the pipeline each call so component/parameter changes take
+        effect immediately.
+
         Parameters
         ----------
         ctx : OptimizationState
@@ -96,6 +99,5 @@ class PreSelectionStrategy(OptimizationStrategy):
         OptimizationState
             Updated state after one generation step.
         """
-        if self.pipeline is None:
-            self.pipeline = self._build_pipeline(provider)
+        self.pipeline = self._build_pipeline(provider)
         return self.pipeline.execute(ctx)

--- a/src/saealib/surrogate/manager.py
+++ b/src/saealib/surrogate/manager.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import copy
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -158,6 +158,25 @@ class SurrogateManager(ABC):
             predictions[i].value shape: (1, n_obj)
         """
         ...
+
+    def iter_acquisitions(self) -> Iterator[AcquisitionFunction]:
+        """Yield every ``AcquisitionFunction`` owned by this manager.
+
+        Used by ``Optimizer._inject_acquisition_directions()`` to auto-inject
+        ``problem.direction`` into direction-sensitive acquisition functions
+        at run start. The default implementation yields ``self.acquisition``
+        if present (covers ``GlobalSurrogateManager``/``LocalSurrogateManager``)
+        and nothing otherwise (e.g. ``PairwiseSurrogateManager``, which has no
+        acquisition function). ``CompositeSurrogateManager`` overrides this to
+        delegate to its sub-managers.
+
+        Returns
+        -------
+        Iterator[AcquisitionFunction]
+        """
+        acq = getattr(self, "acquisition", None)
+        if acq is not None:
+            yield acq
 
     def post_score(
         self,
@@ -633,6 +652,11 @@ class CompositeSurrogateManager(SurrogateManager):
         for manager in self.managers:
             manager.fit(archive, ctx)
         self.last_accuracy = self.managers[0].last_accuracy
+
+    def iter_acquisitions(self) -> Iterator[AcquisitionFunction]:
+        """Yield the acquisition functions of every sub-manager."""
+        for manager in self.managers:
+            yield from manager.iter_acquisitions()
 
     def score_candidates(
         self,

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -8,6 +8,7 @@ Tests cover:
 - LowerConfidenceBound: negated LCB, kappa parameter, requires uncertainty
 - ProbabilityOfFeasibility: P(g<=0), requires uncertainty
 - AcquisitionFunction: abstract base class cannot be instantiated
+- direction-aware minimize-space conversion for EI/LCB (Issue #198)
 """
 
 import numpy as np
@@ -23,6 +24,7 @@ from saealib.acquisition import (
     ProbabilityOfFeasibility,
     ProductOfFeasibility,
 )
+from saealib.population import Archive, PopulationAttribute
 from saealib.surrogate.prediction import SurrogatePrediction
 
 
@@ -34,6 +36,18 @@ def _pred(value, std=None):
     m = np.asarray(value, dtype=float)
     s = np.asarray(std, dtype=float) if std is not None else None
     return SurrogatePrediction(value=m, std=s)
+
+
+def _archive(rows):
+    """Build a single-objective Archive from objective-value rows."""
+    attrs = [
+        PopulationAttribute(name="x", dtype=np.float64, shape=(1,)),
+        PopulationAttribute(name="f", dtype=np.float64, shape=(1,)),
+    ]
+    arc = Archive(attrs, init_capacity=len(rows) + 5)
+    for i, f_row in enumerate(rows):
+        arc.add(x=np.array([float(i)]), f=np.asarray(f_row, dtype=float))
+    return arc
 
 
 # ===========================================================================
@@ -392,3 +406,73 @@ class TestProductOfFeasibility:
         pred = _pred(value=[[mu1, mu2]], std=[[s1, s2]])
         scores = ProductOfFeasibility().score(pred)
         assert scores[0] == pytest.approx(expected, rel=1e-5)
+
+
+# ===========================================================================
+# Direction-aware minimize-space conversion (Issue #198)
+# ===========================================================================
+class TestDirectionSensitivity:
+    """
+    EI/LCB internally convert to minimize-space via ``direction`` before
+    running their (minimize-only) formulas. Scoring (mu, sigma) under
+    ``direction=+1`` (maximize) must mirror scoring (-mu, sigma) under
+    ``direction=-1`` (minimize) exactly, since ``direction=-1`` is a no-op
+    conversion (sign=+1.0), anchoring the maximize side to already-verified
+    minimize behavior.
+    """
+
+    def test_ei_maximize_mirrors_minimize_negated(self) -> None:
+        archive_rows = [[2.0], [0.0], [-1.0]]
+        mu = np.array([[1.0], [3.0], [-2.0], [0.5]])
+        sigma = np.full((4, 1), 0.5)
+
+        af_max = ExpectedImprovement(xi=0.0, direction=np.array([1.0]))
+        af_min = ExpectedImprovement(xi=0.0, direction=np.array([-1.0]))
+
+        ref_max = af_max.compute_reference(_archive(archive_rows))
+        ref_min = af_min.compute_reference(_archive([[-v[0]] for v in archive_rows]))
+
+        scores_max = af_max.score(_pred(mu, sigma), ref_max)
+        scores_min = af_min.score(_pred(-mu, sigma), ref_min)
+
+        np.testing.assert_allclose(scores_max, scores_min)
+        assert np.argsort(scores_max).tolist() == np.argsort(scores_min).tolist()
+
+    def test_lcb_maximize_mirrors_minimize_negated(self) -> None:
+        mu = np.array([[1.0], [3.0], [-2.0], [0.5]])
+        sigma = np.full((4, 1), 0.3)
+
+        af_max = LowerConfidenceBound(kappa=1.5, direction=np.array([1.0]))
+        af_min = LowerConfidenceBound(kappa=1.5, direction=np.array([-1.0]))
+
+        scores_max = af_max.score(_pred(mu, sigma), reference=None)
+        scores_min = af_min.score(_pred(-mu, sigma), reference=None)
+
+        np.testing.assert_allclose(scores_max, scores_min)
+        assert np.argsort(scores_max).tolist() == np.argsort(scores_min).tolist()
+
+    def test_ei_direction_none_matches_direction_minus_one(self) -> None:
+        """Default (direction=None) is a no-op, same as an explicit -1."""
+        pred = _pred(value=[[1.5]], std=[[0.5]])
+        s_default = ExpectedImprovement(xi=0.0).score(pred, reference=2.0)
+        s_explicit = ExpectedImprovement(xi=0.0, direction=np.array([-1.0])).score(
+            pred, reference=2.0
+        )
+        np.testing.assert_allclose(s_default, s_explicit)
+
+
+class TestDirectionSensitiveOptOut:
+    """PoF/ProductOfFeasibility/MaxUncertainty opt out via direction_sensitive=False."""
+
+    def test_probability_of_feasibility_opts_out(self) -> None:
+        assert ProbabilityOfFeasibility.direction_sensitive is False
+
+    def test_product_of_feasibility_opts_out(self) -> None:
+        assert ProductOfFeasibility.direction_sensitive is False
+
+    def test_max_uncertainty_opts_out(self) -> None:
+        assert MaxUncertainty.direction_sensitive is False
+
+    def test_ei_lcb_parego_smsego_ehvi_are_direction_sensitive(self) -> None:
+        assert ExpectedImprovement.direction_sensitive is True
+        assert LowerConfidenceBound.direction_sensitive is True

--- a/tests/test_direct_strategy.py
+++ b/tests/test_direct_strategy.py
@@ -125,14 +125,14 @@ class TestDirectStrategy:
         strategy.step(ctx, provider)
         assert isinstance(strategy.pipeline, Pipeline)
 
-    def test_pipeline_reused_across_steps(self):
+    def test_pipeline_rebuilt_across_steps(self):
         strategy = DirectStrategy()
         ctx = _make_ctx()
         provider = _MockProvider()
         strategy.step(ctx, provider)
         first = strategy.pipeline
         strategy.step(ctx, provider)
-        assert strategy.pipeline is first
+        assert strategy.pipeline is not first
 
     def test_generation_incremented(self):
         strategy = DirectStrategy()

--- a/tests/test_epsilon_constraint_handler.py
+++ b/tests/test_epsilon_constraint_handler.py
@@ -265,3 +265,35 @@ def test_comparator_eps_cv_decreases_each_generation():
     for i in range(1, len(eps_history)):
         assert eps_history[i] < eps_history[i - 1]
     assert eps_history[-1] == pytest.approx(0.0)
+
+
+def test_pareto_archive_eps_cv_synced_each_generation():
+    """ctx.pareto_archive.eps_cv tracks handler.feasibility_threshold (Issue #200)."""
+    from saealib import GenerationEndEvent
+
+    n_gen = 5
+    h = EpsilonConstraintHandler(linear_epsilon_schedule(eps0=1.0, n_gen=n_gen))
+    prob = _make_constrained_problem(h)
+    opt = _make_optimizer(prob, n_gen=n_gen)
+
+    def _check(e):
+        assert e.ctx.pareto_archive.eps_cv == pytest.approx(
+            e.ctx.problem.handler.feasibility_threshold
+        )
+        assert e.ctx.pareto_archive.eps_cv == pytest.approx(e.ctx.comparator.eps_cv)
+
+    opt.cbmanager.register(GenerationEndEvent, _check)
+    opt.run()
+
+
+def test_standalone_pareto_archive_eps_cv_default_unaffected():
+    """A ParetoArchive never touched by Runner keeps its 0.0 default (Issue #200)."""
+    from saealib.population import ParetoArchive, PopulationAttribute
+
+    attrs = [
+        PopulationAttribute(name="x", dtype=np.float64, shape=(1,)),
+        PopulationAttribute(name="f", dtype=np.float64, shape=(1,)),
+        PopulationAttribute(name="cv", dtype=np.float64, shape=()),
+    ]
+    archive = ParetoArchive(attrs, init_capacity=5)
+    assert archive.eps_cv == pytest.approx(0.0)

--- a/tests/test_moo.py
+++ b/tests/test_moo.py
@@ -19,6 +19,7 @@ import pytest
 from saealib import (
     GA,
     CrossoverBLXAlpha,
+    DirectStrategy,
     IndividualBasedStrategy,
     LHSInitializer,
     MutationUniform,
@@ -34,6 +35,7 @@ from saealib import (
     crowding_distance_all_fronts,
     gaussian_kernel,
     max_fe,
+    max_gen,
     non_dominated_sort,
     spea2_fitness,
 )
@@ -81,6 +83,60 @@ def _make_pop(f_values: np.ndarray, cv_values: np.ndarray | None = None) -> Popu
     for i in range(n):
         pop.append(f=f_values[i], cv=float(cv_values[i]))
     return pop
+
+
+def _nsga3_tie_population_f() -> np.ndarray:
+    """5-point front with 3 exact duplicates in one niche (Issue #199).
+
+    All points lie on the segment f1+f2=1, so no point dominates another and
+    the whole set forms a single Pareto front. The 3 duplicates at (0.5, 0.5)
+    guarantee ``_niche_count_select``'s ``rng.choice(candidates)`` branch is
+    hit with more than one candidate at least once, exercising the tie-break.
+    """
+    return np.array(
+        [
+            [0.0, 1.0],
+            [1.0, 0.0],
+            [0.5, 0.5],
+            [0.5, 0.5],
+            [0.5, 0.5],
+        ]
+    )
+
+
+def _nsga3_first_ctx(seed: int, reference_points: np.ndarray):
+    """Build an ``Optimizer(seed=seed)`` wired with an unseeded NSGA3Comparator.
+
+    Returns the context yielded immediately after ``RunStartEvent``, which is
+    already past the point where ``Runner`` injects a spawned ``rng`` into an
+    unseeded ``NSGA3Comparator`` (Issue #199), so no generation needs to run
+    to observe reproducibility.
+    """
+    dim = 2
+    problem = Problem(
+        func=lambda x: np.array([np.sum(x**2), np.sum((x - 2.0) ** 2)]),
+        dim=dim,
+        n_obj=2,
+        direction=np.array([-1.0, -1.0]),
+        lb=[0.0] * dim,
+        ub=[2.0] * dim,
+        comparator=NSGA3Comparator(reference_points, seed=None),
+    )
+    initializer = LHSInitializer(n_init_archive=10, n_init_population=8, seed=seed)
+    algorithm = GA(
+        crossover=CrossoverBLXAlpha(prob=0.7, alpha=0.4),
+        mutation=MutationUniform(prob_var=0.3),
+        parent_selection=SequentialSelection(),
+        survivor_selection=TruncationSelection(),
+    )
+    opt = (
+        Optimizer(problem, seed=seed)
+        .set_initializer(initializer)
+        .set_algorithm(algorithm)
+        .set_termination(Termination(max_gen(0)))
+        .set_strategy(DirectStrategy())
+    )
+    return next(opt.iterate())
 
 
 # ===========================================================================
@@ -2335,6 +2391,68 @@ class TestNSGA3Comparator:
         order_min = comp_min.sort_population(pop_min)
 
         np.testing.assert_array_equal(order_max, order_min)
+
+    # -----------------------------------------------------------------------
+    # seed=None reproducibility under a master Optimizer seed (Issue #199)
+    # -----------------------------------------------------------------------
+    def test_seed_none_does_not_eagerly_create_rng(self) -> None:
+        """seed=None must not eagerly call default_rng() at construction time."""
+        ref = np.array([[0.0, 1.0], [1.0, 0.0]])
+        comp = NSGA3Comparator(ref)
+        assert comp._rng is None
+
+    def test_seed_none_rng_property_lazily_created_and_cached(self) -> None:
+        """The `rng` property lazily creates a Generator and caches it."""
+        ref = np.array([[0.0, 1.0], [1.0, 0.0]])
+        comp = NSGA3Comparator(ref)
+        rng = comp.rng
+        assert isinstance(rng, np.random.Generator)
+        assert comp.rng is rng
+
+    def test_seed_none_standalone_sort_population_still_works(self) -> None:
+        """A standalone comparator (seed=None, never attached to an Optimizer)
+        can still call sort_population without error."""
+        ref = np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]])
+        f = np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]])
+        pop = _make_pop(f)
+        comp = NSGA3Comparator(ref)
+        order = comp.sort_population(pop)
+        assert set(order.tolist()) == {0, 1, 2}
+
+    def test_explicit_seed_reproducible_regression(self) -> None:
+        """NSGA3Comparator(seed=<int>) reproduces exactly as before the fix,
+        independent of any Optimizer/ctx.rng involvement (#199 regression)."""
+        ref = np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]])
+        f = _nsga3_tie_population_f()
+        comp_a = NSGA3Comparator(ref, seed=42)
+        comp_b = NSGA3Comparator(ref, seed=42)
+        order_a = comp_a.sort_population(_make_pop(f))
+        order_b = comp_b.sort_population(_make_pop(f))
+        np.testing.assert_array_equal(order_a, order_b)
+
+    def test_seed_none_reproducible_under_master_optimizer_seed(self) -> None:
+        """Two Optimizer(seed=42) runs must reproduce NSGA3Comparator ordering.
+
+        Covers Issue #199: an unseeded NSGA3Comparator's rng is injected by
+        Runner from a spawned ``ctx.rng`` at run start, so it must reproduce
+        under a fixed master seed like every other rng-consuming component.
+        Uses a tie-break-sensitive population (duplicate objective values in
+        the same niche) to actually exercise ``rng.choice`` tie-breaking.
+        """
+        ref = np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]])
+        f = _nsga3_tie_population_f()
+
+        ctx1 = _nsga3_first_ctx(42, ref)
+        ctx2 = _nsga3_first_ctx(42, ref)
+
+        pre_state = ctx1.comparator.rng.bit_generator.state["state"]["state"]
+        order1 = ctx1.comparator.sort_population(_make_pop(f))
+        post_state = ctx1.comparator.rng.bit_generator.state["state"]["state"]
+        # The tie-break population must actually consume randomness.
+        assert pre_state != post_state
+
+        order2 = ctx2.comparator.sort_population(_make_pop(f))
+        np.testing.assert_array_equal(order1, order2)
 
 
 # ===========================================================================

--- a/tests/test_moo.py
+++ b/tests/test_moo.py
@@ -435,6 +435,48 @@ class TestWeightedSumComparator:
 
 
 # ===========================================================================
+# SingleObjectiveComparator Tests
+# ===========================================================================
+class TestSingleObjectiveComparator:
+    """Tests for SingleObjectiveComparator direction handling (Issue #197)."""
+
+    def test_maximize_compare_and_sort_agree(self) -> None:
+        """direction=+1: compare() and sort_population() must agree on ordering.
+
+        Before the fix, _compare() was hardcoded to minimize while _sort()
+        respected direction, so they disagreed under direction=+1.
+        """
+        f = np.array([[1.0], [3.0], [2.0]])
+        pop = _make_pop(f)
+        comp = SingleObjectiveComparator(direction=1.0)
+        order = comp.sort_population(pop)
+        assert order.tolist() == [1, 2, 0]  # descending: 3, 2, 1
+        assert comp.compare(f[1], 0.0, f[0], 0.0) == -1  # 3.0 better than 1.0
+        assert comp.compare(f[0], 0.0, f[1], 0.0) == 1
+        assert comp.compare(f[1], 0.0, f[2], 0.0) == -1  # 3.0 better than 2.0
+        assert comp.compare(f[0], 0.0, f[0], 0.0) == 0
+
+    def test_minimize_regression(self) -> None:
+        """direction=-1 behavior is unchanged: lower fitness is better."""
+        comp = SingleObjectiveComparator(direction=-1.0)
+        assert comp.compare(np.array([1.0]), 0.0, np.array([2.0]), 0.0) == -1
+        assert comp.compare(np.array([2.0]), 0.0, np.array([1.0]), 0.0) == 1
+        assert comp.compare(np.array([1.0]), 0.0, np.array([1.0]), 0.0) == 0
+
+    def test_direction_none_defaults_to_minimize(self) -> None:
+        """A standalone comparator with direction=None behaves as minimize."""
+        comp = SingleObjectiveComparator()
+        assert comp.direction is None
+        assert comp.compare(np.array([1.0]), 0.0, np.array([2.0]), 0.0) == -1
+        assert comp.compare(np.array([2.0]), 0.0, np.array([1.0]), 0.0) == 1
+
+        f = np.array([[3.0], [1.0], [2.0]])
+        pop = _make_pop(f)
+        order = comp.sort_population(pop)
+        assert order.tolist() == [1, 2, 0]  # ascending: 1, 2, 3
+
+
+# ===========================================================================
 # ParetoComparator Tests
 # ===========================================================================
 class TestParetoComparator:
@@ -734,6 +776,24 @@ class TestProblemComparatorAutoSelection:
             comparator=custom,
         )
         assert p.comparator is custom
+
+    def test_custom_comparator_with_none_direction_gets_injected(self) -> None:
+        """A comparator constructed with direction=None inherits Problem's direction."""
+        comp = SingleObjectiveComparator()
+        assert comp.direction is None
+        p = Problem(
+            func=lambda x: np.array([np.sum(x**2)]),
+            dim=2,
+            n_obj=1,
+            direction=np.array([-1.0]),
+            lb=[-5.0, -5.0],
+            ub=[5.0, 5.0],
+            comparator=comp,
+        )
+        assert p.comparator is comp
+        direction = p.comparator.direction
+        assert direction is not None
+        assert direction[0] == -1.0
 
     def test_problem_evaluate_returns_n_obj_values(self) -> None:
         p = Problem(
@@ -2254,6 +2314,27 @@ class TestNSGA3Comparator:
         comp = NSGA3Comparator(ref, direction=np.array([1.0, 1.0]), seed=0)
         order = comp.sort_population(pop)
         assert order[0] == 0  # [3,3] dominates under maximization
+
+    def test_direction_maximize_matches_negated_minimize(self) -> None:
+        """_normalize_objectives must respect direction (Issue #197).
+
+        Sorting a maximize (direction=+1) population must give the same
+        ordering as sorting the negated population under minimize
+        (direction=-1), since both represent the same preference over the
+        same underlying points.
+        """
+        ref = np.array([[0.0, 1.0], [0.5, 0.5], [1.0, 0.0]])
+        f = np.array([[1.0, 4.0], [4.0, 1.0], [2.0, 2.0], [3.0, 3.0]])
+
+        pop_max = _make_pop(f)
+        comp_max = NSGA3Comparator(ref, direction=np.array([1.0, 1.0]), seed=0)
+        order_max = comp_max.sort_population(pop_max)
+
+        pop_min = _make_pop(-f)
+        comp_min = NSGA3Comparator(ref, direction=np.array([-1.0, -1.0]), seed=0)
+        order_min = comp_min.sort_population(pop_min)
+
+        np.testing.assert_array_equal(order_max, order_min)
 
 
 # ===========================================================================

--- a/tests/test_moo_acquisition.py
+++ b/tests/test_moo_acquisition.py
@@ -304,3 +304,63 @@ class TestEHVIAcquisition:
             scores = af.score(pred, ref)
             assert scores.shape == (1,)
             assert scores[0] >= 0.0
+
+
+# ===========================================================================
+# Direction-aware minimize-space conversion (Issue #198)
+# ===========================================================================
+class TestParEGODirectionSensitivity:
+    """ParEGO's z_star must reflect the raw-space *maximum* under direction=+1."""
+
+    def test_z_star_is_negated_max_under_maximize_direction(self) -> None:
+        arc = _archive([1.0, 5.0], [3.0, 2.0], [0.5, 4.0])
+        af = ParEGOAcquisition(
+            rng=np.random.default_rng(0), direction=np.array([1.0, 1.0])
+        )
+        z_star, _, _ = af.compute_reference(arc)
+        raw_max = arc.f.max(axis=0)
+        np.testing.assert_array_almost_equal(z_star, -raw_max)
+
+    def test_z_star_is_raw_min_under_minimize_direction(self) -> None:
+        """direction=-1 is a no-op; z_star equals the raw archive minimum."""
+        arc = _archive([1.0, 5.0], [3.0, 2.0], [0.5, 4.0])
+        af = ParEGOAcquisition(
+            rng=np.random.default_rng(0), direction=np.array([-1.0, -1.0])
+        )
+        z_star, _, _ = af.compute_reference(arc)
+        np.testing.assert_array_almost_equal(z_star, arc.f.min(axis=0))
+
+
+class TestSMSEGODirectionSensitivity:
+    """Under direction=+1, larger predicted values must score higher."""
+
+    def test_maximize_prefers_larger_predicted_values(self) -> None:
+        arc = _archive([1.0, 1.0])
+        af = SMSEGOAcquisition(
+            reference_point=[0.0, 0.0], direction=np.array([1.0, 1.0])
+        )
+        ref = af.compute_reference(arc)
+        pred_better = _pred(value=[[3.0, 3.0]], std=[[0.01, 0.01]])
+        pred_worse = _pred(value=[[1.5, 1.5]], std=[[0.01, 0.01]])
+        s_better = af.score(pred_better, ref)
+        s_worse = af.score(pred_worse, ref)
+        assert s_better[0] > s_worse[0]
+
+
+class TestEHVIDirectionSensitivity:
+    """Under direction=+1, candidates closer to the maximizing ideal score higher."""
+
+    def test_maximize_prefers_larger_predicted_values(self) -> None:
+        arc = _archive([1.0, 1.0])
+        af = EHVIAcquisition(
+            n_samples=128,
+            reference_point=[0.0, 0.0],
+            rng=np.random.default_rng(0),
+            direction=np.array([1.0, 1.0]),
+        )
+        ref = af.compute_reference(arc)
+        pred_better = _pred(value=[[3.0, 3.0]], std=[[0.1, 0.1]])
+        pred_worse = _pred(value=[[1.2, 1.2]], std=[[0.1, 0.1]])
+        s_better = af.score(pred_better, ref)
+        s_worse = af.score(pred_worse, ref)
+        assert s_better[0] > s_worse[0]

--- a/tests/test_optimizer_validate.py
+++ b/tests/test_optimizer_validate.py
@@ -9,13 +9,17 @@ import pytest
 
 from saealib.acquisition.ei import ExpectedImprovement
 from saealib.acquisition.mean import MeanPrediction
+from saealib.acquisition.pof import ProbabilityOfFeasibility, ProductOfFeasibility
+from saealib.acquisition.uncertainty import MaxUncertainty
 from saealib.comparators import SingleObjectiveComparator
+from saealib.execution.initializer import LHSInitializer
 from saealib.optimizer import Optimizer
 from saealib.problem import Problem
 from saealib.strategies.base import OptimizationStrategy
 from saealib.strategies.ib import IndividualBasedStrategy
 from saealib.surrogate.manager import GlobalSurrogateManager
 from saealib.surrogate.rbf import RBFSurrogate, gaussian_kernel
+from saealib.surrogate.sklearn_surrogate import SklearnGPRSurrogate
 
 DIM = 2
 N_OBJ = 1
@@ -188,3 +192,103 @@ def test_iterate_succeeds_with_no_components_set():
     opt = Optimizer(_make_problem())
     ctx = next(opt.iterate())
     assert ctx is not None
+
+
+# ---------------------------------------------------------------------------
+# Acquisition direction auto-injection (Issue #198)
+# ---------------------------------------------------------------------------
+
+
+def test_acquisition_direction_length_mismatch():
+    opt = _fully_configured()
+    opt.set_surrogate_manager(
+        GlobalSurrogateManager(
+            RBFSurrogate(kernel=gaussian_kernel, dim=DIM),
+            ExpectedImprovement(direction=np.array([1.0, 1.0])),  # len 2 != n_obj=1
+        )
+    )
+    assert any("direction" in m for m in opt.validate())
+
+
+def test_inject_acquisition_directions_sets_from_problem():
+    problem = _make_problem(n_obj=2)
+    opt = Optimizer(problem)
+    opt.set_algorithm(MagicMock())
+    opt.set_strategy(_stub_strategy())
+    opt.initializer = MagicMock()
+    opt.set_termination(MagicMock())
+    acq = MeanPrediction()
+    opt.set_surrogate_manager(
+        GlobalSurrogateManager(RBFSurrogate(kernel=gaussian_kernel, dim=2), acq)
+    )
+    opt._inject_acquisition_directions()
+    np.testing.assert_array_equal(acq.direction, problem.direction)
+
+
+def test_inject_acquisition_directions_idempotent():
+    opt = _fully_configured()
+    acq = MeanPrediction()
+    opt.set_surrogate_manager(
+        GlobalSurrogateManager(RBFSurrogate(kernel=gaussian_kernel, dim=DIM), acq)
+    )
+    opt._inject_acquisition_directions()
+    first = acq.direction
+    opt._inject_acquisition_directions()
+    assert acq.direction is first
+
+
+def test_inject_acquisition_directions_preserves_explicit_direction():
+    opt = _fully_configured()
+    explicit = np.array([1.0])
+    acq = MeanPrediction(direction=explicit)
+    opt.set_surrogate_manager(
+        GlobalSurrogateManager(RBFSurrogate(kernel=gaussian_kernel, dim=DIM), acq)
+    )
+    opt._inject_acquisition_directions()
+    assert acq.direction is explicit
+
+
+def test_inject_acquisition_directions_skips_direction_insensitive():
+    """PoF/ProductOfFeasibility/MaxUncertainty opt out and never get a direction."""
+    opt = _fully_configured()
+    for acq in (
+        ProbabilityOfFeasibility(),
+        ProductOfFeasibility(),
+        MaxUncertainty(),
+    ):
+        opt.set_surrogate_manager(
+            GlobalSurrogateManager(RBFSurrogate(kernel=gaussian_kernel, dim=DIM), acq)
+        )
+        opt._inject_acquisition_directions()
+        # These acquisitions never declare a `direction` field at all; opting
+        # out via direction_sensitive=False means injection must not add one.
+        assert getattr(acq, "direction", None) is None
+
+
+def test_iterate_injects_acquisition_direction_end_to_end():
+    """End-to-end: iterate() auto-injects problem.direction into an unset
+    acquisition."""
+    dim = 2
+    problem = Problem(
+        func=lambda x: np.array([-np.sum(x**2)]),
+        dim=dim,
+        n_obj=1,
+        direction=np.array([1.0]),  # maximize
+        lb=[-5.0] * dim,
+        ub=[5.0] * dim,
+    )
+    acq = ExpectedImprovement()
+    opt = (
+        Optimizer(problem, seed=0)
+        .set_initializer(LHSInitializer(n_init_archive=10, n_init_population=8, seed=0))
+        .set_strategy(IndividualBasedStrategy(evaluation_ratio=0.5))
+        .set_surrogate_manager(GlobalSurrogateManager(SklearnGPRSurrogate(), acq))
+    )
+    gen = opt.iterate()
+    next(gen)
+
+    np.testing.assert_array_equal(acq.direction, problem.direction)
+
+    # Idempotent: re-injecting does not change an already-set direction.
+    opt._inject_acquisition_directions()
+    np.testing.assert_array_equal(acq.direction, problem.direction)

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -13,7 +13,9 @@ import numpy as np
 from saealib import (
     GA,
     CrossoverBLXAlpha,
+    LHSInitializer,
     MutationUniform,
+    Optimizer,
     SequentialSelection,
     TruncationSelection,
 )
@@ -32,6 +34,7 @@ from saealib.surrogate.manager import (
     CompositeSurrogateManager,
     GlobalSurrogateManager,
     LocalSurrogateManager,
+    SurrogateManager,
     rank_weighted_combine,
 )
 from saealib.surrogate.prediction import SurrogatePrediction
@@ -184,12 +187,12 @@ class TestGenerationBasedStrategy:
         assert ctx.gen == 1
         assert ctx.fe == len(ctx.population)
 
-    def test_pipeline_cached_after_first_step(self):
+    def test_pipeline_rebuilt_on_every_step(self):
         ctx, provider, strategy = self._setup(gen_ctrl=3)
         ctx = strategy.step(ctx, provider)
         pipeline_ref = strategy.pipeline
         strategy.step(ctx, provider)
-        assert strategy.pipeline is pipeline_ref
+        assert strategy.pipeline is not pipeline_ref
 
     def test_surrogate_fit_called_once_per_step(self):
         """fit() must be called exactly once per step(), not once per surrogate gen."""
@@ -421,21 +424,106 @@ class TestStrategyPipelineAttribute:
         strategies["gb"].step(ctx, provider)
         assert isinstance(strategies["gb"].pipeline, Pipeline)
 
-    def test_ps_pipeline_reused_across_steps(self):
+    def test_ps_pipeline_rebuilt_across_steps(self):
         provider, strategies = self._providers_and_strategies()
         ctx = _make_ctx()
         s = strategies["ps"]
         s.step(ctx, provider)
         first = s.pipeline
-        s.step(ctx, provider)
-        assert s.pipeline is first
-
-    def test_ps_pipeline_rebuilds_when_reset(self):
-        provider, strategies = self._providers_and_strategies()
-        ctx = _make_ctx()
-        s = strategies["ps"]
-        s.step(ctx, provider)
-        first = s.pipeline
-        s.pipeline = None
         s.step(ctx, provider)
         assert s.pipeline is not first
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #196: rebuilding the pipeline every step means
+# component/parameter changes made mid-``iterate()`` take effect immediately.
+# ---------------------------------------------------------------------------
+
+
+class _SpyManager(SurrogateManager):
+    """Surrogate manager that counts score_candidates() calls."""
+
+    def __init__(self):
+        self.call_count = 0
+
+    def score_candidates(self, candidates_x, archive, ctx=None, *, refit=True):
+        self.call_count += 1
+        n = len(candidates_x)
+        scores = np.linspace(1.0, 0.0, n)
+        predictions = [
+            SurrogatePrediction(
+                value=np.array([[1.0]]), std=None, label=None, metadata={}
+            )
+            for _ in range(n)
+        ]
+        return scores, predictions
+
+
+class TestPipelineRebuildOnRuntimeReassignment:
+    """Regression tests for #196: pipeline must rebuild on every step()."""
+
+    def _make_optimizer(self, strategy, manager) -> Optimizer:
+        return (
+            Optimizer(_make_problem())
+            .set_initializer(
+                LHSInitializer(n_init_archive=N_POP, n_init_population=N_POP, seed=0)
+            )
+            .set_algorithm(_make_ga())
+            .set_strategy(strategy)
+            .set_surrogate_manager(manager)
+            .set_termination(Termination(max_gen(100)))
+        )
+
+    def test_reassigned_surrogate_manager_used_next_generation(self):
+        old_manager = _SpyManager()
+        new_manager = _SpyManager()
+        opt = self._make_optimizer(
+            IndividualBasedStrategy(evaluation_ratio=0.5), old_manager
+        )
+
+        gen = opt.iterate()
+        next(gen)  # initial ctx, before any strategy.step() call
+        next(gen)  # generation 1: uses old_manager
+        assert old_manager.call_count == 1
+        assert new_manager.call_count == 0
+
+        opt.set_surrogate_manager(new_manager)
+        next(gen)  # generation 2: pipeline is rebuilt, must use new_manager
+
+        assert new_manager.call_count == 1
+        assert old_manager.call_count == 1
+
+    def test_gen_ctrl_change_alters_surrogate_only_iteration_count(self):
+        manager = _SpyManager()
+        strategy = GenerationBasedStrategy(gen_ctrl=1)
+        opt = self._make_optimizer(strategy, manager)
+
+        gen = opt.iterate()
+        next(gen)  # initial ctx
+        next(gen)  # generation step with gen_ctrl=1
+        assert manager.call_count == 1
+
+        strategy.gen_ctrl = 3
+        next(gen)  # generation step with gen_ctrl=3
+
+        assert manager.call_count == 1 + 3
+
+    def test_evaluation_ratio_change_alters_true_eval_count(self):
+        manager = _SpyManager()
+        strategy = IndividualBasedStrategy(evaluation_ratio=0.2)
+        opt = self._make_optimizer(strategy, manager)
+
+        gen = opt.iterate()
+        ctx = next(gen)  # initial ctx, before any strategy.step() call
+        fe_before = ctx.fe
+        ctx = next(gen)  # generation step with evaluation_ratio=0.2
+        n_offspring = len(ctx.population)
+        fe_first_step = ctx.fe - fe_before
+        assert fe_first_step == max(1, int(0.2 * n_offspring))
+
+        strategy.evaluation_ratio = 0.6
+        fe_before = ctx.fe
+        ctx = next(gen)  # generation step with evaluation_ratio=0.6
+
+        fe_second_step = ctx.fe - fe_before
+        assert fe_second_step == max(1, int(0.6 * n_offspring))

--- a/tests/test_surrogate_manager.py
+++ b/tests/test_surrogate_manager.py
@@ -1386,3 +1386,41 @@ class TestPairwiseSurrogateManager:
             SklearnRFCClassificationSurrogate(n_estimators=5, random_state=0)
         )
         assert isinstance(manager.training_set, PairwiseComparisonSet)
+
+
+# ===========================================================================
+# SurrogateManager.iter_acquisitions (Issue #198)
+# ===========================================================================
+class TestIterAcquisitions:
+    """Tests for iter_acquisitions(), used by Optimizer direction auto-injection."""
+
+    def test_global_manager_yields_single_acquisition(
+        self, surrogate_1obj: RBFSurrogate
+    ) -> None:
+        acq = MeanPrediction()
+        manager = GlobalSurrogateManager(surrogate_1obj, acq)
+        assert list(manager.iter_acquisitions()) == [acq]
+
+    def test_local_manager_yields_single_acquisition(
+        self, surrogate_1obj: RBFSurrogate
+    ) -> None:
+        acq = MeanPrediction()
+        manager = LocalSurrogateManager(surrogate_1obj, acq)
+        assert list(manager.iter_acquisitions()) == [acq]
+
+    def test_composite_manager_yields_all_sub_manager_acquisitions(
+        self, surrogate_1obj: RBFSurrogate
+    ) -> None:
+        acq1 = MeanPrediction()
+        acq2 = MeanPrediction()
+        m1 = GlobalSurrogateManager(surrogate_1obj, acq1)
+        m2 = GlobalSurrogateManager(surrogate_1obj, acq2)
+        composite = CompositeSurrogateManager([m1, m2], combine_fn=product_combine)
+        assert list(composite.iter_acquisitions()) == [acq1, acq2]
+
+    def test_pairwise_manager_yields_nothing(self) -> None:
+        """PairwiseSurrogateManager has no acquisition function at all."""
+        manager = PairwiseSurrogateManager(
+            SklearnRFCClassificationSurrogate(n_estimators=5, random_state=0)
+        )
+        assert list(manager.iter_acquisitions()) == []


### PR DESCRIPTION
## Related Issue
Closes #196
Closes #197
Closes #198
Closes #199
Closes #200

## Changes
- **#197**: Make `SingleObjectiveComparator._compare()` direction-aware, resolving its disagreement with `sort_population()`. `direction` now defaults to `None` and is auto-injected from `Problem.direction`. Also fixes `NSGA3Comparator._normalize_objectives`'s unused `direction` argument.
- **#196**: The four strategies (IndividualBased/GenerationBased/PreSelection/Direct) only built their `Pipeline` on the first `step()` call and cached it, so runtime component reassignment and parameter changes had no effect. `step()` now rebuilds the pipeline every call.
- **#199**: Fix `NSGA3Comparator`'s RNG not being tied to the Optimizer's master seed, breaking reproducibility. When unseeded, a generator spawned from the master RNG is now injected (at both `Initializer._create_context` and `Runner.iterate_from`).
- **#200**: Extend the `eps_cv` sync (previously only `ctx.comparator.eps_cv`) to also cover `ctx.pareto_archive.eps_cv`, consolidated into a `_sync_eps_cv` helper.
- **#198**: Fix EI/LCB/ParEGO/SMS-EGO/EHVI assuming minimization and not supporting `direction` (maximize). Added a `direction_to_minimize_sign()` helper that converts inputs at the entry point, leaving the existing (minimize-only) formulas unchanged. `direction` is auto-injected from `Problem.direction` via the new `SurrogateManager.iter_acquisitions()`. PoF/MaxUncertainty opt out via `direction_sensitive=False`.

## Verification Steps
Each commit was verified with:
```
pytest tests/
ruff format src/ tests/
ruff check --fix src/ tests/
ty check
```

## Concerns
- `NSGA3Comparator`'s privately-owned RNG is not part of `OptimizationState.save()`'s checkpoint, so resuming spawns a fresh generator rather than continuing the pre-checkpoint draw sequence (documented as a known limitation; a permanent fix is left for future consideration).

## Other
- Merge method: **rebase merge** (this is a multi-issue bundle, so squash merge would collapse per-issue bisectability).
