### PR TITLE
refactor: API surface bundle: Registry reduction and Tier 2 export inventory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,3 +121,13 @@ pytest
 
 1. Ensure all tests pass locally.
 2. Use the provided Pull Request Template.
+
+### 6. Public API Export Tiers
+
+`src/saealib/__init__.py` exposes public components in three tiers (see the "Export tiers" comment at the top of that file for the authoritative version):
+
+* **Tier 1** (eager import, listed in `__all__`): entry points likely to be named in the first script or a subclass definition — the 5 root abstractions (`Algorithm`, `OptimizationStrategy`, `Surrogate`, `AcquisitionFunction`, `SurrogateManager`), one or two representative default implementations per concept, and the `Comparator`/`Evaluator`/`Initializer`/`Termination`/`Event` bases with their common defaults.
+* **Tier 2** (`_TIER2_MAP`, lazy import via `__getattr__`): every other public component. A name in a subpackage's `__all__` belongs here unless it is namespace-only.
+* **namespace-only** (not listed at the top level at all): generic-named bulk sets or domain toolkits, e.g. `saealib.benchmarks` (`sphere`/`zdt*`/`dtlz*`/...), `saealib.registry.get`/`build`/`to_spec`, and `saealib.defaults` (internal). Access these via their subpackage directly.
+
+When you add a new public class or function to a subpackage's `__all__`, add it to `_TIER2_MAP` (or the `NAMESPACE_ONLY` allowlist in `tests/test_exports.py` if it's a namespace-only case) and to `src/saealib/__init__.pyi` in the same PR — `tests/test_exports.py` fails otherwise.

--- a/docs/api/registry.md
+++ b/docs/api/registry.md
@@ -6,7 +6,7 @@
    :nosignatures:
 
    saealib.register
-   saealib.build
-   saealib.get
-   saealib.to_spec
+   saealib.registry.build
+   saealib.registry.get
+   saealib.registry.to_spec
 ```

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -61,7 +61,7 @@ from saealib.problem import (
     Problem,
     StaticToleranceHandler,
 )
-from saealib.registry import build, get, register, to_spec
+from saealib.registry import register
 from saealib.stages import (
     ArchiveUpdateStage,
     AskStage,
@@ -178,9 +178,7 @@ __all__ = [
     "TruncationSelection",
     "ValidationError",
     "Variable",
-    "build",
     "f_target",
-    "get",
     "hypervolume",
     "hypervolume_contributions",
     "max_fe",
@@ -189,7 +187,6 @@ __all__ = [
     "minimize",
     "register",
     "stalled",
-    "to_spec",
 ]
 
 # ---------------------------------------------------------------------------

--- a/src/saealib/__init__.py
+++ b/src/saealib/__init__.py
@@ -6,7 +6,23 @@ from importlib.metadata import version
 __version__ = version("saealib")
 
 # ---------------------------------------------------------------------------
-# Tier 1 — eager imports (always available, listed in __all__)
+# Export tiers
+#
+# Tier 1 (this section, eager import + __all__): entry points likely to be
+#   named in the first script or a subclass definition — the 5 root
+#   abstractions (Algorithm, OptimizationStrategy, Surrogate,
+#   AcquisitionFunction, SurrogateManager), one or two representative default
+#   implementations per concept, and the Comparator/Evaluator/Initializer/
+#   Termination/Event bases with their common defaults.
+# Tier 2 (_TIER2_MAP below, lazy import via __getattr__): every other public
+#   component. A name in a subpackage's __all__ belongs here unless it is
+#   namespace-only.
+# namespace-only (not listed at the top level at all): generic-named bulk
+#   sets or domain toolkits, e.g. saealib.benchmarks (sphere/zdt*/dtlz*/...),
+#   saealib.registry.get/build/to_spec, and saealib.defaults (internal).
+#   Access these via their subpackage directly. Tracked in
+#   tests/test_exports.py's NAMESPACE_ONLY allowlist so new subpackage
+#   exports can't silently drift out of this scheme.
 # ---------------------------------------------------------------------------
 
 from saealib.acquisition import AcquisitionFunction, ExpectedImprovement
@@ -234,11 +250,14 @@ _TIER2_MAP: dict[str, str] = {
     "SequentialSelection": "saealib.operators",
     "repair_clipping": "saealib.operators",
     # acquisition (less common)
+    "EHVIAcquisition": "saealib.acquisition",
     "LowerConfidenceBound": "saealib.acquisition",
     "MaxUncertainty": "saealib.acquisition",
     "MeanPrediction": "saealib.acquisition",
+    "ParEGOAcquisition": "saealib.acquisition",
     "ProbabilityOfFeasibility": "saealib.acquisition",
     "ProductOfFeasibility": "saealib.acquisition",
+    "SMSEGOAcquisition": "saealib.acquisition",
     # surrogate (specialized)
     "ArchiveBasedManager": "saealib.surrogate",
     "CompositeSurrogateManager": "saealib.surrogate",
@@ -260,6 +279,40 @@ _TIER2_MAP: dict[str, str] = {
     "TorchSurrogate": "saealib.surrogate",
     "product_combine": "saealib.surrogate",
     "rank_weighted_combine": "saealib.surrogate",
+    # surrogate (training-set builders)
+    "ArchiveObjectiveSet": "saealib.surrogate",
+    "ConstraintObjectiveSet": "saealib.surrogate",
+    "FeasibilityClassificationSet": "saealib.surrogate",
+    "KNNConstraintObjectiveSet": "saealib.surrogate",
+    "KNNObjectiveSet": "saealib.surrogate",
+    "LevelBasedSet": "saealib.surrogate",
+    "PairwiseComparisonSet": "saealib.surrogate",
+    "ReferencePointComparisonSet": "saealib.surrogate",
+    "TopKBipartitionSet": "saealib.surrogate",
+    "TrainingData": "saealib.surrogate",
+    "TrainingSet": "saealib.surrogate",
+    # surrogate (accuracy evaluation)
+    "AccuracyEvaluator": "saealib.surrogate",
+    "HeldOutAccuracyEvaluator": "saealib.surrogate",
+    "KFoldAccuracyEvaluator": "saealib.surrogate",
+    "LOOAccuracyEvaluator": "saealib.surrogate",
+    "R2Score": "saealib.surrogate",
+    "RMSE": "saealib.surrogate",
+    "SpearmanCorrelation": "saealib.surrogate",
+    "SurrogateAccuracy": "saealib.surrogate",
+    "SurrogateAccuracyMetric": "saealib.surrogate",
+    # surrogate (switching)
+    "AccuracyBasedSurrogateSwitcher": "saealib.surrogate",
+    "GenCtrlSwitcher": "saealib.surrogate",
+    "ManagerSwitcher": "saealib.surrogate",
+    "StrategySwitcher": "saealib.surrogate",
+    # surrogate (other)
+    "ComparisonSurrogate": "saealib.surrogate",
+    "PairwiseSurrogateManager": "saealib.surrogate",
+    "RegressionSurrogate": "saealib.surrogate",
+    "SklearnClassificationSurrogate": "saealib.surrogate",
+    "SklearnRFCClassificationSurrogate": "saealib.surrogate",
+    "SklearnSVCClassificationSurrogate": "saealib.surrogate",
     # problem (less common)
     "Constraint": "saealib.problem",
     "GradientRepairHandler": "saealib.problem",

--- a/src/saealib/__init__.pyi
+++ b/src/saealib/__init__.pyi
@@ -10,14 +10,17 @@ __all__: list[str]
 # ---------------------------------------------------------------------------
 
 from saealib.acquisition import AcquisitionFunction as AcquisitionFunction
-from saealib.acquisition import ExpectedImprovement as ExpectedImprovement
 
 # acquisition (less common)
+from saealib.acquisition import EHVIAcquisition as EHVIAcquisition
+from saealib.acquisition import ExpectedImprovement as ExpectedImprovement
 from saealib.acquisition import LowerConfidenceBound as LowerConfidenceBound
 from saealib.acquisition import MaxUncertainty as MaxUncertainty
 from saealib.acquisition import MeanPrediction as MeanPrediction
+from saealib.acquisition import ParEGOAcquisition as ParEGOAcquisition
 from saealib.acquisition import ProbabilityOfFeasibility as ProbabilityOfFeasibility
 from saealib.acquisition import ProductOfFeasibility as ProductOfFeasibility
+from saealib.acquisition import SMSEGOAcquisition as SMSEGOAcquisition
 from saealib.algorithms import GA as GA
 from saealib.algorithms import PSO as PSO
 from saealib.algorithms import Algorithm as Algorithm
@@ -155,28 +158,76 @@ from saealib.strategies import GenerationBasedStrategy as GenerationBasedStrateg
 from saealib.strategies import IndividualBasedStrategy as IndividualBasedStrategy
 from saealib.strategies import OptimizationStrategy as OptimizationStrategy
 from saealib.strategies import PreSelectionStrategy as PreSelectionStrategy
+from saealib.surrogate import RMSE as RMSE
+
+# surrogate (switching)
+from saealib.surrogate import (
+    AccuracyBasedSurrogateSwitcher as AccuracyBasedSurrogateSwitcher,
+)
+
+# surrogate (accuracy evaluation)
+from saealib.surrogate import AccuracyEvaluator as AccuracyEvaluator
 
 # surrogate (specialized)
 from saealib.surrogate import ArchiveBasedManager as ArchiveBasedManager
+
+# surrogate (training-set builders)
+from saealib.surrogate import ArchiveObjectiveSet as ArchiveObjectiveSet
+
+# surrogate (other)
+from saealib.surrogate import ComparisonSurrogate as ComparisonSurrogate
 from saealib.surrogate import CompositeSurrogateManager as CompositeSurrogateManager
+from saealib.surrogate import ConstraintObjectiveSet as ConstraintObjectiveSet
 from saealib.surrogate import DensityManager as DensityManager
+from saealib.surrogate import (
+    FeasibilityClassificationSet as FeasibilityClassificationSet,
+)
+from saealib.surrogate import GenCtrlSwitcher as GenCtrlSwitcher
 from saealib.surrogate import GlobalSurrogateManager as GlobalSurrogateManager
+from saealib.surrogate import HeldOutAccuracyEvaluator as HeldOutAccuracyEvaluator
+from saealib.surrogate import KFoldAccuracyEvaluator as KFoldAccuracyEvaluator
+from saealib.surrogate import KNNConstraintObjectiveSet as KNNConstraintObjectiveSet
+from saealib.surrogate import KNNObjectiveSet as KNNObjectiveSet
+from saealib.surrogate import LevelBasedSet as LevelBasedSet
 from saealib.surrogate import LocalSurrogateManager as LocalSurrogateManager
+from saealib.surrogate import LOOAccuracyEvaluator as LOOAccuracyEvaluator
+from saealib.surrogate import ManagerSwitcher as ManagerSwitcher
 from saealib.surrogate import NichingManager as NichingManager
 from saealib.surrogate import NoveltyManager as NoveltyManager
+from saealib.surrogate import PairwiseComparisonSet as PairwiseComparisonSet
+from saealib.surrogate import PairwiseSurrogateManager as PairwiseSurrogateManager
 from saealib.surrogate import PerObjectiveSurrogate as PerObjectiveSurrogate
+from saealib.surrogate import R2Score as R2Score
 from saealib.surrogate import RBFSurrogate as RBFSurrogate
+from saealib.surrogate import ReferencePointComparisonSet as ReferencePointComparisonSet
+from saealib.surrogate import RegressionSurrogate as RegressionSurrogate
+from saealib.surrogate import (
+    SklearnClassificationSurrogate as SklearnClassificationSurrogate,
+)
 from saealib.surrogate import SklearnGPRSurrogate as SklearnGPRSurrogate
 from saealib.surrogate import SklearnLGBMSurrogate as SklearnLGBMSurrogate
 from saealib.surrogate import SklearnNNSurrogate as SklearnNNSurrogate
+from saealib.surrogate import (
+    SklearnRFCClassificationSurrogate as SklearnRFCClassificationSurrogate,
+)
 from saealib.surrogate import SklearnRFRSurrogate as SklearnRFRSurrogate
 from saealib.surrogate import SklearnSurrogate as SklearnSurrogate
+from saealib.surrogate import (
+    SklearnSVCClassificationSurrogate as SklearnSVCClassificationSurrogate,
+)
 from saealib.surrogate import SklearnSVMSurrogate as SklearnSVMSurrogate
 from saealib.surrogate import SklearnXGBSurrogate as SklearnXGBSurrogate
+from saealib.surrogate import SpearmanCorrelation as SpearmanCorrelation
+from saealib.surrogate import StrategySwitcher as StrategySwitcher
 from saealib.surrogate import Surrogate as Surrogate
+from saealib.surrogate import SurrogateAccuracy as SurrogateAccuracy
+from saealib.surrogate import SurrogateAccuracyMetric as SurrogateAccuracyMetric
 from saealib.surrogate import SurrogateManager as SurrogateManager
 from saealib.surrogate import SurrogatePrediction as SurrogatePrediction
+from saealib.surrogate import TopKBipartitionSet as TopKBipartitionSet
 from saealib.surrogate import TorchSurrogate as TorchSurrogate
+from saealib.surrogate import TrainingData as TrainingData
+from saealib.surrogate import TrainingSet as TrainingSet
 from saealib.surrogate import product_combine as product_combine
 from saealib.surrogate import rank_weighted_combine as rank_weighted_combine
 
@@ -203,3 +254,5 @@ from saealib.variables import CategoricalVariable as CategoricalVariable
 from saealib.variables import ContinuousVariable as ContinuousVariable
 from saealib.variables import IntegerVariable as IntegerVariable
 from saealib.variables import Variable as Variable
+
+_TIER2_MAP: dict[str, str]

--- a/src/saealib/__init__.pyi
+++ b/src/saealib/__init__.pyi
@@ -136,10 +136,7 @@ from saealib.problem import Problem as Problem
 from saealib.problem import StaticToleranceHandler as StaticToleranceHandler
 from saealib.problem import exponential_epsilon_schedule as exponential_epsilon_schedule
 from saealib.problem import linear_epsilon_schedule as linear_epsilon_schedule
-from saealib.registry import build as build
-from saealib.registry import get as get
 from saealib.registry import register as register
-from saealib.registry import to_spec as to_spec
 
 # stages
 from saealib.stages import ArchiveUpdateStage as ArchiveUpdateStage

--- a/src/saealib/optimizer.py
+++ b/src/saealib/optimizer.py
@@ -245,7 +245,7 @@ class Optimizer:
             cannot be serialized (e.g. holds a raw lambda).
         """
         from saealib.defaults import dump_preset
-        from saealib.registry import strip_params, to_spec
+        from saealib.registry import _strip_params, to_spec
 
         preset: dict = {}
         for name in ("algorithm", "surrogate_manager", "strategy", "termination"):
@@ -258,7 +258,7 @@ class Optimizer:
                 raise ValidationError(
                     f"Cannot save preset: {name} is not serializable: {e}"
                 ) from e
-            preset[name] = strip_params(spec, "dim", "direction")
+            preset[name] = _strip_params(spec, "dim", "direction")
 
         if not preset:
             raise ValidationError(
@@ -367,7 +367,7 @@ class Optimizer:
         evaluations only if neither ``set_*()`` nor a preset supplies one.
         """
         from saealib.defaults import load_defaults
-        from saealib.registry import build, inject_params
+        from saealib.registry import _inject_params, build
 
         algorithm = getattr(self, "algorithm", None)
         strategy = getattr(self, "strategy", None)
@@ -379,7 +379,7 @@ class Optimizer:
             direction = self.problem.direction
             if algorithm is None and "algorithm" in user_preset:
                 algorithm = build(
-                    inject_params(
+                    _inject_params(
                         user_preset["algorithm"], dim=dim, direction=direction
                     )
                 )
@@ -391,7 +391,9 @@ class Optimizer:
                 self.surrogate_manager = surrogate_manager
             if strategy is None and "strategy" in user_preset:
                 strategy = build(
-                    inject_params(user_preset["strategy"], dim=dim, direction=direction)
+                    _inject_params(
+                        user_preset["strategy"], dim=dim, direction=direction
+                    )
                 )
                 self.strategy = strategy
             if (
@@ -399,7 +401,7 @@ class Optimizer:
                 and "termination" in user_preset
             ):
                 self.termination = build(
-                    inject_params(
+                    _inject_params(
                         user_preset["termination"], dim=dim, direction=direction
                     )
                 )
@@ -472,7 +474,7 @@ class Optimizer:
         Shared by ``Optimizer._resolve_defaults()`` and ``saealib.api``'s
         ``'rbf'`` surrogate shorthand, so the injection logic is defined once.
         """
-        from saealib.registry import build, inject_params
+        from saealib.registry import _inject_params, build
 
         spec = copy.deepcopy(spec)
         params = spec.setdefault("params", {})
@@ -484,7 +486,7 @@ class Optimizer:
             "acquisition",
             {"type": "MeanPrediction", "params": {"direction": direction}},
         )
-        spec = inject_params(spec, dim=dim, direction=direction)
+        spec = _inject_params(spec, dim=dim, direction=direction)
         return build(spec)
 
     def _register_checkpoint(

--- a/src/saealib/registry.py
+++ b/src/saealib/registry.py
@@ -142,7 +142,7 @@ def build(spec: Any) -> Any:
     return spec
 
 
-def dotted_path(obj: Any) -> str:
+def _dotted_path(obj: Any) -> str:
     """Return the ``module.qualname`` import path of a class or function."""
     return f"{obj.__module__}.{obj.__qualname__}"
 
@@ -175,7 +175,7 @@ def to_spec(obj: Any) -> Any:
     if isinstance(obj, dict):
         return {k: to_spec(v) for k, v in obj.items()}
     if inspect.isfunction(obj) or inspect.isbuiltin(obj):
-        path = dotted_path(obj)
+        path = _dotted_path(obj)
         try:
             resolved = get(path)
         except ValidationError:
@@ -197,7 +197,7 @@ def to_spec(obj: Any) -> Any:
         return spec
 
     cls = type(obj)
-    type_name = _find_registered_name(cls) or dotted_path(cls)
+    type_name = _find_registered_name(cls) or _dotted_path(cls)
     parameters = [
         p
         for name, p in inspect.signature(cls.__init__).parameters.items()
@@ -232,7 +232,7 @@ def to_spec(obj: Any) -> Any:
     return {"type": type_name, "params": params}
 
 
-def strip_params(spec: Any, *names: str) -> Any:
+def _strip_params(spec: Any, *names: str) -> Any:
     """Return a copy of ``spec`` with the given param names removed recursively.
 
     Non-spec values (including lists of specs, encountered while descending
@@ -240,20 +240,20 @@ def strip_params(spec: Any, *names: str) -> Any:
     mutated.
     """
     if isinstance(spec, list):
-        return [strip_params(v, *names) for v in spec]
+        return [_strip_params(v, *names) for v in spec]
     if not _is_spec(spec):
         return spec
     params = spec.get("params", {})
     if isinstance(params, list):
-        new_params: Any = [strip_params(v, *names) for v in params]
+        new_params: Any = [_strip_params(v, *names) for v in params]
     else:
         new_params = {
-            k: strip_params(v, *names) for k, v in params.items() if k not in names
+            k: _strip_params(v, *names) for k, v in params.items() if k not in names
         }
     return {**spec, "params": new_params}
 
 
-def inject_params(spec: Any, **overrides: Any) -> Any:
+def _inject_params(spec: Any, **overrides: Any) -> Any:
     """Return a copy of ``spec`` with ``overrides`` injected recursively.
 
     For each ``{"type", "params": dict}`` node, an override is injected only
@@ -261,12 +261,12 @@ def inject_params(spec: Any, **overrides: Any) -> Any:
     already present in ``params``. ``spec`` itself is not mutated.
     """
     if isinstance(spec, list):
-        return [inject_params(spec_item, **overrides) for spec_item in spec]
+        return [_inject_params(spec_item, **overrides) for spec_item in spec]
     if not _is_spec(spec):
         return spec
     params = spec.get("params", {})
     if isinstance(params, list):
-        new_params: Any = [inject_params(v, **overrides) for v in params]
+        new_params: Any = [_inject_params(v, **overrides) for v in params]
         return {**spec, "params": new_params}
 
     target = get(spec["type"])
@@ -274,7 +274,7 @@ def inject_params(spec: Any, **overrides: Any) -> Any:
         target.__init__ if inspect.isclass(target) else target
     )
     accepted = signature.parameters
-    new_params = {k: inject_params(v, **overrides) for k, v in params.items()}
+    new_params = {k: _inject_params(v, **overrides) for k, v in params.items()}
     for name, value in overrides.items():
         if name in accepted and name not in new_params:
             new_params[name] = value

--- a/src/saealib/surrogate/__init__.py
+++ b/src/saealib/surrogate/__init__.py
@@ -112,7 +112,6 @@ __all__ = [
     "TorchSurrogate",
     "TrainingData",
     "TrainingSet",
-    "XGBSurrogate",
     "gaussian_kernel",
     "product_combine",
     "rank_weighted_combine",

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,0 +1,75 @@
+"""Drift-guard tests for saealib's top-level export tiers.
+
+See the "Export tiers" comment at the top of src/saealib/__init__.py for the
+Tier 1 / Tier 2 / namespace-only policy these tests enforce.
+"""
+
+import importlib
+
+import saealib
+
+# Subpackages whose __all__ must be fully covered by (Tier 1 + Tier 2 + the
+# allowlist below). saealib.registry is deliberately excluded: it defines no
+# __all__, and its get/build/to_spec namespace-only status is covered by
+# tests/test_registry.py::TestTopLevelExport instead.
+SCANNED_SUBPACKAGES = [
+    "saealib.acquisition",
+    "saealib.algorithms",
+    "saealib.benchmarks",
+    "saealib.callback",
+    "saealib.comparators",
+    "saealib.defaults",
+    "saealib.exceptions",
+    "saealib.execution",
+    "saealib.operators",
+    "saealib.population",
+    "saealib.problem",
+    "saealib.strategies",
+    "saealib.surrogate",
+    "saealib.utils",
+    "saealib.variables",
+]
+
+NAMESPACE_ONLY: dict[str, set[str]] = {
+    "saealib.benchmarks": {
+        "ackley",
+        "dtlz1",
+        "dtlz2",
+        "dtlz3",
+        "dtlz4",
+        "dtlz5",
+        "dtlz6",
+        "dtlz7",
+        "rastrigin",
+        "rosenbrock",
+        "sphere",
+        "zdt1",
+        "zdt2",
+        "zdt3",
+        "zdt4",
+        "zdt5",
+        "zdt6",
+    },
+    "saealib.defaults": {"dump_preset", "load_defaults", "load_preset"},
+}
+
+
+def test_tier1_and_tier2_do_not_overlap():
+    assert set(saealib.__all__).isdisjoint(saealib._TIER2_MAP)
+
+
+def test_tier1_and_tier2_names_resolve():
+    for name in list(saealib.__all__) + list(saealib._TIER2_MAP):
+        assert hasattr(saealib, name), f"{name} listed but not resolvable"
+
+
+def test_subpackage_exports_are_covered():
+    covered = set(saealib.__all__) | set(saealib._TIER2_MAP)
+    for modname in SCANNED_SUBPACKAGES:
+        mod = importlib.import_module(modname)
+        allowed_extra = NAMESPACE_ONLY.get(modname, set())
+        for name in getattr(mod, "__all__", []):
+            assert name in covered or name in allowed_extra, (
+                f"{modname}.{name} is public but neither listed at the "
+                "saealib top level nor in the NAMESPACE_ONLY allowlist"
+            )

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -4,7 +4,14 @@ import numpy as np
 import pytest
 
 from saealib.exceptions import ValidationError
-from saealib.registry import build, get, inject_params, register, strip_params, to_spec
+from saealib.registry import (
+    _inject_params,
+    _strip_params,
+    build,
+    get,
+    register,
+    to_spec,
+)
 
 
 class Engine:
@@ -296,7 +303,7 @@ class TestToSpec:
 class TestStripParams:
     def test_strips_key_from_flat_spec(self):
         spec = {"type": "Engine", "params": {"power": 1, "dim": 3}}
-        stripped = strip_params(spec, "dim")
+        stripped = _strip_params(spec, "dim")
         assert stripped == {"type": "Engine", "params": {"power": 1}}
 
     def test_strips_recursively_from_nested_dict_params(self):
@@ -307,7 +314,7 @@ class TestStripParams:
                 "dim": 3,
             },
         }
-        stripped = strip_params(spec, "dim", "direction")
+        stripped = _strip_params(spec, "dim", "direction")
         assert stripped == {
             "type": "Car",
             "params": {"engine": {"type": "Engine", "params": {"power": 1}}},
@@ -318,7 +325,7 @@ class TestStripParams:
             "type": "Convoy",
             "params": [{"type": "Engine", "params": {"power": 1, "dim": 3}}],
         }
-        stripped = strip_params(spec, "dim")
+        stripped = _strip_params(spec, "dim")
         assert stripped == {
             "type": "Convoy",
             "params": [{"type": "Engine", "params": {"power": 1}}],
@@ -326,26 +333,33 @@ class TestStripParams:
 
     def test_is_non_destructive(self):
         spec = {"type": "Engine", "params": {"power": 1, "dim": 3}}
-        strip_params(spec, "dim")
+        _strip_params(spec, "dim")
         assert spec == {"type": "Engine", "params": {"power": 1, "dim": 3}}
 
 
 class TestTopLevelExport:
-    def test_importable_from_top_level(self):
+    def test_register_importable_from_top_level(self):
         import saealib
 
         assert saealib.register is register
-        assert saealib.build is build
-        assert saealib.get is get
-        assert saealib.to_spec is to_spec
+        assert "register" in saealib.__all__
 
-    def test_exported_in_all(self):
+    def test_get_build_to_spec_not_exported_at_top_level(self):
         import saealib
 
-        assert "register" in saealib.__all__
-        assert "build" in saealib.__all__
-        assert "get" in saealib.__all__
-        assert "to_spec" in saealib.__all__
+        assert "build" not in saealib.__all__
+        assert "get" not in saealib.__all__
+        assert "to_spec" not in saealib.__all__
+        assert not hasattr(saealib, "build")
+        assert not hasattr(saealib, "get")
+        assert not hasattr(saealib, "to_spec")
+
+    def test_get_build_to_spec_importable_via_registry_namespace(self):
+        import saealib.registry
+
+        assert saealib.registry.build is build
+        assert saealib.registry.get is get
+        assert saealib.registry.to_spec is to_spec
 
 
 class TestInjectParams:
@@ -355,17 +369,17 @@ class TestInjectParams:
 
     def test_injects_missing_param(self):
         spec = {"type": "Engine", "params": {}}
-        injected = inject_params(spec, power=250)
+        injected = _inject_params(spec, power=250)
         assert injected == {"type": "Engine", "params": {"power": 250}}
 
     def test_does_not_overwrite_existing_param(self):
         spec = {"type": "Engine", "params": {"power": 42}}
-        injected = inject_params(spec, power=250)
+        injected = _inject_params(spec, power=250)
         assert injected == {"type": "Engine", "params": {"power": 42}}
 
     def test_does_not_inject_param_absent_from_signature(self):
         spec = {"type": "Engine", "params": {}}
-        injected = inject_params(spec, not_a_param=1)
+        injected = _inject_params(spec, not_a_param=1)
         assert injected == {"type": "Engine", "params": {}}
 
     def test_injects_into_nested_spec(self):
@@ -373,7 +387,7 @@ class TestInjectParams:
             "type": "Car",
             "params": {"engine": {"type": "Engine", "params": {}}, "wheels": 4},
         }
-        injected = inject_params(spec, power=99)
+        injected = _inject_params(spec, power=99)
         assert injected == {
             "type": "Car",
             "params": {
@@ -384,5 +398,5 @@ class TestInjectParams:
 
     def test_is_non_destructive(self):
         spec = {"type": "Engine", "params": {}}
-        inject_params(spec, power=250)
+        _inject_params(spec, power=250)
         assert spec == {"type": "Engine", "params": {}}

--- a/tests/test_surrogate_exports.py
+++ b/tests/test_surrogate_exports.py
@@ -1,0 +1,15 @@
+"""Regression test for saealib.surrogate.__all__ integrity."""
+
+import saealib.surrogate
+
+
+def test_all_entries_resolve():
+    for name in saealib.surrogate.__all__:
+        assert hasattr(saealib.surrogate, name), f"{name} in __all__ but not defined"
+
+
+def test_star_import():
+    namespace: dict = {}
+    exec("from saealib.surrogate import *", namespace)
+    for name in saealib.surrogate.__all__:
+        assert name in namespace


### PR DESCRIPTION
## Related Issue
Closes #202
Closes #203
Closes #204

## Changes
- #202: Remove the phantom `XGBSurrogate` entry from `saealib.surrogate.__all__` (leftover from the `SklearnXGBSurrogate` rename in #177), which was breaking `from saealib.surrogate import *`. Added a regression test.
- #203: Restrict saealib's top-level `__all__` to `register` only; `get`/`build`/`to_spec` are now accessed via `saealib.registry`. Privatized the unexported registry helpers (`dotted_path`/`strip_params`/`inject_params`) and updated all call sites.
- #204: Documented the Tier 1 / Tier 2 / namespace-only export policy in `__init__.py` and `CONTRIBUTING.md`, added the 33 previously-unlisted public names (3 acquisition, 30 surrogate) to `_TIER2_MAP`, synced `__init__.pyi`, and added a drift-guard test (`tests/test_exports.py`).

## Verification Steps
Each commit was verified with:
```
pytest tests/
ruff format src/ tests/
ruff check --fix src/ tests/
ty check
```

## Concerns
None.

## Other
- Merge method: **rebase merge** (multi-issue bundle — squash merge would collapse per-issue bisectability)
